### PR TITLE
Add count-based stabilization

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -24,11 +24,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include "inference_profiler.h"
 #include <math.h>
 #include <algorithm>
 #include <limits>
 #include <queue>
-#include "inference_profiler.h"
 
 
 namespace perfanalyzer {

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "inference_profiler.h"
+
 #include <math.h>
 #include <algorithm>
 #include <limits>

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -25,11 +25,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <math.h>
-
 #include <algorithm>
 #include <limits>
 #include <queue>
-
 #include "inference_profiler.h"
 
 
@@ -593,18 +591,21 @@ InferenceProfiler::Measure(
     // Wait for specified time interval in msec
     std::this_thread::sleep_for(
         std::chrono::milliseconds((uint64_t)(measurement_window_ms_ * 1.2)));
-    measurement_window_ms = measurement_window_ms_; 
+    measurement_window_ms = measurement_window_ms_;
   } else {
-    std::chrono::milliseconds measurement_window_start = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch());
+    std::chrono::milliseconds measurement_window_start =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch());
     do {
       // Wait for 1s until enough samples have been collected.
       std::this_thread::sleep_for(std::chrono::milliseconds((uint64_t)1000));
     } while (manager_->CountCollectedRequests() < measurement_window);
 
-    std::chrono::milliseconds measurement_window_end = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch());
-    measurement_window_ms =  (measurement_window_end - measurement_window_start).count();
+    std::chrono::milliseconds measurement_window_end =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch());
+    measurement_window_ms =
+        (measurement_window_end - measurement_window_start).count();
   }
 
   RETURN_IF_ERROR(manager_->GetAccumulatedClientStat(&end_stat));

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <thread>
-
 #include "concurrency_manager.h"
 #include "custom_load_manager.h"
 #include "model_parser.h"
@@ -300,7 +299,8 @@ class InferenceProfiler {
   /// \param measurement_window Indicating the number of requests or the
   /// duration in milliseconds to collect requests.
   /// \param is_count_based determines whether measurement_window is indicating
-  /// time or count. \return cb::Error object indicating success or failure.
+  /// time or count.
+  /// \return cb::Error object indicating success or failure.
   cb::Error Measure(
       PerfStatus& status_summary, uint64_t measurement_window,
       bool is_count_based);
@@ -336,7 +336,8 @@ class InferenceProfiler {
   /// window.
   void MeasurementTimestamp(
       const TimestampVector& timestamps,
-      std::pair<uint64_t, uint64_t>* valid_range, long long measurement_window_ms);
+      std::pair<uint64_t, uint64_t>* valid_range,
+      long long measurement_window_ms);
 
   /// \param timestamps The timestamps collected for the measurement.
   /// \param valid_range The start and end timestamp of the measurement window.

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <thread>
+
 #include "concurrency_manager.h"
 #include "custom_load_manager.h"
 #include "model_parser.h"
@@ -54,6 +55,9 @@ struct LoadStatus {
   // Stores the average latency within the stability window
   uint64_t avg_latency = 0;
 };
+
+/// Different measurement modes possible.
+enum MeasurementMode { TIME_WINDOWS = 0, COUNT_WINDOWS = 1 };
 
 // Holds the total of the timiming components of composing models of an
 // ensemble.
@@ -158,7 +162,11 @@ class InferenceProfiler {
   /// \param manager The LoadManager object that will produce load on the
   /// server.
   /// \param profiler Returns a new InferenceProfiler object.
-  /// \return cb::Error object indicating success or failure.
+  /// \param measurement_request_count The number of requests to capture when
+  /// using "count_windows" mode.
+  /// \param measurement_mode The measurement mode to use for windows.
+  /// \return cb::Error object indicating success or
+  /// failure.
   static cb::Error Create(
       const bool verbose, const double stability_threshold,
       const uint64_t measurement_window_ms, const size_t max_trials,
@@ -166,7 +174,8 @@ class InferenceProfiler {
       const cb::ProtocolType protocol, std::shared_ptr<ModelParser>& parser,
       std::unique_ptr<cb::ClientBackend> profile_backend,
       std::unique_ptr<LoadManager> manager,
-      std::unique_ptr<InferenceProfiler>* profiler);
+      std::unique_ptr<InferenceProfiler>* profiler,
+      uint64_t measurement_request_count, MeasurementMode measurement_mode);
 
   /// Performs the profiling on the given range with the given search algorithm.
   /// For profiling using request rate invoke template with double, otherwise
@@ -239,7 +248,8 @@ class InferenceProfiler {
       const uint64_t latency_threshold_ms, const cb::ProtocolType protocol,
       std::shared_ptr<ModelParser>& parser,
       std::unique_ptr<cb::ClientBackend> profile_backend,
-      std::unique_ptr<LoadManager> manager);
+      std::unique_ptr<LoadManager> manager, uint64_t measurement_request_count,
+      MeasurementMode measurement_mode);
 
   /// Actively measure throughput in every 'measurement_window' msec until the
   /// throughput is stable. Once the throughput is stable, it adds the
@@ -287,8 +297,13 @@ class InferenceProfiler {
 
   /// Helper function to perform measurement.
   /// \param status_summary The summary of this measurement.
-  /// \return cb::Error object indicating success or failure.
-  cb::Error Measure(PerfStatus& status_summary);
+  /// \param measurement_window Indicating the number of requests or the
+  /// duration in milliseconds to collect requests.
+  /// \param is_count_based determines whether measurement_window is indicating
+  /// time or count. \return cb::Error object indicating success or failure.
+  cb::Error Measure(
+      PerfStatus& status_summary, uint64_t measurement_window,
+      bool is_count_based);
 
   /// Gets the server side statistics
   /// \param model_status Returns the status of the models provided by
@@ -313,7 +328,7 @@ class InferenceProfiler {
       const std::map<cb::ModelIdentifier, cb::ModelStatistics>& start_status,
       const std::map<cb::ModelIdentifier, cb::ModelStatistics>& end_status,
       const cb::InferStat& start_stat, const cb::InferStat& end_stat,
-      PerfStatus& summary);
+      PerfStatus& summary, long long measurement_window_ms);
 
   /// A helper function to get the start and end of a measurement window.
   /// \param timestamps The timestamps collected for the measurement.
@@ -321,7 +336,7 @@ class InferenceProfiler {
   /// window.
   void MeasurementTimestamp(
       const TimestampVector& timestamps,
-      std::pair<uint64_t, uint64_t>* valid_range);
+      std::pair<uint64_t, uint64_t>* valid_range, long long measurement_window_ms);
 
   /// \param timestamps The timestamps collected for the measurement.
   /// \param valid_range The start and end timestamp of the measurement window.
@@ -397,6 +412,8 @@ class InferenceProfiler {
 
   bool verbose_;
   uint64_t measurement_window_ms_;
+  uint64_t measurement_request_count_;
+  MeasurementMode measurement_mode_;
   size_t max_trials_;
   bool extra_percentile_;
   size_t percentile_;

--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -166,6 +166,16 @@ LoadManager::SwapTimestamps(TimestampVector& new_timestamps)
   return cb::Error::Success;
 }
 
+uint64_t
+LoadManager::CountCollectedRequests()
+{
+  uint64_t num_of_requests = 0;
+  for (auto& thread_stat : threads_stat_) {
+    num_of_requests += thread_stat->request_timestamps_.size();
+  }
+  return num_of_requests;
+}
+
 cb::Error
 LoadManager::GetAccumulatedClientStat(cb::InferStat* contexts_stat)
 {

--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -171,6 +171,7 @@ LoadManager::CountCollectedRequests()
 {
   uint64_t num_of_requests = 0;
   for (auto& thread_stat : threads_stat_) {
+    std::lock_guard<std::mutex> lock(thread_stat->mu_);
     num_of_requests += thread_stat->request_timestamps_.size();
   }
   return num_of_requests;

--- a/src/c++/perf_analyzer/load_manager.h
+++ b/src/c++/perf_analyzer/load_manager.h
@@ -28,6 +28,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <thread>
+
 #include "client_backend/client_backend.h"
 #include "data_loader.h"
 #include "perf_utils.h"
@@ -64,6 +65,9 @@ class LoadManager {
     return cb::Error(
         "resetting worker threads not supported for this load manager.");
   }
+
+  /// Count the number of requests collected until now.
+  uint64_t CountCollectedRequests();
 
   /// Wraps the information required to send an inference to the
   /// server
@@ -166,6 +170,7 @@ class LoadManager {
 
   /// Stops all the worker threads generating the request load.
   void StopWorkerThreads();
+
 
  private:
   /// Helper function to update the inputs

--- a/src/c++/perf_analyzer/load_manager.h
+++ b/src/c++/perf_analyzer/load_manager.h
@@ -28,7 +28,6 @@
 #include <atomic>
 #include <condition_variable>
 #include <thread>
-
 #include "client_backend/client_backend.h"
 #include "data_loader.h"
 #include "perf_utils.h"

--- a/src/c++/perf_analyzer/load_manager.h
+++ b/src/c++/perf_analyzer/load_manager.h
@@ -170,7 +170,6 @@ class LoadManager {
   /// Stops all the worker threads generating the request load.
   void StopWorkerThreads();
 
-
  private:
   /// Helper function to update the inputs
   /// \param inputs The vector of pointers to InferInput objects

--- a/src/c++/perf_analyzer/main.cc
+++ b/src/c++/perf_analyzer/main.cc
@@ -1343,8 +1343,13 @@ main(int argc, char** argv)
   if (kind == cb::BackendKind::TRITON || using_batch_size) {
     std::cout << "  Batch size: " << batch_size << std::endl;
   }
-  std::cout << "  Measurement window: " << measurement_window_ms << " msec"
-            << std::endl;
+  if (measurement_mode == pa::MeasurementMode::TIME_WINDOWS) {
+    std::cout << "  Measurement window: " << measurement_window_ms << " msec"
+              << std::endl;
+  } else if (measurement_mode == pa::MeasurementMode::COUNT_WINDOWS) {
+    std::cout << "  Number of samples in each window: "
+              << measurement_request_count << std::endl;
+  }
   if (concurrency_range[SEARCH_RANGE::kEND] != 1) {
     std::cout << "  Latency limit: " << latency_threshold_ms << " msec"
               << std::endl;

--- a/src/c++/perf_analyzer/main.cc
+++ b/src/c++/perf_analyzer/main.cc
@@ -26,9 +26,7 @@
 
 #include <getopt.h>
 #include <signal.h>
-
 #include <algorithm>
-
 #include "concurrency_manager.h"
 #include "custom_load_manager.h"
 #include "inference_profiler.h"

--- a/src/c++/perf_analyzer/main.cc
+++ b/src/c++/perf_analyzer/main.cc
@@ -26,7 +26,9 @@
 
 #include <getopt.h>
 #include <signal.h>
+
 #include <algorithm>
+
 #include "concurrency_manager.h"
 #include "custom_load_manager.h"
 #include "inference_profiler.h"
@@ -344,6 +346,22 @@ Usage(char** argv, const std::string& msg = std::string())
              "value is 5000 msec.",
              18)
       << std::endl;
+  std::cerr << FormatMessage(
+                   " --measurement-mode <\"time_windows\"|\"count_windows\">: "
+                   "Indicates the mode used for stabilizing measurements."
+                   " \"time_windows\" will create windows such that the length "
+                   "of each window is equal to --measurement-interval. "
+                   "\"count_windows\" will create "
+                   "windows such that there are at least "
+                   "--measurement-request-count requests in each window.",
+                   18)
+            << std::endl;
+  std::cerr << FormatMessage(
+      " --measurement-request-count: "
+      "Indicates the minimum number of requests to be collected in each "
+      "measurement window when \"count_windows\" mode is used. This mode can "
+      "be enabeld using the --measurement-mode flag.",
+      18);
   std::cerr
       << FormatMessage(
              " --concurrency-range <start:end:step>: Determines the range of "
@@ -629,6 +647,8 @@ main(int argc, char** argv)
   std::string model_signature_name("serving_default");
   std::string url("localhost:8000");
   std::string filename("");
+  pa::MeasurementMode measurement_mode = pa::MeasurementMode::TIME_WINDOWS;
+  uint64_t measurement_request_count = 50;
   cb::ProtocolType protocol = cb::ProtocolType::HTTP;
   std::shared_ptr<cb::Headers> http_headers(new cb::Headers());
   cb::GrpcCompressionAlgorithm compression_algorithm =
@@ -688,6 +708,8 @@ main(int argc, char** argv)
       {"service-kind", 1, 0, 23},
       {"model-signature-name", 1, 0, 24},
       {"grpc-compression-algorithm", 1, 0, 25},
+      {"measurement-mode", 1, 0, 26},
+      {"measurement-request-count", 1, 0, 27},
       {0, 0, 0, 0}};
 
   // Parse commandline...
@@ -927,6 +949,21 @@ main(int argc, char** argv)
         }
         break;
       }
+      case 26: {
+        std::string arg = optarg;
+        if (arg.compare("time_windows") == 0) {
+          measurement_mode = pa::MeasurementMode::TIME_WINDOWS;
+        } else if (arg.compare("count_windows") == 0) {
+          measurement_mode = pa::MeasurementMode::COUNT_WINDOWS;
+        } else {
+          Usage(argv, "unsupported --measurement-mode specified");
+        }
+        break;
+      }
+      case 27: {
+        measurement_request_count = std::atoi(optarg);
+        break;
+      }
       case 'v':
         extra_verbose = verbose;
         verbose = true;
@@ -1001,6 +1038,9 @@ main(int argc, char** argv)
   }
   if (measurement_window_ms <= 0) {
     Usage(argv, "measurement window must be > 0 in msec");
+  }
+  if (measurement_request_count <= 0) {
+    Usage(argv, "measurement request count must be > 0");
   }
   if (concurrency_range[SEARCH_RANGE::kSTART] <= 0 ||
       concurrent_request_count < 0) {
@@ -1296,7 +1336,8 @@ main(int argc, char** argv)
       pa::InferenceProfiler::Create(
           verbose, stability_threshold, measurement_window_ms, max_trials,
           percentile, latency_threshold_ms, protocol, parser,
-          std::move(backend), std::move(manager), &profiler),
+          std::move(backend), std::move(manager), &profiler,
+          measurement_request_count, measurement_mode),
       "failed to create profiler");
 
   // pre-run report


### PR DESCRIPTION
The count based algorithm can be enabled by using the `--window-size` flag. I didn't reuse the `-p` flag because it still would require another flag to interpret the meaning of `-p` flag.