### PR TITLE
Remove nvidia from client namespace

### DIFF
--- a/src/c++/examples/ensemble_image_client.cc
+++ b/src/c++/examples/ensemble_image_client.cc
@@ -36,8 +36,7 @@
 #include "http_client.h"
 #include "json_utils.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/ensemble_image_client.cc
+++ b/src/c++/examples/ensemble_image_client.cc
@@ -36,8 +36,8 @@
 #include "http_client.h"
 #include "json_utils.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/image_client.cc
+++ b/src/c++/examples/image_client.cc
@@ -58,8 +58,8 @@
 #define GET_TRANSFORMATION_CODE(x) CV_##x
 #endif
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 namespace {
 

--- a/src/c++/examples/image_client.cc
+++ b/src/c++/examples/image_client.cc
@@ -58,8 +58,7 @@
 #define GET_TRANSFORMATION_CODE(x) CV_##x
 #endif
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 namespace {
 
@@ -190,7 +189,7 @@ Preprocess(
 
 void
 Postprocess(
-    const std::unique_ptr<nic::InferResult> result,
+    const std::unique_ptr<tc::InferResult> result,
     const std::vector<std::string>& filenames, const size_t batch_size,
     const std::string& output_name, const size_t topk, const bool batching)
 {
@@ -207,7 +206,7 @@ Postprocess(
 
   // Get and validate the shape and datatype
   std::vector<int64_t> shape;
-  nic::Error err = result->Shape(output_name, &shape);
+  tc::Error err = result->Shape(output_name, &shape);
   if (!err.IsOk()) {
     std::cerr << "unable to get shape for " << output_name << std::endl;
     exit(1);
@@ -742,12 +741,12 @@ FileToInputData(
 union TritonClient {
   TritonClient()
   {
-    new (&http_client_) std::unique_ptr<nic::InferenceServerHttpClient>{};
+    new (&http_client_) std::unique_ptr<tc::InferenceServerHttpClient>{};
   }
   ~TritonClient() {}
 
-  std::unique_ptr<nic::InferenceServerHttpClient> http_client_;
-  std::unique_ptr<nic::InferenceServerGrpcClient> grpc_client_;
+  std::unique_ptr<tc::InferenceServerHttpClient> http_client_;
+  std::unique_ptr<tc::InferenceServerGrpcClient> grpc_client_;
 };
 
 }  // namespace
@@ -766,7 +765,7 @@ main(int argc, char** argv)
   std::string model_version = "";
   std::string url("localhost:8000");
   ProtocolType protocol = ProtocolType::HTTP;
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   static struct option long_options[] = {{"streaming", 0, 0, 0}, {0, 0, 0, 0}};
 
@@ -848,12 +847,12 @@ main(int argc, char** argv)
   // extract and validate that the model meets the requirements for
   // image classification.
   TritonClient triton_client;
-  nic::Error err;
+  tc::Error err;
   if (protocol == ProtocolType::HTTP) {
-    err = nic::InferenceServerHttpClient::Create(
+    err = tc::InferenceServerHttpClient::Create(
         &triton_client.http_client_, url, verbose);
   } else {
-    err = nic::InferenceServerGrpcClient::Create(
+    err = tc::InferenceServerGrpcClient::Create(
         &triton_client.grpc_client_, url, verbose);
   }
   if (!err.IsOk()) {
@@ -871,7 +870,7 @@ main(int argc, char** argv)
       std::cerr << "error: failed to get model metadata: " << err << std::endl;
     }
     rapidjson::Document model_metadata_json;
-    err = nic::ParseJson(&model_metadata_json, model_metadata);
+    err = tc::ParseJson(&model_metadata_json, model_metadata);
     if (!err.IsOk()) {
       std::cerr << "error: failed to parse model metadata: " << err
                 << std::endl;
@@ -883,7 +882,7 @@ main(int argc, char** argv)
       std::cerr << "error: failed to get model config: " << err << std::endl;
     }
     rapidjson::Document model_config_json;
-    err = nic::ParseJson(&model_config_json, model_config);
+    err = tc::ParseJson(&model_config_json, model_config);
     if (!err.IsOk()) {
       std::cerr << "error: failed to parse model config: " << err << std::endl;
     }
@@ -967,31 +966,31 @@ main(int argc, char** argv)
   }
 
   // Initialize the inputs with the data.
-  nic::InferInput* input;
-  err = nic::InferInput::Create(
+  tc::InferInput* input;
+  err = tc::InferInput::Create(
       &input, model_info.input_name_, shape, model_info.input_datatype_);
   if (!err.IsOk()) {
     std::cerr << "unable to get input: " << err << std::endl;
     exit(1);
   }
-  std::shared_ptr<nic::InferInput> input_ptr(input);
+  std::shared_ptr<tc::InferInput> input_ptr(input);
 
 
-  nic::InferRequestedOutput* output;
+  tc::InferRequestedOutput* output;
   // Set the number of classification expected
   err =
-      nic::InferRequestedOutput::Create(&output, model_info.output_name_, topk);
+      tc::InferRequestedOutput::Create(&output, model_info.output_name_, topk);
   if (!err.IsOk()) {
     std::cerr << "unable to get output: " << err << std::endl;
     exit(1);
   }
-  std::shared_ptr<nic::InferRequestedOutput> output_ptr(output);
+  std::shared_ptr<tc::InferRequestedOutput> output_ptr(output);
 
-  std::vector<nic::InferInput*> inputs = {input_ptr.get()};
-  std::vector<const nic::InferRequestedOutput*> outputs = {output_ptr.get()};
+  std::vector<tc::InferInput*> inputs = {input_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output_ptr.get()};
 
   // Configure context for 'batch_size' and 'topk'
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
 
   // Send requests of 'batch_size' images. If the number of images
@@ -999,7 +998,7 @@ main(int argc, char** argv)
   // the first images until the batch is filled.
   //
   // Number of requests sent = ceil(number of images / batch_size)
-  std::vector<std::unique_ptr<nic::InferResult>> results;
+  std::vector<std::unique_ptr<tc::InferResult>> results;
   std::vector<std::vector<std::string>> result_filenames;
   size_t image_idx = 0;
   size_t done_cnt = 0;
@@ -1008,7 +1007,7 @@ main(int argc, char** argv)
   std::mutex mtx;
   std::condition_variable cv;
 
-  auto callback_func = [&](nic::InferResult* result) {
+  auto callback_func = [&](tc::InferResult* result) {
     {
       // Defer the response retrieval to main thread
       std::lock_guard<std::mutex> lk(mtx);
@@ -1057,7 +1056,7 @@ main(int argc, char** argv)
 
     // Send request.
     if (!async) {
-      nic::InferResult* result;
+      tc::InferResult* result;
       if (protocol == ProtocolType::HTTP) {
         err = triton_client.http_client_->Infer(
             &result, options, inputs, outputs, http_headers);

--- a/src/c++/examples/image_client.cc
+++ b/src/c++/examples/image_client.cc
@@ -58,8 +58,8 @@
 #define GET_TRANSFORMATION_CODE(x) CV_##x
 #endif
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 namespace {
 

--- a/src/c++/examples/reuse_infer_objects_client.cc
+++ b/src/c++/examples/reuse_infer_objects_client.cc
@@ -31,12 +31,11 @@
 #include "http_client.h"
 #include "shm_utils.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -48,17 +47,17 @@ namespace {
 union TritonClient {
   TritonClient()
   {
-    new (&http_client_) std::unique_ptr<nic::InferenceServerHttpClient>{};
+    new (&http_client_) std::unique_ptr<tc::InferenceServerHttpClient>{};
   }
   ~TritonClient() {}
 
-  std::unique_ptr<nic::InferenceServerHttpClient> http_client_;
-  std::unique_ptr<nic::InferenceServerGrpcClient> grpc_client_;
+  std::unique_ptr<tc::InferenceServerHttpClient> http_client_;
+  std::unique_ptr<tc::InferenceServerGrpcClient> grpc_client_;
 };
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 {
   std::vector<int64_t> shape;
   FAIL_IF_ERR(
@@ -84,10 +83,10 @@ ValidateShapeAndDatatype(
 void
 InferAndValidate(
     const bool use_shared_memory, TritonClient& triton_client,
-    const std::string& protocol, const nic::InferOptions& options,
-    const nic::Headers& http_headers, std::vector<nic::InferInput*>& inputs,
+    const std::string& protocol, const tc::InferOptions& options,
+    const tc::Headers& http_headers, std::vector<tc::InferInput*>& inputs,
     const size_t input_byte_size,
-    std::vector<nic::InferRequestedOutput*>& outputs,
+    std::vector<tc::InferRequestedOutput*>& outputs,
     const size_t output_byte_size, std::vector<int*>& shm_ptrs)
 {
   std::vector<int32_t> input0_data(16);
@@ -153,10 +152,10 @@ InferAndValidate(
         "unable to unset shared memory for 'OUTPUT1'");
   }
 
-  std::vector<const nic::InferRequestedOutput*> routputs = {outputs[0],
+  std::vector<const tc::InferRequestedOutput*> routputs = {outputs[0],
                                                             outputs[1]};
 
-  nic::InferResult* results;
+  tc::InferResult* results;
   if (protocol == "http") {
     FAIL_IF_ERR(
         triton_client.http_client_->Infer(
@@ -168,7 +167,7 @@ InferAndValidate(
             &results, options, inputs, routputs, http_headers),
         "unable to run model");
   }
-  std::shared_ptr<nic::InferResult> results_ptr;
+  std::shared_ptr<tc::InferResult> results_ptr;
   results_ptr.reset(results);
 
   // Validate the results...
@@ -255,7 +254,7 @@ main(int argc, char** argv)
   bool verbose = false;
   std::string url("localhost:8000");
   bool url_specified = false;
-  nic::Headers http_headers;
+  tc::Headers http_headers;
   std::string protocol("http");
 
   // Parse commandline...
@@ -297,15 +296,15 @@ main(int argc, char** argv)
   // extract and validate that the model meets the requirements for
   // image classification.
   TritonClient triton_client;
-  nic::Error err;
+  tc::Error err;
   if (protocol == "http") {
-    err = nic::InferenceServerHttpClient::Create(
+    err = tc::InferenceServerHttpClient::Create(
         &triton_client.http_client_, url, verbose);
   } else if (protocol == "grpc") {
     if (!url_specified) {
       url = "localhost:8001";
     }
-    err = nic::InferenceServerGrpcClient::Create(
+    err = tc::InferenceServerGrpcClient::Create(
         &triton_client.grpc_client_, url, verbose);
   } else {
     std::cerr
@@ -342,18 +341,18 @@ main(int argc, char** argv)
   size_t output_byte_size = 64;
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
-  nic::InferInput* input1;
+  tc::InferInput* input0;
+  tc::InferInput* input1;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
+      tc::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
       "unable to get INPUT1");
-  std::shared_ptr<nic::InferInput> input1_ptr;
+  std::shared_ptr<tc::InferInput> input1_ptr;
   input1_ptr.reset(input1);
 
   // Create Input0 and Input1 in Shared Memory. Initialize Input0 to unique
@@ -361,13 +360,13 @@ main(int argc, char** argv)
   std::string shm_key = "/input_simple";
   int shm_fd_ip, *input0_shm;
   FAIL_IF_ERR(
-      nic::CreateSharedMemoryRegion(shm_key, input_byte_size * 2, &shm_fd_ip),
+      tc::CreateSharedMemoryRegion(shm_key, input_byte_size * 2, &shm_fd_ip),
       "");
   FAIL_IF_ERR(
-      nic::MapSharedMemory(
+      tc::MapSharedMemory(
           shm_fd_ip, 0, input_byte_size * 2, (void**)&input0_shm),
       "");
-  FAIL_IF_ERR(nic::CloseSharedMemory(shm_fd_ip), "");
+  FAIL_IF_ERR(tc::CloseSharedMemory(shm_fd_ip), "");
   int* input1_shm = (int*)(input0_shm + 16);
   for (size_t i = 0; i < 16; ++i) {
     *(input0_shm + i) = i;
@@ -387,18 +386,18 @@ main(int argc, char** argv)
   }
 
   // Generate the outputs to be requested.
-  nic::InferRequestedOutput* output0;
-  nic::InferRequestedOutput* output1;
+  tc::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output1;
 
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
       "unable to get 'OUTPUT0'");
-  std::shared_ptr<nic::InferRequestedOutput> output0_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output1, "OUTPUT1"),
+      tc::InferRequestedOutput::Create(&output1, "OUTPUT1"),
       "unable to get 'OUTPUT1'");
-  std::shared_ptr<nic::InferRequestedOutput> output1_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output1_ptr;
   output1_ptr.reset(output1);
 
   // Create Output0 and Output1 in Shared Memory
@@ -406,13 +405,13 @@ main(int argc, char** argv)
   int shm_fd_op;
   int* output0_shm;
   FAIL_IF_ERR(
-      nic::CreateSharedMemoryRegion(shm_key, output_byte_size * 2, &shm_fd_op),
+      tc::CreateSharedMemoryRegion(shm_key, output_byte_size * 2, &shm_fd_op),
       "");
   FAIL_IF_ERR(
-      nic::MapSharedMemory(
+      tc::MapSharedMemory(
           shm_fd_op, 0, output_byte_size * 2, (void**)&output0_shm),
       "");
-  FAIL_IF_ERR(nic::CloseSharedMemory(shm_fd_op), "");
+  FAIL_IF_ERR(tc::CloseSharedMemory(shm_fd_op), "");
   int* output1_shm = (int*)(output0_shm + 16);
 
   if (protocol == "http") {
@@ -427,15 +426,15 @@ main(int argc, char** argv)
         "failed to register output shared memory region");
   }
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
-  std::vector<nic::InferRequestedOutput*> outputs = {output0_ptr.get(),
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
+  std::vector<tc::InferRequestedOutput*> outputs = {output0_ptr.get(),
                                                      output1_ptr.get()};
 
   std::vector<int*> shm_ptrs = {input0_shm, input1_shm, output0_shm,
                                 output1_shm};
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
 
   // Issue inference using shared memory
@@ -474,10 +473,10 @@ main(int argc, char** argv)
   }
 
   // Cleanup shared memory
-  FAIL_IF_ERR(nic::UnmapSharedMemory(input0_shm, input_byte_size * 2), "");
-  FAIL_IF_ERR(nic::UnlinkSharedMemoryRegion("/input_simple"), "");
-  FAIL_IF_ERR(nic::UnmapSharedMemory(output0_shm, output_byte_size * 2), "");
-  FAIL_IF_ERR(nic::UnlinkSharedMemoryRegion("/output_simple"), "");
+  FAIL_IF_ERR(tc::UnmapSharedMemory(input0_shm, input_byte_size * 2), "");
+  FAIL_IF_ERR(tc::UnlinkSharedMemoryRegion("/input_simple"), "");
+  FAIL_IF_ERR(tc::UnmapSharedMemory(output0_shm, output_byte_size * 2), "");
+  FAIL_IF_ERR(tc::UnlinkSharedMemoryRegion("/output_simple"), "");
 
   return 0;
 }

--- a/src/c++/examples/reuse_infer_objects_client.cc
+++ b/src/c++/examples/reuse_infer_objects_client.cc
@@ -31,8 +31,8 @@
 #include "http_client.h"
 #include "shm_utils.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/reuse_infer_objects_client.cc
+++ b/src/c++/examples/reuse_infer_objects_client.cc
@@ -31,8 +31,8 @@
 #include "http_client.h"
 #include "shm_utils.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_async_infer_client.cc
+++ b/src/c++/examples/simple_grpc_async_infer_client.cc
@@ -31,8 +31,8 @@
 #include <string>
 #include "grpc_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_async_infer_client.cc
+++ b/src/c++/examples/simple_grpc_async_infer_client.cc
@@ -31,8 +31,8 @@
 #include <string>
 #include "grpc_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_cudashm_client.cc
+++ b/src/c++/examples/simple_grpc_cudashm_client.cc
@@ -32,8 +32,8 @@
 
 #include <cuda_runtime_api.h>
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_cudashm_client.cc
+++ b/src/c++/examples/simple_grpc_cudashm_client.cc
@@ -32,8 +32,8 @@
 
 #include <cuda_runtime_api.h>
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_cudashm_client.cc
+++ b/src/c++/examples/simple_grpc_cudashm_client.cc
@@ -32,12 +32,11 @@
 
 #include <cuda_runtime_api.h>
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -48,7 +47,7 @@ namespace {
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 {
   std::vector<int64_t> shape;
   FAIL_IF_ERR(
@@ -119,7 +118,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8001");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -152,9 +151,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
-  std::unique_ptr<nic::InferenceServerGrpcClient> client;
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerGrpcClient::Create(&client, url, verbose),
+      tc::InferenceServerGrpcClient::Create(&client, url, verbose),
       "unable to create grpc client");
 
   // Unregistering all shared memory regions for a clean
@@ -171,18 +170,18 @@ main(int argc, char** argv)
   size_t output_byte_size = 64;
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
-  nic::InferInput* input1;
+  tc::InferInput* input0;
+  tc::InferInput* input1;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
+      tc::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
       "unable to get INPUT1");
-  std::shared_ptr<nic::InferInput> input1_ptr;
+  std::shared_ptr<tc::InferInput> input1_ptr;
   input1_ptr.reset(input1);
 
   // Create Input0 and Input1 in CUDA Shared Memory. Initialize Input0 to
@@ -219,18 +218,18 @@ main(int argc, char** argv)
       "unable to set shared memory for INPUT1");
 
   // Generate the outputs to be requested.
-  nic::InferRequestedOutput* output0;
-  nic::InferRequestedOutput* output1;
+  tc::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output1;
 
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
       "unable to get 'OUTPUT0'");
-  std::shared_ptr<nic::InferRequestedOutput> output0_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output1, "OUTPUT1"),
+      tc::InferRequestedOutput::Create(&output1, "OUTPUT1"),
       "unable to get 'OUTPUT1'");
-  std::shared_ptr<nic::InferRequestedOutput> output1_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output1_ptr;
   output1_ptr.reset(output1);
 
   // Create Output0 and Output1 in CUDA Shared Memory
@@ -258,18 +257,18 @@ main(int argc, char** argv)
 
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
-  std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get(),
                                                            output1_ptr.get()};
 
-  nic::InferResult* results;
+  tc::InferResult* results;
   FAIL_IF_ERR(
       client->Infer(&results, options, inputs, outputs, http_headers),
       "unable to run model");
-  std::shared_ptr<nic::InferResult> results_ptr;
+  std::shared_ptr<tc::InferResult> results_ptr;
   results_ptr.reset(results);
 
   // Validate the results...

--- a/src/c++/examples/simple_grpc_custom_repeat.cc
+++ b/src/c++/examples/simple_grpc_custom_repeat.cc
@@ -33,12 +33,11 @@
 #include <vector>
 #include "grpc_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 using ResultMap =
-    std::map<std::string, std::vector<std::shared_ptr<nic::InferResult>>>;
-using ResultList = std::vector<std::shared_ptr<nic::InferResult>>;
+    std::map<std::string, std::vector<std::shared_ptr<tc::InferResult>>>;
+using ResultList = std::vector<std::shared_ptr<tc::InferResult>>;
 
 // Global mutex to synchronize the threads
 std::mutex mutex_;
@@ -46,7 +45,7 @@ std::condition_variable cv_;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -85,7 +84,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8001");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
   int request_count = 1;
   int repeat_count = 1;
   int data_offset = 100;
@@ -129,7 +128,7 @@ main(int argc, char** argv)
     }
   }
 
-  nic::Error err;
+  tc::Error err;
 
   // We use the custom "repeat_int32" model which takes 3 inputs and
   // 1 output. For a single request the model will generate 'repeat_count'
@@ -139,9 +138,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
-  std::unique_ptr<nic::InferenceServerGrpcClient> client;
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerGrpcClient::Create(&client, url, verbose),
+      tc::InferenceServerGrpcClient::Create(&client, url, verbose),
       "unable to create grpc client");
 
   ResultMap result_map;
@@ -150,9 +149,9 @@ main(int argc, char** argv)
   // of decoupled model.
   FAIL_IF_ERR(
       client->StartStream(
-          [&](nic::InferResult* result) {
+          [&](tc::InferResult* result) {
             {
-              std::shared_ptr<nic::InferResult> result_ptr(result);
+              std::shared_ptr<tc::InferResult> result_ptr(result);
               std::lock_guard<std::mutex> lk(mutex_);
               std::string request_id;
               result->Id(&request_id);
@@ -179,12 +178,12 @@ main(int argc, char** argv)
   wait_data.push_back(wait_time);
 
   // Initialize the inputs with the data.
-  nic::InferInput* in;
+  tc::InferInput* in;
   std::vector<int64_t> shape{repeat_count};
   FAIL_IF_ERR(
-      nic::InferInput::Create(&in, "IN", shape, "INT32"),
+      tc::InferInput::Create(&in, "IN", shape, "INT32"),
       "unable to create 'IN'");
-  std::shared_ptr<nic::InferInput> in_ptr(in);
+  std::shared_ptr<tc::InferInput> in_ptr(in);
   FAIL_IF_ERR(in_ptr->Reset(), "unable to reset 'IN'");
   FAIL_IF_ERR(
       in_ptr->AppendRaw(
@@ -192,11 +191,11 @@ main(int argc, char** argv)
           sizeof(int32_t) * repeat_count),
       "unable to set data for 'IN'");
 
-  nic::InferInput* delay;
+  tc::InferInput* delay;
   FAIL_IF_ERR(
-      nic::InferInput::Create(&delay, "DELAY", shape, "UINT32"),
+      tc::InferInput::Create(&delay, "DELAY", shape, "UINT32"),
       "unable to create 'DELAY'");
-  std::shared_ptr<nic::InferInput> delay_ptr(delay);
+  std::shared_ptr<tc::InferInput> delay_ptr(delay);
   FAIL_IF_ERR(delay_ptr->Reset(), "unable to reset 'DELAY'");
   FAIL_IF_ERR(
       delay_ptr->AppendRaw(
@@ -204,22 +203,22 @@ main(int argc, char** argv)
           sizeof(uint32_t) * repeat_count),
       "unable to set data for 'DELAY'");
 
-  nic::InferInput* wait;
+  tc::InferInput* wait;
   shape[0] = 1;
   FAIL_IF_ERR(
-      nic::InferInput::Create(&wait, "WAIT", shape, "UINT32"),
+      tc::InferInput::Create(&wait, "WAIT", shape, "UINT32"),
       "unable to create 'WAIT'");
-  std::shared_ptr<nic::InferInput> wait_ptr(wait);
+  std::shared_ptr<tc::InferInput> wait_ptr(wait);
   FAIL_IF_ERR(wait_ptr->Reset(), "unable to reset 'WAIT'");
   FAIL_IF_ERR(
       wait_ptr->AppendRaw(
           reinterpret_cast<uint8_t*>(&wait_data[0]), sizeof(uint32_t)),
       "unable to set data for 'WAIT'");
 
-  std::vector<nic::InferInput*> inputs = {in_ptr.get(), delay_ptr.get(),
+  std::vector<tc::InferInput*> inputs = {in_ptr.get(), delay_ptr.get(),
                                           wait_ptr.get()};
 
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
 
   for (int id = 0; id < request_count; id++) {
     options.request_id_ = std::to_string(id);

--- a/src/c++/examples/simple_grpc_custom_repeat.cc
+++ b/src/c++/examples/simple_grpc_custom_repeat.cc
@@ -33,8 +33,8 @@
 #include <vector>
 #include "grpc_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 using ResultMap =
     std::map<std::string, std::vector<std::shared_ptr<nic::InferResult>>>;

--- a/src/c++/examples/simple_grpc_custom_repeat.cc
+++ b/src/c++/examples/simple_grpc_custom_repeat.cc
@@ -33,8 +33,8 @@
 #include <vector>
 #include "grpc_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 using ResultMap =
     std::map<std::string, std::vector<std::shared_ptr<nic::InferResult>>>;

--- a/src/c++/examples/simple_grpc_health_metadata.cc
+++ b/src/c++/examples/simple_grpc_health_metadata.cc
@@ -29,12 +29,11 @@
 #include <string>
 #include "grpc_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -69,7 +68,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8001");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -102,9 +101,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
-  std::unique_ptr<nic::InferenceServerGrpcClient> client;
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerGrpcClient::Create(&client, url, verbose),
+      tc::InferenceServerGrpcClient::Create(&client, url, verbose),
       "unable to create grpc client");
 
   bool live;
@@ -167,7 +166,7 @@ main(int argc, char** argv)
     exit(1);
   }
 
-  nic::Error err = client->ModelMetadata(
+  tc::Error err = client->ModelMetadata(
       &model_metadata, "wrong_model_name", model_version, http_headers);
   if (err.IsOk()) {
     std::cerr << "error: expected an error but got: " << err << std::endl;

--- a/src/c++/examples/simple_grpc_health_metadata.cc
+++ b/src/c++/examples/simple_grpc_health_metadata.cc
@@ -29,8 +29,8 @@
 #include <string>
 #include "grpc_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_health_metadata.cc
+++ b/src/c++/examples/simple_grpc_health_metadata.cc
@@ -29,8 +29,8 @@
 #include <string>
 #include "grpc_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_infer_client.cc
+++ b/src/c++/examples/simple_grpc_infer_client.cc
@@ -30,8 +30,8 @@
 #include <string>
 #include "grpc_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_infer_client.cc
+++ b/src/c++/examples/simple_grpc_infer_client.cc
@@ -30,8 +30,8 @@
 #include <string>
 #include "grpc_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_model_control.cc
+++ b/src/c++/examples/simple_grpc_model_control.cc
@@ -29,8 +29,8 @@
 #include <string>
 #include "grpc_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_model_control.cc
+++ b/src/c++/examples/simple_grpc_model_control.cc
@@ -29,8 +29,8 @@
 #include <string>
 #include "grpc_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_model_control.cc
+++ b/src/c++/examples/simple_grpc_model_control.cc
@@ -29,12 +29,11 @@
 #include <string>
 #include "grpc_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -69,7 +68,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8001");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -97,9 +96,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
-  std::unique_ptr<nic::InferenceServerGrpcClient> client;
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerGrpcClient::Create(&client, url, verbose),
+      tc::InferenceServerGrpcClient::Create(&client, url, verbose),
       "unable to create grpc client");
 
   inference::RepositoryIndexResponse repository_index;
@@ -134,7 +133,7 @@ main(int argc, char** argv)
     exit(1);
   }
 
-  nic::Error err = client->LoadModel("wrong_model_name", http_headers);
+  tc::Error err = client->LoadModel("wrong_model_name", http_headers);
   if (err.IsOk()) {
     std::cerr << "error: wrong model name was successfully loaded" << std::endl;
   }

--- a/src/c++/examples/simple_grpc_sequence_stream_infer_client.cc
+++ b/src/c++/examples/simple_grpc_sequence_stream_infer_client.cc
@@ -31,8 +31,8 @@
 #include <vector>
 #include "grpc_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 using ResultList = std::vector<std::shared_ptr<nic::InferResult>>;
 

--- a/src/c++/examples/simple_grpc_sequence_stream_infer_client.cc
+++ b/src/c++/examples/simple_grpc_sequence_stream_infer_client.cc
@@ -31,8 +31,8 @@
 #include <vector>
 #include "grpc_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 using ResultList = std::vector<std::shared_ptr<nic::InferResult>>;
 

--- a/src/c++/examples/simple_grpc_sequence_stream_infer_client.cc
+++ b/src/c++/examples/simple_grpc_sequence_stream_infer_client.cc
@@ -31,10 +31,9 @@
 #include <vector>
 #include "grpc_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
-using ResultList = std::vector<std::shared_ptr<nic::InferResult>>;
+using ResultList = std::vector<std::shared_ptr<tc::InferResult>>;
 
 // Global mutex to synchronize the threads
 std::mutex mutex_;
@@ -42,7 +41,7 @@ std::condition_variable cv_;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -76,11 +75,11 @@ Usage(char** argv, const std::string& msg = std::string())
 
 void
 StreamSend(
-    const std::unique_ptr<nic::InferenceServerGrpcClient>& client,
+    const std::unique_ptr<tc::InferenceServerGrpcClient>& client,
     const std::string& model_name, int32_t value, const uint64_t sequence_id,
     bool start_of_sequence, bool end_of_sequence, const int32_t index)
 {
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.sequence_id_ = sequence_id;
   options.sequence_start_ = start_of_sequence;
   options.sequence_end_ = end_of_sequence;
@@ -88,18 +87,18 @@ StreamSend(
       std::to_string(sequence_id) + "_" + std::to_string(index);
 
   // Initialize the inputs with the data.
-  nic::InferInput* input;
+  tc::InferInput* input;
   std::vector<int64_t> shape{1, 1};
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input, "INPUT", shape, "INT32"),
+      tc::InferInput::Create(&input, "INPUT", shape, "INT32"),
       "unable to create 'INPUT'");
-  std::shared_ptr<nic::InferInput> ivalue(input);
+  std::shared_ptr<tc::InferInput> ivalue(input);
   FAIL_IF_ERR(ivalue->Reset(), "unable to reset 'INPUT'");
   FAIL_IF_ERR(
       ivalue->AppendRaw(reinterpret_cast<uint8_t*>(&value), sizeof(int32_t)),
       "unable to set data for 'INPUT'");
 
-  std::vector<nic::InferInput*> inputs = {ivalue.get()};
+  std::vector<tc::InferInput*> inputs = {ivalue.get()};
 
   // Send inference request to the inference server.
   FAIL_IF_ERR(client->AsyncStreamInfer(options, inputs), "unable to run model");
@@ -113,7 +112,7 @@ main(int argc, char** argv)
   bool verbose = false;
   bool dyna_sequence = false;
   std::string url("localhost:8001");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
   int sequence_id_offset = 0;
   uint32_t stream_timeout = 0;
 
@@ -148,7 +147,7 @@ main(int argc, char** argv)
     }
   }
 
-  nic::Error err;
+  tc::Error err;
 
   // We use the custom "sequence" model which takes 1 input value. The
   // output is the accumulated value of the inputs. See
@@ -164,9 +163,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
-  std::unique_ptr<nic::InferenceServerGrpcClient> client;
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerGrpcClient::Create(&client, url, verbose),
+      tc::InferenceServerGrpcClient::Create(&client, url, verbose),
       "unable to create grpc client");
 
   // Now send the inference sequences..
@@ -176,9 +175,9 @@ main(int argc, char** argv)
 
   FAIL_IF_ERR(
       client->StartStream(
-          [&](nic::InferResult* result) {
+          [&](tc::InferResult* result) {
             {
-              std::shared_ptr<nic::InferResult> result_ptr(result);
+              std::shared_ptr<tc::InferResult> result_ptr(result);
               std::lock_guard<std::mutex> lk(mutex_);
               result_list.push_back(result_ptr);
             }

--- a/src/c++/examples/simple_grpc_sequence_sync_infer_client.cc
+++ b/src/c++/examples/simple_grpc_sequence_sync_infer_client.cc
@@ -31,8 +31,8 @@
 #include <vector>
 #include "grpc_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 using ResultList = std::vector<std::shared_ptr<nic::InferResult>>;
 

--- a/src/c++/examples/simple_grpc_sequence_sync_infer_client.cc
+++ b/src/c++/examples/simple_grpc_sequence_sync_infer_client.cc
@@ -31,8 +31,8 @@
 #include <vector>
 #include "grpc_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 using ResultList = std::vector<std::shared_ptr<nic::InferResult>>;
 

--- a/src/c++/examples/simple_grpc_sequence_sync_infer_client.cc
+++ b/src/c++/examples/simple_grpc_sequence_sync_infer_client.cc
@@ -31,10 +31,9 @@
 #include <vector>
 #include "grpc_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
-using ResultList = std::vector<std::shared_ptr<nic::InferResult>>;
+using ResultList = std::vector<std::shared_ptr<tc::InferResult>>;
 
 // Global mutex to synchronize the threads
 std::mutex mutex_;
@@ -42,7 +41,7 @@ std::condition_variable cv_;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -75,45 +74,45 @@ Usage(char** argv, const std::string& msg = std::string())
 
 void
 SyncSend(
-    const std::unique_ptr<nic::InferenceServerGrpcClient>& client,
+    const std::unique_ptr<tc::InferenceServerGrpcClient>& client,
     const std::string& model_name, int32_t value, const uint64_t sequence_id,
     bool start_of_sequence, bool end_of_sequence,
-    std::vector<int32_t>& result_data, nic::Headers& http_headers)
+    std::vector<int32_t>& result_data, tc::Headers& http_headers)
 {
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.sequence_id_ = sequence_id;
   options.sequence_start_ = start_of_sequence;
   options.sequence_end_ = end_of_sequence;
 
   // Initialize the inputs with the data.
-  nic::InferInput* input;
+  tc::InferInput* input;
   std::vector<int64_t> shape{1, 1};
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input, "INPUT", shape, "INT32"),
+      tc::InferInput::Create(&input, "INPUT", shape, "INT32"),
       "unable to create 'INPUT'");
-  std::shared_ptr<nic::InferInput> ivalue(input);
+  std::shared_ptr<tc::InferInput> ivalue(input);
   FAIL_IF_ERR(ivalue->Reset(), "unable to reset 'INPUT'");
   FAIL_IF_ERR(
       ivalue->AppendRaw(reinterpret_cast<uint8_t*>(&value), sizeof(int32_t)),
       "unable to set data for 'INPUT'");
 
-  std::vector<nic::InferInput*> inputs = {ivalue.get()};
+  std::vector<tc::InferInput*> inputs = {ivalue.get()};
 
-  nic::InferRequestedOutput* output;
+  tc::InferRequestedOutput* output;
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output, "OUTPUT"),
+      tc::InferRequestedOutput::Create(&output, "OUTPUT"),
       "unable to get 'OUTPUT'");
-  std::shared_ptr<const nic::InferRequestedOutput> routput;
+  std::shared_ptr<const tc::InferRequestedOutput> routput;
   routput.reset(output);
 
-  std::vector<const nic::InferRequestedOutput*> outputs = {routput.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {routput.get()};
 
-  nic::InferResult* result;
+  tc::InferResult* result;
   // Send inference request to the inference server.
   FAIL_IF_ERR(
       client->Infer(&result, options, inputs, outputs, http_headers),
       "unable to run model");
-  std::shared_ptr<nic::InferResult> this_result(result);
+  std::shared_ptr<tc::InferResult> this_result(result);
 
   // Get pointers to the result returned...
   int32_t* output_data;
@@ -140,7 +139,7 @@ main(int argc, char** argv)
   bool dyna_sequence = false;
   std::string url("localhost:8001");
   int sequence_id_offset = 0;
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -170,7 +169,7 @@ main(int argc, char** argv)
     }
   }
 
-  nic::Error err;
+  tc::Error err;
 
   // We use the custom "sequence" model which takes 1 input value. The
   // output is the accumulated value of the inputs. See
@@ -186,9 +185,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
-  std::unique_ptr<nic::InferenceServerGrpcClient> client;
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerGrpcClient::Create(&client, url, verbose),
+      tc::InferenceServerGrpcClient::Create(&client, url, verbose),
       "unable to create grpc client");
 
   // Now send the inference sequences..

--- a/src/c++/examples/simple_grpc_shm_client.cc
+++ b/src/c++/examples/simple_grpc_shm_client.cc
@@ -30,8 +30,8 @@
 #include "grpc_client.h"
 #include "shm_utils.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_shm_client.cc
+++ b/src/c++/examples/simple_grpc_shm_client.cc
@@ -30,8 +30,8 @@
 #include "grpc_client.h"
 #include "shm_utils.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_shm_client.cc
+++ b/src/c++/examples/simple_grpc_shm_client.cc
@@ -30,12 +30,11 @@
 #include "grpc_client.h"
 #include "shm_utils.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -46,7 +45,7 @@ namespace {
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 {
   std::vector<int64_t> shape;
   FAIL_IF_ERR(
@@ -95,7 +94,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8001");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -128,9 +127,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
-  std::unique_ptr<nic::InferenceServerGrpcClient> client;
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerGrpcClient::Create(&client, url, verbose),
+      tc::InferenceServerGrpcClient::Create(&client, url, verbose),
       "unable to create grpc client");
 
   // Unregistering all shared memory regions for a clean
@@ -147,18 +146,18 @@ main(int argc, char** argv)
   size_t output_byte_size = 64;
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
-  nic::InferInput* input1;
+  tc::InferInput* input0;
+  tc::InferInput* input1;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
+      tc::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
       "unable to get INPUT1");
-  std::shared_ptr<nic::InferInput> input1_ptr;
+  std::shared_ptr<tc::InferInput> input1_ptr;
   input1_ptr.reset(input1);
 
   // Create Input0 and Input1 in Shared Memory. Initialize Input0 to unique
@@ -166,13 +165,13 @@ main(int argc, char** argv)
   std::string shm_key = "/input_simple";
   int shm_fd_ip, *input0_shm;
   FAIL_IF_ERR(
-      nic::CreateSharedMemoryRegion(shm_key, input_byte_size * 2, &shm_fd_ip),
+      tc::CreateSharedMemoryRegion(shm_key, input_byte_size * 2, &shm_fd_ip),
       "");
   FAIL_IF_ERR(
-      nic::MapSharedMemory(
+      tc::MapSharedMemory(
           shm_fd_ip, 0, input_byte_size * 2, (void**)&input0_shm),
       "");
-  FAIL_IF_ERR(nic::CloseSharedMemory(shm_fd_ip), "");
+  FAIL_IF_ERR(tc::CloseSharedMemory(shm_fd_ip), "");
   int* input1_shm = (int*)(input0_shm + 16);
   for (size_t i = 0; i < 16; ++i) {
     *(input0_shm + i) = i;
@@ -194,18 +193,18 @@ main(int argc, char** argv)
       "unable to set shared memory for INPUT1");
 
   // Generate the outputs to be requested.
-  nic::InferRequestedOutput* output0;
-  nic::InferRequestedOutput* output1;
+  tc::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output1;
 
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
       "unable to get 'OUTPUT0'");
-  std::shared_ptr<nic::InferRequestedOutput> output0_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output1, "OUTPUT1"),
+      tc::InferRequestedOutput::Create(&output1, "OUTPUT1"),
       "unable to get 'OUTPUT1'");
-  std::shared_ptr<nic::InferRequestedOutput> output1_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output1_ptr;
   output1_ptr.reset(output1);
 
   // Create Output0 and Output1 in Shared Memory
@@ -213,13 +212,13 @@ main(int argc, char** argv)
   int shm_fd_op;
   int* output0_shm;
   FAIL_IF_ERR(
-      nic::CreateSharedMemoryRegion(shm_key, output_byte_size * 2, &shm_fd_op),
+      tc::CreateSharedMemoryRegion(shm_key, output_byte_size * 2, &shm_fd_op),
       "");
   FAIL_IF_ERR(
-      nic::MapSharedMemory(
+      tc::MapSharedMemory(
           shm_fd_op, 0, output_byte_size * 2, (void**)&output0_shm),
       "");
-  FAIL_IF_ERR(nic::CloseSharedMemory(shm_fd_op), "");
+  FAIL_IF_ERR(tc::CloseSharedMemory(shm_fd_op), "");
   int* output1_shm = (int*)(output0_shm + 16);
 
 
@@ -239,18 +238,18 @@ main(int argc, char** argv)
 
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
-  std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get(),
                                                            output1_ptr.get()};
 
-  nic::InferResult* results;
+  tc::InferResult* results;
   FAIL_IF_ERR(
       client->Infer(&results, options, inputs, outputs, http_headers),
       "unable to run model");
-  std::shared_ptr<nic::InferResult> results_ptr;
+  std::shared_ptr<tc::InferResult> results_ptr;
   results_ptr.reset(results);
 
   // Validate the results...
@@ -289,10 +288,10 @@ main(int argc, char** argv)
       "unable to unregister shared memory output region");
 
   // Cleanup shared memory
-  FAIL_IF_ERR(nic::UnmapSharedMemory(input0_shm, input_byte_size * 2), "");
-  FAIL_IF_ERR(nic::UnlinkSharedMemoryRegion("/input_simple"), "");
-  FAIL_IF_ERR(nic::UnmapSharedMemory(output0_shm, output_byte_size * 2), "");
-  FAIL_IF_ERR(nic::UnlinkSharedMemoryRegion("/output_simple"), "");
+  FAIL_IF_ERR(tc::UnmapSharedMemory(input0_shm, input_byte_size * 2), "");
+  FAIL_IF_ERR(tc::UnlinkSharedMemoryRegion("/input_simple"), "");
+  FAIL_IF_ERR(tc::UnmapSharedMemory(output0_shm, output_byte_size * 2), "");
+  FAIL_IF_ERR(tc::UnlinkSharedMemoryRegion("/output_simple"), "");
 
   std::cout << "PASS : System Shared Memory " << std::endl;
 

--- a/src/c++/examples/simple_grpc_string_infer_client.cc
+++ b/src/c++/examples/simple_grpc_string_infer_client.cc
@@ -29,8 +29,8 @@
 #include <string>
 #include "grpc_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_string_infer_client.cc
+++ b/src/c++/examples/simple_grpc_string_infer_client.cc
@@ -29,8 +29,8 @@
 #include <string>
 #include "grpc_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_grpc_string_infer_client.cc
+++ b/src/c++/examples/simple_grpc_string_infer_client.cc
@@ -29,12 +29,11 @@
 #include <string>
 #include "grpc_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -45,7 +44,7 @@ namespace {
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 {
   std::vector<int64_t> shape;
   FAIL_IF_ERR(result->Shape(name, &shape), "unable to get shape for " + name);
@@ -91,7 +90,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8001");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -125,9 +124,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
-  std::unique_ptr<nic::InferenceServerGrpcClient> client;
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerGrpcClient::Create(&client, url, verbose),
+      tc::InferenceServerGrpcClient::Create(&client, url, verbose),
       "unable to create grpc client");
 
   // Create the data for the two input tensors. Initialize the first
@@ -147,18 +146,18 @@ main(int argc, char** argv)
   std::vector<int64_t> shape{1, 16};
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
-  nic::InferInput* input1;
+  tc::InferInput* input0;
+  tc::InferInput* input1;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "BYTES"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "BYTES"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input1, "INPUT1", shape, "BYTES"),
+      tc::InferInput::Create(&input1, "INPUT1", shape, "BYTES"),
       "unable to get INPUT1");
-  std::shared_ptr<nic::InferInput> input1_ptr;
+  std::shared_ptr<tc::InferInput> input1_ptr;
   input1_ptr.reset(input1);
 
   FAIL_IF_ERR(
@@ -169,34 +168,34 @@ main(int argc, char** argv)
       "unable to set data for INPUT1");
 
   // Generate the outputs to be requested.
-  nic::InferRequestedOutput* output0;
-  nic::InferRequestedOutput* output1;
+  tc::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output1;
 
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
       "unable to get OUTPUT0");
-  std::shared_ptr<nic::InferRequestedOutput> output0_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output1, "OUTPUT1"),
+      tc::InferRequestedOutput::Create(&output1, "OUTPUT1"),
       "unable to get OUTPUT1");
-  std::shared_ptr<nic::InferRequestedOutput> output1_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output1_ptr;
   output1_ptr.reset(output1);
 
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
-  std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get(),
                                                            output1_ptr.get()};
 
-  nic::InferResult* results;
+  tc::InferResult* results;
   FAIL_IF_ERR(
       client->Infer(&results, options, inputs, outputs, http_headers),
       "unable to run model");
-  std::shared_ptr<nic::InferResult> results_ptr;
+  std::shared_ptr<tc::InferResult> results_ptr;
   results_ptr.reset(results);
 
   // Validate the results...

--- a/src/c++/examples/simple_http_async_infer_client.cc
+++ b/src/c++/examples/simple_http_async_infer_client.cc
@@ -31,8 +31,8 @@
 #include <string>
 #include "http_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_async_infer_client.cc
+++ b/src/c++/examples/simple_http_async_infer_client.cc
@@ -31,8 +31,8 @@
 #include <string>
 #include "http_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_async_infer_client.cc
+++ b/src/c++/examples/simple_http_async_infer_client.cc
@@ -31,12 +31,11 @@
 #include <string>
 #include "http_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -47,7 +46,7 @@ namespace {
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 {
   std::vector<int64_t> shape;
   FAIL_IF_ERR(
@@ -72,7 +71,7 @@ ValidateShapeAndDatatype(
 
 void
 ValidateResult(
-    const std::shared_ptr<nic::InferResult> result,
+    const std::shared_ptr<tc::InferResult> result,
     std::vector<int32_t>& input0_data, std::vector<int32_t>& input1_data)
 {
   // Validate the results...
@@ -151,7 +150,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8000");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
   uint32_t client_timeout = 0;
 
   // Parse commandline...
@@ -188,9 +187,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerHttpClient instance to communicate with the
   // server using HTTP protocol.
-  std::unique_ptr<nic::InferenceServerHttpClient> client;
+  std::unique_ptr<tc::InferenceServerHttpClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerHttpClient::Create(&client, url, verbose),
+      tc::InferenceServerHttpClient::Create(&client, url, verbose),
       "unable to create http client");
 
   // Create the data for the two input tensors. Initialize the first
@@ -205,18 +204,18 @@ main(int argc, char** argv)
   std::vector<int64_t> shape{1, 16};
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
-  nic::InferInput* input1;
+  tc::InferInput* input0;
+  tc::InferInput* input1;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
+      tc::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
       "unable to get INPUT1");
-  std::shared_ptr<nic::InferInput> input1_ptr;
+  std::shared_ptr<tc::InferInput> input1_ptr;
   input1_ptr.reset(input1);
 
   FAIL_IF_ERR(
@@ -231,28 +230,28 @@ main(int argc, char** argv)
       "unable to set data for INPUT1");
 
   // Generate the outputs to be requested.
-  nic::InferRequestedOutput* output0;
-  nic::InferRequestedOutput* output1;
+  tc::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output1;
 
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
       "unable to get 'OUTPUT0'");
-  std::shared_ptr<nic::InferRequestedOutput> output0_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output1, "OUTPUT1"),
+      tc::InferRequestedOutput::Create(&output1, "OUTPUT1"),
       "unable to get 'OUTPUT1'");
-  std::shared_ptr<nic::InferRequestedOutput> output1_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output1_ptr;
   output1_ptr.reset(output1);
 
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
   options.client_timeout_ = client_timeout;
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
-  std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get(),
                                                            output1_ptr.get()};
 
   // Send inference request to the inference server.
@@ -263,9 +262,9 @@ main(int argc, char** argv)
   for (size_t i = 0; i < repeat_cnt; i++) {
     FAIL_IF_ERR(
         client->AsyncInfer(
-            [&, i](nic::InferResult* result) {
+            [&, i](tc::InferResult* result) {
               {
-                std::shared_ptr<nic::InferResult> result_ptr;
+                std::shared_ptr<tc::InferResult> result_ptr;
                 result_ptr.reset(result);
                 std::lock_guard<std::mutex> lk(mtx);
                 std::cout << "Callback no." << i << " is called" << std::endl;
@@ -306,12 +305,12 @@ main(int argc, char** argv)
   // Send another AsyncInfer whose callback defers the completed request
   // to another thread (main thread) to handle
   bool callback_invoked = false;
-  std::shared_ptr<nic::InferResult> result_placeholder;
+  std::shared_ptr<tc::InferResult> result_placeholder;
   FAIL_IF_ERR(
       client->AsyncInfer(
-          [&](nic::InferResult* result) {
+          [&](tc::InferResult* result) {
             {
-              std::shared_ptr<nic::InferResult> result_ptr;
+              std::shared_ptr<tc::InferResult> result_ptr;
               result_ptr.reset(result);
               // Defer the response retrieval to main thread
               std::lock_guard<std::mutex> lk(mtx);
@@ -339,7 +338,7 @@ main(int argc, char** argv)
     exit(1);
   }
 
-  nic::InferStat infer_stat;
+  tc::InferStat infer_stat;
   client->ClientInferStat(&infer_stat);
   std::cout << "completed_request_count " << infer_stat.completed_request_count
             << std::endl;

--- a/src/c++/examples/simple_http_cudashm_client.cc
+++ b/src/c++/examples/simple_http_cudashm_client.cc
@@ -32,8 +32,8 @@
 
 #include <cuda_runtime_api.h>
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_cudashm_client.cc
+++ b/src/c++/examples/simple_http_cudashm_client.cc
@@ -32,8 +32,8 @@
 
 #include <cuda_runtime_api.h>
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_cudashm_client.cc
+++ b/src/c++/examples/simple_http_cudashm_client.cc
@@ -32,12 +32,11 @@
 
 #include <cuda_runtime_api.h>
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -48,7 +47,7 @@ namespace {
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 {
   std::vector<int64_t> shape;
   FAIL_IF_ERR(
@@ -119,7 +118,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8000");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -152,9 +151,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerHttpClient instance to communicate with the
   // server using http protocol.
-  std::unique_ptr<nic::InferenceServerHttpClient> client;
+  std::unique_ptr<tc::InferenceServerHttpClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerHttpClient::Create(&client, url, verbose),
+      tc::InferenceServerHttpClient::Create(&client, url, verbose),
       "unable to create http client");
 
   // Unregistering all shared memory regions for a clean
@@ -171,18 +170,18 @@ main(int argc, char** argv)
   size_t output_byte_size = 64;
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
-  nic::InferInput* input1;
+  tc::InferInput* input0;
+  tc::InferInput* input1;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
+      tc::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
       "unable to get INPUT1");
-  std::shared_ptr<nic::InferInput> input1_ptr;
+  std::shared_ptr<tc::InferInput> input1_ptr;
   input1_ptr.reset(input1);
 
   // Create Input0 and Input1 in CUDA Shared Memory. Initialize Input0 to
@@ -219,18 +218,18 @@ main(int argc, char** argv)
       "unable to set shared memory for INPUT1");
 
   // Generate the outputs to be requested.
-  nic::InferRequestedOutput* output0;
-  nic::InferRequestedOutput* output1;
+  tc::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output1;
 
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
       "unable to get 'OUTPUT0'");
-  std::shared_ptr<nic::InferRequestedOutput> output0_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output1, "OUTPUT1"),
+      tc::InferRequestedOutput::Create(&output1, "OUTPUT1"),
       "unable to get 'OUTPUT1'");
-  std::shared_ptr<nic::InferRequestedOutput> output1_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output1_ptr;
   output1_ptr.reset(output1);
 
   // Create Output0 and Output1 in CUDA Shared Memory
@@ -258,18 +257,18 @@ main(int argc, char** argv)
 
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
-  std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get(),
                                                            output1_ptr.get()};
 
-  nic::InferResult* results;
+  tc::InferResult* results;
   FAIL_IF_ERR(
       client->Infer(&results, options, inputs, outputs, http_headers),
       "unable to run model");
-  std::shared_ptr<nic::InferResult> results_ptr;
+  std::shared_ptr<tc::InferResult> results_ptr;
   results_ptr.reset(results);
 
   // Validate the results...

--- a/src/c++/examples/simple_http_health_metadata.cc
+++ b/src/c++/examples/simple_http_health_metadata.cc
@@ -30,12 +30,11 @@
 #include "http_client.h"
 #include "json_utils.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -70,7 +69,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8000");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -103,9 +102,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerHttpClient instance to communicate with the
   // server using http protocol.
-  std::unique_ptr<nic::InferenceServerHttpClient> client;
+  std::unique_ptr<tc::InferenceServerHttpClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerHttpClient::Create(&client, url, verbose),
+      tc::InferenceServerHttpClient::Create(&client, url, verbose),
       "unable to create http client");
 
   bool live;
@@ -139,7 +138,7 @@ main(int argc, char** argv)
 
     rapidjson::Document server_metadata_json;
     FAIL_IF_ERR(
-        nic::ParseJson(&server_metadata_json, server_metadata),
+        tc::ParseJson(&server_metadata_json, server_metadata),
         "failed to parse server metadata");
     if ((std::string(server_metadata_json["name"].GetString()))
             .compare("triton") != 0) {
@@ -158,7 +157,7 @@ main(int argc, char** argv)
 
     rapidjson::Document model_metadata_json;
     FAIL_IF_ERR(
-        nic::ParseJson(&model_metadata_json, model_metadata),
+        tc::ParseJson(&model_metadata_json, model_metadata),
         "failed to parse model metadata");
     if ((std::string(model_metadata_json["name"].GetString()))
             .compare(model_name) != 0) {
@@ -177,7 +176,7 @@ main(int argc, char** argv)
 
     rapidjson::Document model_config_json;
     FAIL_IF_ERR(
-        nic::ParseJson(&model_config_json, model_config),
+        tc::ParseJson(&model_config_json, model_config),
         "failed to parse model config");
     if ((std::string(model_config_json["name"].GetString()))
             .compare(model_name) != 0) {
@@ -189,7 +188,7 @@ main(int argc, char** argv)
 
   {
     std::string model_metadata;
-    nic::Error err = client->ModelMetadata(
+    tc::Error err = client->ModelMetadata(
         &model_metadata, "wrong_model_name", model_version, http_headers);
     if (err.IsOk()) {
       std::cerr << "error: expected an error but got: " << err << std::endl;

--- a/src/c++/examples/simple_http_health_metadata.cc
+++ b/src/c++/examples/simple_http_health_metadata.cc
@@ -30,8 +30,8 @@
 #include "http_client.h"
 #include "json_utils.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_health_metadata.cc
+++ b/src/c++/examples/simple_http_health_metadata.cc
@@ -30,8 +30,8 @@
 #include "http_client.h"
 #include "json_utils.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_infer_client.cc
+++ b/src/c++/examples/simple_http_infer_client.cc
@@ -29,12 +29,11 @@
 #include <string>
 #include "http_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -45,7 +44,7 @@ namespace {
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 {
   std::vector<int64_t> shape;
   FAIL_IF_ERR(
@@ -102,12 +101,12 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8000");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
   uint32_t client_timeout = 0;
   auto request_compression_algorithm =
-      nic::InferenceServerHttpClient::CompressionType::NONE;
+      tc::InferenceServerHttpClient::CompressionType::NONE;
   auto response_compression_algorithm =
-      nic::InferenceServerHttpClient::CompressionType::NONE;
+      tc::InferenceServerHttpClient::CompressionType::NONE;
 
   // Parse commandline...
   int opt;
@@ -132,10 +131,10 @@ main(int argc, char** argv)
         std::string arg = optarg;
         if (arg == "gzip") {
           request_compression_algorithm =
-              nic::InferenceServerHttpClient::CompressionType::GZIP;
+              tc::InferenceServerHttpClient::CompressionType::GZIP;
         } else if (arg == "deflate") {
           request_compression_algorithm =
-              nic::InferenceServerHttpClient::CompressionType::DEFLATE;
+              tc::InferenceServerHttpClient::CompressionType::DEFLATE;
         }
         break;
       }
@@ -143,10 +142,10 @@ main(int argc, char** argv)
         std::string arg = optarg;
         if (arg == "gzip") {
           response_compression_algorithm =
-              nic::InferenceServerHttpClient::CompressionType::GZIP;
+              tc::InferenceServerHttpClient::CompressionType::GZIP;
         } else if (arg == "deflate") {
           response_compression_algorithm =
-              nic::InferenceServerHttpClient::CompressionType::DEFLATE;
+              tc::InferenceServerHttpClient::CompressionType::DEFLATE;
         }
         break;
       }
@@ -165,9 +164,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerHttpClient instance to communicate with the
   // server using HTTP protocol.
-  std::unique_ptr<nic::InferenceServerHttpClient> client;
+  std::unique_ptr<tc::InferenceServerHttpClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerHttpClient::Create(&client, url, verbose),
+      tc::InferenceServerHttpClient::Create(&client, url, verbose),
       "unable to create http client");
 
   // Create the data for the two input tensors. Initialize the first
@@ -182,18 +181,18 @@ main(int argc, char** argv)
   std::vector<int64_t> shape{1, 16};
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
-  nic::InferInput* input1;
+  tc::InferInput* input0;
+  tc::InferInput* input1;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
+      tc::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
       "unable to get INPUT1");
-  std::shared_ptr<nic::InferInput> input1_ptr;
+  std::shared_ptr<tc::InferInput> input1_ptr;
   input1_ptr.reset(input1);
 
   FAIL_IF_ERR(
@@ -208,22 +207,22 @@ main(int argc, char** argv)
       "unable to set data for INPUT1");
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
   options.client_timeout_ = client_timeout;
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
   // Empty output vector will request data for all the output tensors from
   // the server.
-  std::vector<const nic::InferRequestedOutput*> outputs = {};
+  std::vector<const tc::InferRequestedOutput*> outputs = {};
 
-  nic::InferResult* results;
+  tc::InferResult* results;
   FAIL_IF_ERR(
       client->Infer(
-          &results, options, inputs, outputs, http_headers, nic::Parameters(),
+          &results, options, inputs, outputs, http_headers, tc::Parameters(),
           request_compression_algorithm, response_compression_algorithm),
       "unable to run model");
-  std::shared_ptr<nic::InferResult> results_ptr;
+  std::shared_ptr<tc::InferResult> results_ptr;
   results_ptr.reset(results);
 
   // Validate the results...
@@ -274,7 +273,7 @@ main(int argc, char** argv)
   // Get full response
   std::cout << results_ptr->DebugString() << std::endl;
 
-  nic::InferStat infer_stat;
+  tc::InferStat infer_stat;
   client->ClientInferStat(&infer_stat);
   std::cout << "======Client Statistics======" << std::endl;
   std::cout << "completed_request_count " << infer_stat.completed_request_count

--- a/src/c++/examples/simple_http_infer_client.cc
+++ b/src/c++/examples/simple_http_infer_client.cc
@@ -29,8 +29,8 @@
 #include <string>
 #include "http_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_infer_client.cc
+++ b/src/c++/examples/simple_http_infer_client.cc
@@ -29,8 +29,8 @@
 #include <string>
 #include "http_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_model_control.cc
+++ b/src/c++/examples/simple_http_model_control.cc
@@ -30,8 +30,8 @@
 #include "http_client.h"
 #include "json_utils.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_model_control.cc
+++ b/src/c++/examples/simple_http_model_control.cc
@@ -30,8 +30,8 @@
 #include "http_client.h"
 #include "json_utils.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_model_control.cc
+++ b/src/c++/examples/simple_http_model_control.cc
@@ -30,12 +30,11 @@
 #include "http_client.h"
 #include "json_utils.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -70,7 +69,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8000");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -98,9 +97,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerHttpClient instance to communicate with the
   // server using http protocol.
-  std::unique_ptr<nic::InferenceServerHttpClient> client;
+  std::unique_ptr<tc::InferenceServerHttpClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerHttpClient::Create(&client, url, verbose),
+      tc::InferenceServerHttpClient::Create(&client, url, verbose),
       "unable to create http client");
 
   {
@@ -110,7 +109,7 @@ main(int argc, char** argv)
         "Failed to get repository index");
     rapidjson::Document repository_index_json;
     FAIL_IF_ERR(
-        nic::ParseJson(&repository_index_json, repository_index),
+        tc::ParseJson(&repository_index_json, repository_index),
         "failed to parse model config");
     if (repository_index_json.Size() != 6) {
       std::cerr << "expected number of models 6, got "
@@ -142,7 +141,7 @@ main(int argc, char** argv)
     exit(1);
   }
 
-  nic::Error err = client->LoadModel("wrong_model_name", http_headers);
+  tc::Error err = client->LoadModel("wrong_model_name", http_headers);
   if (err.IsOk()) {
     std::cerr << "error: wrong model name was successfully loaded" << std::endl;
   }

--- a/src/c++/examples/simple_http_sequence_sync_infer_client.cc
+++ b/src/c++/examples/simple_http_sequence_sync_infer_client.cc
@@ -31,8 +31,8 @@
 #include <vector>
 #include "http_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 using ResultList = std::vector<std::shared_ptr<nic::InferResult>>;
 

--- a/src/c++/examples/simple_http_sequence_sync_infer_client.cc
+++ b/src/c++/examples/simple_http_sequence_sync_infer_client.cc
@@ -31,8 +31,8 @@
 #include <vector>
 #include "http_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 using ResultList = std::vector<std::shared_ptr<nic::InferResult>>;
 

--- a/src/c++/examples/simple_http_sequence_sync_infer_client.cc
+++ b/src/c++/examples/simple_http_sequence_sync_infer_client.cc
@@ -31,10 +31,9 @@
 #include <vector>
 #include "http_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
-using ResultList = std::vector<std::shared_ptr<nic::InferResult>>;
+using ResultList = std::vector<std::shared_ptr<tc::InferResult>>;
 
 // Global mutex to synchronize the threads
 std::mutex mutex_;
@@ -42,7 +41,7 @@ std::condition_variable cv_;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -75,45 +74,45 @@ Usage(char** argv, const std::string& msg = std::string())
 
 void
 SyncSend(
-    const std::unique_ptr<nic::InferenceServerHttpClient>& client,
+    const std::unique_ptr<tc::InferenceServerHttpClient>& client,
     const std::string& model_name, int32_t value, const uint64_t sequence_id,
     bool start_of_sequence, bool end_of_sequence,
-    std::vector<int32_t>& result_data, nic::Headers& http_headers)
+    std::vector<int32_t>& result_data, tc::Headers& http_headers)
 {
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.sequence_id_ = sequence_id;
   options.sequence_start_ = start_of_sequence;
   options.sequence_end_ = end_of_sequence;
 
   // Initialize the inputs with the data.
-  nic::InferInput* input;
+  tc::InferInput* input;
   std::vector<int64_t> shape{1, 1};
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input, "INPUT", shape, "INT32"),
+      tc::InferInput::Create(&input, "INPUT", shape, "INT32"),
       "unable to create 'INPUT'");
-  std::shared_ptr<nic::InferInput> ivalue(input);
+  std::shared_ptr<tc::InferInput> ivalue(input);
   FAIL_IF_ERR(ivalue->Reset(), "unable to reset 'INPUT'");
   FAIL_IF_ERR(
       ivalue->AppendRaw(reinterpret_cast<uint8_t*>(&value), sizeof(int32_t)),
       "unable to set data for 'INPUT'");
 
-  std::vector<nic::InferInput*> inputs = {ivalue.get()};
+  std::vector<tc::InferInput*> inputs = {ivalue.get()};
 
-  nic::InferRequestedOutput* output;
+  tc::InferRequestedOutput* output;
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output, "OUTPUT"),
+      tc::InferRequestedOutput::Create(&output, "OUTPUT"),
       "unable to get 'OUTPUT'");
-  std::shared_ptr<const nic::InferRequestedOutput> routput;
+  std::shared_ptr<const tc::InferRequestedOutput> routput;
   routput.reset(output);
 
-  std::vector<const nic::InferRequestedOutput*> outputs = {routput.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {routput.get()};
 
-  nic::InferResult* result;
+  tc::InferResult* result;
   // Send inference request to the inference server.
   FAIL_IF_ERR(
       client->Infer(&result, options, inputs, outputs, http_headers),
       "unable to run model");
-  std::shared_ptr<nic::InferResult> this_result(result);
+  std::shared_ptr<tc::InferResult> this_result(result);
 
   // Get pointers to the result returned...
   int32_t* output_data;
@@ -140,7 +139,7 @@ main(int argc, char** argv)
   bool dyna_sequence = false;
   std::string url("localhost:8000");
   int sequence_id_offset = 0;
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -170,7 +169,7 @@ main(int argc, char** argv)
     }
   }
 
-  nic::Error err;
+  tc::Error err;
 
   // We use the custom "sequence" model which takes 1 input value. The
   // output is the accumulated value of the inputs. See
@@ -186,9 +185,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerHttpClient instance to communicate with the
   // server using http protocol.
-  std::unique_ptr<nic::InferenceServerHttpClient> client;
+  std::unique_ptr<tc::InferenceServerHttpClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerHttpClient::Create(&client, url, verbose),
+      tc::InferenceServerHttpClient::Create(&client, url, verbose),
       "unable to create http client");
 
   // Now send the inference sequences..

--- a/src/c++/examples/simple_http_shm_client.cc
+++ b/src/c++/examples/simple_http_shm_client.cc
@@ -30,12 +30,11 @@
 #include "http_client.h"
 #include "shm_utils.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -46,7 +45,7 @@ namespace {
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 
 {
   std::vector<int64_t> shape;
@@ -96,7 +95,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8000");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -129,9 +128,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerHttpClient instance to communicate with the
   // server using http protocol.
-  std::unique_ptr<nic::InferenceServerHttpClient> client;
+  std::unique_ptr<tc::InferenceServerHttpClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerHttpClient::Create(&client, url, verbose),
+      tc::InferenceServerHttpClient::Create(&client, url, verbose),
       "unable to create http client");
 
   // Unregistering all shared memory regions for a clean
@@ -148,18 +147,18 @@ main(int argc, char** argv)
   size_t output_byte_size = 64;
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
-  nic::InferInput* input1;
+  tc::InferInput* input0;
+  tc::InferInput* input1;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
+      tc::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
       "unable to get INPUT1");
-  std::shared_ptr<nic::InferInput> input1_ptr;
+  std::shared_ptr<tc::InferInput> input1_ptr;
   input1_ptr.reset(input1);
 
   // Create Input0 and Input1 in Shared Memory. Initialize Input0 to unique
@@ -167,13 +166,13 @@ main(int argc, char** argv)
   std::string shm_key = "/input_simple";
   int shm_fd_ip, *input0_shm;
   FAIL_IF_ERR(
-      nic::CreateSharedMemoryRegion(shm_key, input_byte_size * 2, &shm_fd_ip),
+      tc::CreateSharedMemoryRegion(shm_key, input_byte_size * 2, &shm_fd_ip),
       "");
   FAIL_IF_ERR(
-      nic::MapSharedMemory(
+      tc::MapSharedMemory(
           shm_fd_ip, 0, input_byte_size * 2, (void**)&input0_shm),
       "");
-  FAIL_IF_ERR(nic::CloseSharedMemory(shm_fd_ip), "");
+  FAIL_IF_ERR(tc::CloseSharedMemory(shm_fd_ip), "");
   int* input1_shm = (int*)(input0_shm + 16);
   for (size_t i = 0; i < 16; ++i) {
     *(input0_shm + i) = i;
@@ -195,18 +194,18 @@ main(int argc, char** argv)
       "unable to set shared memory for INPUT1");
 
   // Generate the outputs to be requested.
-  nic::InferRequestedOutput* output0;
-  nic::InferRequestedOutput* output1;
+  tc::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output1;
 
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
       "unable to get 'OUTPUT0'");
-  std::shared_ptr<nic::InferRequestedOutput> output0_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output1, "OUTPUT1"),
+      tc::InferRequestedOutput::Create(&output1, "OUTPUT1"),
       "unable to get 'OUTPUT1'");
-  std::shared_ptr<nic::InferRequestedOutput> output1_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output1_ptr;
   output1_ptr.reset(output1);
 
   // Create Output0 and Output1 in Shared Memory
@@ -214,13 +213,13 @@ main(int argc, char** argv)
   int shm_fd_op;
   int* output0_shm;
   FAIL_IF_ERR(
-      nic::CreateSharedMemoryRegion(shm_key, output_byte_size * 2, &shm_fd_op),
+      tc::CreateSharedMemoryRegion(shm_key, output_byte_size * 2, &shm_fd_op),
       "");
   FAIL_IF_ERR(
-      nic::MapSharedMemory(
+      tc::MapSharedMemory(
           shm_fd_op, 0, output_byte_size * 2, (void**)&output0_shm),
       "");
-  FAIL_IF_ERR(nic::CloseSharedMemory(shm_fd_op), "");
+  FAIL_IF_ERR(tc::CloseSharedMemory(shm_fd_op), "");
   int* output1_shm = (int*)(output0_shm + 16);
 
 
@@ -240,18 +239,18 @@ main(int argc, char** argv)
 
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
-  std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get(),
                                                            output1_ptr.get()};
 
-  nic::InferResult* results;
+  tc::InferResult* results;
   FAIL_IF_ERR(
       client->Infer(&results, options, inputs, outputs, http_headers),
       "unable to run model");
-  std::shared_ptr<nic::InferResult> results_ptr;
+  std::shared_ptr<tc::InferResult> results_ptr;
   results_ptr.reset(results);
 
   // Validate the results...
@@ -290,10 +289,10 @@ main(int argc, char** argv)
       "unable to unregister shared memory output region");
 
   // Cleanup shared memory
-  FAIL_IF_ERR(nic::UnmapSharedMemory(input0_shm, input_byte_size * 2), "");
-  FAIL_IF_ERR(nic::UnlinkSharedMemoryRegion("/input_simple"), "");
-  FAIL_IF_ERR(nic::UnmapSharedMemory(output0_shm, output_byte_size * 2), "");
-  FAIL_IF_ERR(nic::UnlinkSharedMemoryRegion("/output_simple"), "");
+  FAIL_IF_ERR(tc::UnmapSharedMemory(input0_shm, input_byte_size * 2), "");
+  FAIL_IF_ERR(tc::UnlinkSharedMemoryRegion("/input_simple"), "");
+  FAIL_IF_ERR(tc::UnmapSharedMemory(output0_shm, output_byte_size * 2), "");
+  FAIL_IF_ERR(tc::UnlinkSharedMemoryRegion("/output_simple"), "");
 
   std::cout << "PASS : System Shared Memory " << std::endl;
 

--- a/src/c++/examples/simple_http_shm_client.cc
+++ b/src/c++/examples/simple_http_shm_client.cc
@@ -30,8 +30,8 @@
 #include "http_client.h"
 #include "shm_utils.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_shm_client.cc
+++ b/src/c++/examples/simple_http_shm_client.cc
@@ -30,8 +30,8 @@
 #include "http_client.h"
 #include "shm_utils.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_string_infer_client.cc
+++ b/src/c++/examples/simple_http_string_infer_client.cc
@@ -29,12 +29,11 @@
 #include <string>
 #include "http_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -45,7 +44,7 @@ namespace {
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 {
   std::vector<int64_t> shape;
   FAIL_IF_ERR(result->Shape(name, &shape), "unable to get shape for " + name);
@@ -91,7 +90,7 @@ main(int argc, char** argv)
 {
   bool verbose = false;
   std::string url("localhost:8000");
-  nic::Headers http_headers;
+  tc::Headers http_headers;
 
   // Parse commandline...
   int opt;
@@ -125,9 +124,9 @@ main(int argc, char** argv)
 
   // Create a InferenceServerHttpClient instance to communicate with the
   // server using http protocol.
-  std::unique_ptr<nic::InferenceServerHttpClient> client;
+  std::unique_ptr<tc::InferenceServerHttpClient> client;
   FAIL_IF_ERR(
-      nic::InferenceServerHttpClient::Create(&client, url, verbose),
+      tc::InferenceServerHttpClient::Create(&client, url, verbose),
       "unable to create http client");
 
   // Create the data for the two input tensors. Initialize the first
@@ -147,18 +146,18 @@ main(int argc, char** argv)
   std::vector<int64_t> shape{1, 16};
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
-  nic::InferInput* input1;
+  tc::InferInput* input0;
+  tc::InferInput* input1;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "BYTES"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "BYTES"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input1, "INPUT1", shape, "BYTES"),
+      tc::InferInput::Create(&input1, "INPUT1", shape, "BYTES"),
       "unable to get INPUT1");
-  std::shared_ptr<nic::InferInput> input1_ptr;
+  std::shared_ptr<tc::InferInput> input1_ptr;
   input1_ptr.reset(input1);
 
   FAIL_IF_ERR(
@@ -169,34 +168,34 @@ main(int argc, char** argv)
       "unable to set data for INPUT1");
 
   // Generate the outputs to be requested.
-  nic::InferRequestedOutput* output0;
-  nic::InferRequestedOutput* output1;
+  tc::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output1;
 
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
       "unable to get OUTPUT0");
-  std::shared_ptr<nic::InferRequestedOutput> output0_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output1, "OUTPUT1"),
+      tc::InferRequestedOutput::Create(&output1, "OUTPUT1"),
       "unable to get OUTPUT1");
-  std::shared_ptr<nic::InferRequestedOutput> output1_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output1_ptr;
   output1_ptr.reset(output1);
 
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
-  std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get(),
                                                            output1_ptr.get()};
 
-  nic::InferResult* results;
+  tc::InferResult* results;
   FAIL_IF_ERR(
       client->Infer(&results, options, inputs, outputs, http_headers),
       "unable to run model");
-  std::shared_ptr<nic::InferResult> results_ptr;
+  std::shared_ptr<tc::InferResult> results_ptr;
   results_ptr.reset(results);
 
   // Validate the results...

--- a/src/c++/examples/simple_http_string_infer_client.cc
+++ b/src/c++/examples/simple_http_string_infer_client.cc
@@ -29,8 +29,8 @@
 #include <string>
 #include "http_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/examples/simple_http_string_infer_client.cc
+++ b/src/c++/examples/simple_http_string_infer_client.cc
@@ -29,8 +29,8 @@
 #include <string>
 #include "http_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/library/common.cc
+++ b/src/c++/library/common.cc
@@ -324,4 +324,4 @@ InferRequestedOutput::SharedMemoryInfo(
 
 //==============================================================================
 
-}}}  // namespace triton::client
+}}  // namespace triton::client

--- a/src/c++/library/common.cc
+++ b/src/c++/library/common.cc
@@ -26,7 +26,7 @@
 
 #include "common.h"
 
-namespace inferenceserver { namespace client {
+namespace triton { namespace client {
 
 //==============================================================================
 
@@ -324,4 +324,4 @@ InferRequestedOutput::SharedMemoryInfo(
 
 //==============================================================================
 
-}}}  // namespace inferenceserver::client
+}}}  // namespace triton::client

--- a/src/c++/library/common.cc
+++ b/src/c++/library/common.cc
@@ -26,7 +26,7 @@
 
 #include "common.h"
 
-namespace nvidia { namespace inferenceserver { namespace client {
+namespace inferenceserver { namespace client {
 
 //==============================================================================
 
@@ -324,4 +324,4 @@ InferRequestedOutput::SharedMemoryInfo(
 
 //==============================================================================
 
-}}}  // namespace nvidia::inferenceserver::client
+}}}  // namespace inferenceserver::client

--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -40,7 +40,7 @@
 #include <thread>
 #include <vector>
 
-namespace nvidia { namespace inferenceserver { namespace client {
+namespace inferenceserver { namespace client {
 
 constexpr char kInferHeaderContentLengthHTTPHeader[] =
     "Inference-Header-Content-Length";
@@ -615,4 +615,4 @@ class InferRequest {
 };
 
 
-}}}  // namespace nvidia::inferenceserver::client
+}}  // namespace inferenceserver::client

--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -40,7 +40,7 @@
 #include <thread>
 #include <vector>
 
-namespace inferenceserver { namespace client {
+namespace triton { namespace client {
 
 constexpr char kInferHeaderContentLengthHTTPHeader[] =
     "Inference-Header-Content-Length";
@@ -615,4 +615,4 @@ class InferRequest {
 };
 
 
-}}  // namespace inferenceserver::client
+}}  // namespace triton::client

--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -367,7 +367,7 @@ class InferRequestedOutput {
   /// default value is 0 which means the classification results are not
   /// requested.
   /// \return Error object indicating success or failure.
-  static Error Create(
+ static Error Create(
       InferRequestedOutput** infer_output, const std::string& name,
       const size_t class_count = 0);
 

--- a/src/c++/library/grpc_client.cc
+++ b/src/c++/library/grpc_client.cc
@@ -38,7 +38,7 @@
 #include <sstream>
 #include "grpc_client.h"
 
-namespace inferenceserver { namespace client {
+namespace triton { namespace client {
 namespace {
 
 //==============================================================================
@@ -1340,4 +1340,4 @@ InferenceServerGrpcClient::~InferenceServerGrpcClient()
 
 //==============================================================================
 
-}}  // namespace inferenceserver::client
+}}  // namespace triton::client

--- a/src/c++/library/grpc_client.cc
+++ b/src/c++/library/grpc_client.cc
@@ -38,7 +38,7 @@
 #include <sstream>
 #include "grpc_client.h"
 
-namespace nvidia { namespace inferenceserver { namespace client {
+namespace inferenceserver { namespace client {
 namespace {
 
 //==============================================================================
@@ -1340,4 +1340,4 @@ InferenceServerGrpcClient::~InferenceServerGrpcClient()
 
 //==============================================================================
 
-}}}  // namespace nvidia::inferenceserver::client
+}}  // namespace inferenceserver::client

--- a/src/c++/library/grpc_client.h
+++ b/src/c++/library/grpc_client.h
@@ -33,7 +33,7 @@
 #include "ipc.h"
 #include "model_config.pb.h"
 
-namespace inferenceserver { namespace client {
+namespace triton { namespace client {
 
 /// The key-value map type to be included in the request
 /// metadata
@@ -408,4 +408,4 @@ class InferenceServerGrpcClient : public InferenceServerClient {
 };
 
 
-}}  // namespace inferenceserver::client
+}}  // namespace triton::client

--- a/src/c++/library/grpc_client.h
+++ b/src/c++/library/grpc_client.h
@@ -33,7 +33,7 @@
 #include "ipc.h"
 #include "model_config.pb.h"
 
-namespace nvidia { namespace inferenceserver { namespace client {
+namespace inferenceserver { namespace client {
 
 /// The key-value map type to be included in the request
 /// metadata
@@ -408,4 +408,4 @@ class InferenceServerGrpcClient : public InferenceServerClient {
 };
 
 
-}}}  // namespace nvidia::inferenceserver::client
+}}  // namespace inferenceserver::client

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -39,10 +39,10 @@ extern "C" {
 #include "cencode.h"
 }
 
-#define TRITONJSON_STATUSTYPE inferenceserver::client::Error
+#define TRITONJSON_STATUSTYPE triton::client::Error
 #define TRITONJSON_STATUSRETURN(M) \
-  return inferenceserver::client::Error(M)
-#define TRITONJSON_STATUSSUCCESS inferenceserver::client::Error::Success
+  return triton::client::Error(M)
+#define TRITONJSON_STATUSSUCCESS triton::client::Error::Success
 #include "triton/common/triton_json.h"
 
 #ifdef _WIN32

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -39,17 +39,17 @@ extern "C" {
 #include "cencode.h"
 }
 
-#define TRITONJSON_STATUSTYPE nvidia::inferenceserver::client::Error
+#define TRITONJSON_STATUSTYPE inferenceserver::client::Error
 #define TRITONJSON_STATUSRETURN(M) \
-  return nvidia::inferenceserver::client::Error(M)
-#define TRITONJSON_STATUSSUCCESS nvidia::inferenceserver::client::Error::Success
+  return inferenceserver::client::Error(M)
+#define TRITONJSON_STATUSSUCCESS inferenceserver::client::Error::Success
 #include "triton/common/triton_json.h"
 
 #ifdef _WIN32
 #define strncasecmp(x, y, z) _strnicmp(x, y, z)
 #endif  //_WIN32
 
-namespace nvidia { namespace inferenceserver { namespace client {
+namespace inferenceserver { namespace client {
 
 namespace {
 
@@ -1746,4 +1746,4 @@ InferenceServerHttpClient::Post(
 
 //==============================================================================
 
-}}}  // namespace nvidia::inferenceserver::client
+}}  // namespace inferenceserver::client

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -49,7 +49,7 @@ extern "C" {
 #define strncasecmp(x, y, z) _strnicmp(x, y, z)
 #endif  //_WIN32
 
-namespace inferenceserver { namespace client {
+namespace triton { namespace client {
 
 namespace {
 
@@ -1746,4 +1746,4 @@ InferenceServerHttpClient::Post(
 
 //==============================================================================
 
-}}  // namespace inferenceserver::client
+}}  // namespace triton::client

--- a/src/c++/library/http_client.h
+++ b/src/c++/library/http_client.h
@@ -32,7 +32,7 @@
 #include "common.h"
 #include "ipc.h"
 
-namespace nvidia { namespace inferenceserver { namespace client {
+namespace inferenceserver { namespace client {
 
 class HttpInferRequest;
 
@@ -415,4 +415,4 @@ class InferenceServerHttpClient : public InferenceServerClient {
   AsyncReqMap ongoing_async_requests_;
 };
 
-}}}  // namespace nvidia::inferenceserver::client
+}}  // namespace inferenceserver::client

--- a/src/c++/library/http_client.h
+++ b/src/c++/library/http_client.h
@@ -32,7 +32,7 @@
 #include "common.h"
 #include "ipc.h"
 
-namespace inferenceserver { namespace client {
+namespace triton { namespace client {
 
 class HttpInferRequest;
 
@@ -415,4 +415,4 @@ class InferenceServerHttpClient : public InferenceServerClient {
   AsyncReqMap ongoing_async_requests_;
 };
 
-}}  // namespace inferenceserver::client
+}}  // namespace triton::client

--- a/src/c++/library/json_utils.cc
+++ b/src/c++/library/json_utils.cc
@@ -28,7 +28,7 @@
 
 #include <rapidjson/error/en.h>
 
-  namespace triton { namespace client {
+namespace triton { namespace client {
 
 Error
 ParseJson(rapidjson::Document* document, const std::string& json_str)

--- a/src/c++/library/json_utils.cc
+++ b/src/c++/library/json_utils.cc
@@ -28,7 +28,7 @@
 
 #include <rapidjson/error/en.h>
 
-  namespace inferenceserver { namespace client {
+  namespace triton { namespace client {
 
 Error
 ParseJson(rapidjson::Document* document, const std::string& json_str)
@@ -43,4 +43,4 @@ ParseJson(rapidjson::Document* document, const std::string& json_str)
   return Error::Success;
 }
 
-}}  // namespace inferenceserver::client
+}}  // namespace triton::client

--- a/src/c++/library/json_utils.cc
+++ b/src/c++/library/json_utils.cc
@@ -28,7 +28,7 @@
 
 #include <rapidjson/error/en.h>
 
-namespace nvidia { namespace inferenceserver { namespace client {
+  namespace inferenceserver { namespace client {
 
 Error
 ParseJson(rapidjson::Document* document, const std::string& json_str)
@@ -43,4 +43,4 @@ ParseJson(rapidjson::Document* document, const std::string& json_str)
   return Error::Success;
 }
 
-}}}  // namespace nvidia::inferenceserver::client
+}}  // namespace inferenceserver::client

--- a/src/c++/library/json_utils.h
+++ b/src/c++/library/json_utils.h
@@ -30,8 +30,8 @@
 #include <string>
 #include "common.h"
 
-namespace nvidia { namespace inferenceserver { namespace client {
+  namespace inferenceserver { namespace client {
 
 Error ParseJson(rapidjson::Document* document, const std::string& json_str);
 
-}}}  // namespace nvidia::inferenceserver::client
+}}  // namespace inferenceserver::client

--- a/src/c++/library/json_utils.h
+++ b/src/c++/library/json_utils.h
@@ -30,7 +30,7 @@
 #include <string>
 #include "common.h"
 
-  namespace triton { namespace client {
+namespace triton { namespace client {
 
 Error ParseJson(rapidjson::Document* document, const std::string& json_str);
 

--- a/src/c++/library/json_utils.h
+++ b/src/c++/library/json_utils.h
@@ -30,8 +30,8 @@
 #include <string>
 #include "common.h"
 
-  namespace inferenceserver { namespace client {
+  namespace triton { namespace client {
 
 Error ParseJson(rapidjson::Document* document, const std::string& json_str);
 
-}}  // namespace inferenceserver::client
+}}  // namespace triton::client

--- a/src/c++/library/libgrpcclient.ldscript
+++ b/src/c++/library/libgrpcclient.ldscript
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 {
   global:
     extern "C++" {
-      inferenceserver*;
+      triton*;
       inference*;
     };
   local: *;

--- a/src/c++/library/libgrpcclient.ldscript
+++ b/src/c++/library/libgrpcclient.ldscript
@@ -26,7 +26,7 @@
 {
   global:
     extern "C++" {
-      triton*;
+      triton::client*;
       inference*;
     };
   local: *;

--- a/src/c++/library/libgrpcclient.ldscript
+++ b/src/c++/library/libgrpcclient.ldscript
@@ -26,7 +26,7 @@
 {
   global:
     extern "C++" {
-      nvidia::inferenceserver*;
+      inferenceserver*;
       inference*;
     };
   local: *;

--- a/src/c++/library/libhttpclient.ldscript
+++ b/src/c++/library/libhttpclient.ldscript
@@ -26,7 +26,7 @@
 {
   global:
     extern "C++" {
-      nvidia::inferenceserver*
+      inferenceserver*
     };
   local: *;
 };

--- a/src/c++/library/libhttpclient.ldscript
+++ b/src/c++/library/libhttpclient.ldscript
@@ -26,7 +26,7 @@
 {
   global:
     extern "C++" {
-      triton*
+      triton::client*
     };
   local: *;
 };

--- a/src/c++/library/libhttpclient.ldscript
+++ b/src/c++/library/libhttpclient.ldscript
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 {
   global:
     extern "C++" {
-      inferenceserver*
+      triton*
     };
   local: *;
 };

--- a/src/c++/library/shm_utils.cc
+++ b/src/c++/library/shm_utils.cc
@@ -32,7 +32,7 @@
 #include <iostream>
 #include <string>
 
-namespace nvidia { namespace inferenceserver { namespace client {
+  namespace inferenceserver { namespace client {
 
 nic::Error
 CreateSharedMemoryRegion(std::string shm_key, size_t byte_size, int* shm_fd)
@@ -105,4 +105,4 @@ UnmapSharedMemory(void* shm_addr, size_t byte_size)
   return nic::Error::Success;
 }
 
-}}}  // namespace nvidia::inferenceserver::client
+}}  // namespace inferenceserver::client

--- a/src/c++/library/shm_utils.cc
+++ b/src/c++/library/shm_utils.cc
@@ -62,7 +62,7 @@ MapSharedMemory(int shm_fd, size_t offset, size_t byte_size, void** shm_addr)
   *shm_addr =
       mmap(NULL, byte_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, offset);
   if (*shm_addr == MAP_FAILED) {
-    return  Error(
+    return Error(
         "unable to process address space or shared-memory descriptor: " +
         std::to_string(shm_fd));
   }
@@ -75,7 +75,7 @@ CloseSharedMemory(int shm_fd)
 {
   // close shared memory descriptor
   if (close(shm_fd) == -1) {
-    return  Error(
+    return Error(
         "unable to close shared-memory descriptor: " + std::to_string(shm_fd));
   }
 

--- a/src/c++/library/shm_utils.cc
+++ b/src/c++/library/shm_utils.cc
@@ -34,75 +34,75 @@
 
   namespace triton { namespace client {
 
-nic::Error
+tc::Error
 CreateSharedMemoryRegion(std::string shm_key, size_t byte_size, int* shm_fd)
 {
   // get shared memory region descriptor
   *shm_fd = shm_open(shm_key.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
   if (*shm_fd == -1) {
-    return nic::Error(
+    return tc::Error(
         "unable to get shared memory descriptor for shared-memory key '" +
         shm_key + "'");
   }
   // extend shared memory object as by default it's initialized with size 0
   int res = ftruncate(*shm_fd, byte_size);
   if (res == -1) {
-    return nic::Error(
+    return tc::Error(
         "unable to initialize shared-memory key '" + shm_key +
         "' to requested size: " + std::to_string(byte_size) + " bytes");
   }
 
-  return nic::Error::Success;
+  return tc::Error::Success;
 }
 
-nic::Error
+tc::Error
 MapSharedMemory(int shm_fd, size_t offset, size_t byte_size, void** shm_addr)
 {
   // map shared memory to process address space
   *shm_addr =
       mmap(NULL, byte_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, offset);
   if (*shm_addr == MAP_FAILED) {
-    return nic::Error(
+    return tc::Error(
         "unable to process address space or shared-memory descriptor: " +
         std::to_string(shm_fd));
   }
 
-  return nic::Error::Success;
+  return tc::Error::Success;
 }
 
-nic::Error
+tc::Error
 CloseSharedMemory(int shm_fd)
 {
   // close shared memory descriptor
   if (close(shm_fd) == -1) {
-    return nic::Error(
+    return tc::Error(
         "unable to close shared-memory descriptor: " + std::to_string(shm_fd));
   }
 
-  return nic::Error::Success;
+  return tc::Error::Success;
 }
 
-nic::Error
+tc::Error
 UnlinkSharedMemoryRegion(std::string shm_key)
 {
   int shm_fd = shm_unlink(shm_key.c_str());
   if (shm_fd == -1) {
-    return nic::Error(
+    return tc::Error(
         "unable to unlink shared memory for key '" + shm_key + "'");
   }
 
-  return nic::Error::Success;
+  return tc::Error::Success;
 }
 
-nic::Error
+tc::Error
 UnmapSharedMemory(void* shm_addr, size_t byte_size)
 {
   int tmp_fd = munmap(shm_addr, byte_size);
   if (tmp_fd == -1) {
-    return nic::Error("unable to munmap shared memory region");
+    return tc::Error("unable to munmap shared memory region");
   }
 
-  return nic::Error::Success;
+  return tc::Error::Success;
 }
 
 }}  // namespace triton::client

--- a/src/c++/library/shm_utils.cc
+++ b/src/c++/library/shm_utils.cc
@@ -32,30 +32,30 @@
 #include <iostream>
 #include <string>
 
-  namespace triton { namespace client {
+namespace triton { namespace client {
 
- Error
+Error
 CreateSharedMemoryRegion(std::string shm_key, size_t byte_size, int* shm_fd)
 {
   // get shared memory region descriptor
   *shm_fd = shm_open(shm_key.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
   if (*shm_fd == -1) {
-    return  Error(
+    return Error(
         "unable to get shared memory descriptor for shared-memory key '" +
         shm_key + "'");
   }
   // extend shared memory object as by default it's initialized with size 0
   int res = ftruncate(*shm_fd, byte_size);
   if (res == -1) {
-    return  Error(
+    return Error(
         "unable to initialize shared-memory key '" + shm_key +
         "' to requested size: " + std::to_string(byte_size) + " bytes");
   }
 
-  return  Error::Success;
+  return Error::Success;
 }
 
- Error
+Error
 MapSharedMemory(int shm_fd, size_t offset, size_t byte_size, void** shm_addr)
 {
   // map shared memory to process address space
@@ -67,10 +67,10 @@ MapSharedMemory(int shm_fd, size_t offset, size_t byte_size, void** shm_addr)
         std::to_string(shm_fd));
   }
 
-  return  Error::Success;
+  return Error::Success;
 }
 
- Error
+Error
 CloseSharedMemory(int shm_fd)
 {
   // close shared memory descriptor
@@ -79,30 +79,30 @@ CloseSharedMemory(int shm_fd)
         "unable to close shared-memory descriptor: " + std::to_string(shm_fd));
   }
 
-  return  Error::Success;
+  return Error::Success;
 }
 
- Error
+Error
 UnlinkSharedMemoryRegion(std::string shm_key)
 {
   int shm_fd = shm_unlink(shm_key.c_str());
   if (shm_fd == -1) {
-    return  Error(
+    return Error(
         "unable to unlink shared memory for key '" + shm_key + "'");
   }
 
-  return  Error::Success;
+  return Error::Success;
 }
 
- Error
+Error
 UnmapSharedMemory(void* shm_addr, size_t byte_size)
 {
   int tmp_fd = munmap(shm_addr, byte_size);
   if (tmp_fd == -1) {
-    return  Error("unable to munmap shared memory region");
+    return Error("unable to munmap shared memory region");
   }
 
-  return  Error::Success;
+  return Error::Success;
 }
 
 }}  // namespace triton::client

--- a/src/c++/library/shm_utils.cc
+++ b/src/c++/library/shm_utils.cc
@@ -32,7 +32,7 @@
 #include <iostream>
 #include <string>
 
-  namespace inferenceserver { namespace client {
+  namespace triton { namespace client {
 
 nic::Error
 CreateSharedMemoryRegion(std::string shm_key, size_t byte_size, int* shm_fd)
@@ -105,4 +105,4 @@ UnmapSharedMemory(void* shm_addr, size_t byte_size)
   return nic::Error::Success;
 }
 
-}}  // namespace inferenceserver::client
+}}  // namespace triton::client

--- a/src/c++/library/shm_utils.cc
+++ b/src/c++/library/shm_utils.cc
@@ -34,75 +34,75 @@
 
   namespace triton { namespace client {
 
-tc::Error
+ Error
 CreateSharedMemoryRegion(std::string shm_key, size_t byte_size, int* shm_fd)
 {
   // get shared memory region descriptor
   *shm_fd = shm_open(shm_key.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
   if (*shm_fd == -1) {
-    return tc::Error(
+    return  Error(
         "unable to get shared memory descriptor for shared-memory key '" +
         shm_key + "'");
   }
   // extend shared memory object as by default it's initialized with size 0
   int res = ftruncate(*shm_fd, byte_size);
   if (res == -1) {
-    return tc::Error(
+    return  Error(
         "unable to initialize shared-memory key '" + shm_key +
         "' to requested size: " + std::to_string(byte_size) + " bytes");
   }
 
-  return tc::Error::Success;
+  return  Error::Success;
 }
 
-tc::Error
+ Error
 MapSharedMemory(int shm_fd, size_t offset, size_t byte_size, void** shm_addr)
 {
   // map shared memory to process address space
   *shm_addr =
       mmap(NULL, byte_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, offset);
   if (*shm_addr == MAP_FAILED) {
-    return tc::Error(
+    return  Error(
         "unable to process address space or shared-memory descriptor: " +
         std::to_string(shm_fd));
   }
 
-  return tc::Error::Success;
+  return  Error::Success;
 }
 
-tc::Error
+ Error
 CloseSharedMemory(int shm_fd)
 {
   // close shared memory descriptor
   if (close(shm_fd) == -1) {
-    return tc::Error(
+    return  Error(
         "unable to close shared-memory descriptor: " + std::to_string(shm_fd));
   }
 
-  return tc::Error::Success;
+  return  Error::Success;
 }
 
-tc::Error
+ Error
 UnlinkSharedMemoryRegion(std::string shm_key)
 {
   int shm_fd = shm_unlink(shm_key.c_str());
   if (shm_fd == -1) {
-    return tc::Error(
+    return  Error(
         "unable to unlink shared memory for key '" + shm_key + "'");
   }
 
-  return tc::Error::Success;
+  return  Error::Success;
 }
 
-tc::Error
+ Error
 UnmapSharedMemory(void* shm_addr, size_t byte_size)
 {
   int tmp_fd = munmap(shm_addr, byte_size);
   if (tmp_fd == -1) {
-    return tc::Error("unable to munmap shared memory region");
+    return  Error("unable to munmap shared memory region");
   }
 
-  return tc::Error::Success;
+  return  Error::Success;
 }
 
 }}  // namespace triton::client

--- a/src/c++/library/shm_utils.h
+++ b/src/c++/library/shm_utils.h
@@ -27,8 +27,7 @@
 
 #include "common.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 namespace triton { namespace client {
 
@@ -38,7 +37,7 @@ namespace triton { namespace client {
 // \param byte_size The size in bytes of the shared memory region
 // \param shm_fd Returns an int descriptor of the created shared memory region
 // \return error Returns an error if unable to open shared memory region.
-nic::Error CreateSharedMemoryRegion(
+tc::Error CreateSharedMemoryRegion(
     std::string shm_key, size_t byte_size, int* shm_fd);
 
 // Mmap the shared memory region with the given 'offset' and 'byte_size' and
@@ -49,21 +48,21 @@ nic::Error CreateSharedMemoryRegion(
 // \param byte_size The size in bytes of the shared memory region
 // \param shm_addr Returns the base address of the shared memory region
 // \return error Returns an error if unable to mmap shared memory region.
-nic::Error MapSharedMemory(
+tc::Error MapSharedMemory(
     int shm_fd, size_t offset, size_t byte_size, void** shm_addr);
 
 // Close the shared memory descriptor.
 // \param shm_fd The int descriptor of the created shared memory region
 // \return error Returns an error if unable to close shared memory descriptor.
-nic::Error CloseSharedMemory(int shm_fd);
+tc::Error CloseSharedMemory(int shm_fd);
 
 // Destory the shared memory region with the given name.
 // \return error Returns an error if unable to unlink shared memory region.
-nic::Error UnlinkSharedMemoryRegion(std::string shm_key);
+tc::Error UnlinkSharedMemoryRegion(std::string shm_key);
 
 // Munmap the shared memory region from the base address with the given
 // byte_size.
 // \return error Returns an error if unable to unmap shared memory region.
-nic::Error UnmapSharedMemory(void* shm_addr, size_t byte_size);
+tc::Error UnmapSharedMemory(void* shm_addr, size_t byte_size);
 
 }}  // namespace triton::client

--- a/src/c++/library/shm_utils.h
+++ b/src/c++/library/shm_utils.h
@@ -27,10 +27,10 @@
 
 #include "common.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
-namespace nvidia { namespace inferenceserver { namespace client {
+namespace inferenceserver { namespace client {
 
 // Create a shared memory region of the size 'byte_size' and return the unique
 // identifier.
@@ -66,4 +66,4 @@ nic::Error UnlinkSharedMemoryRegion(std::string shm_key);
 // \return error Returns an error if unable to unmap shared memory region.
 nic::Error UnmapSharedMemory(void* shm_addr, size_t byte_size);
 
-}}}  // namespace nvidia::inferenceserver::client
+}}  // namespace inferenceserver::client

--- a/src/c++/library/shm_utils.h
+++ b/src/c++/library/shm_utils.h
@@ -27,10 +27,10 @@
 
 #include "common.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
-namespace inferenceserver { namespace client {
+namespace triton { namespace client {
 
 // Create a shared memory region of the size 'byte_size' and return the unique
 // identifier.
@@ -66,4 +66,4 @@ nic::Error UnlinkSharedMemoryRegion(std::string shm_key);
 // \return error Returns an error if unable to unmap shared memory region.
 nic::Error UnmapSharedMemory(void* shm_addr, size_t byte_size);
 
-}}  // namespace inferenceserver::client
+}}  // namespace triton::client

--- a/src/c++/library/shm_utils.h
+++ b/src/c++/library/shm_utils.h
@@ -27,8 +27,6 @@
 
 #include "common.h"
 
-namespace tc = triton::client;
-
 namespace triton { namespace client {
 
 // Create a shared memory region of the size 'byte_size' and return the unique
@@ -37,7 +35,7 @@ namespace triton { namespace client {
 // \param byte_size The size in bytes of the shared memory region
 // \param shm_fd Returns an int descriptor of the created shared memory region
 // \return error Returns an error if unable to open shared memory region.
-tc::Error CreateSharedMemoryRegion(
+ Error CreateSharedMemoryRegion(
     std::string shm_key, size_t byte_size, int* shm_fd);
 
 // Mmap the shared memory region with the given 'offset' and 'byte_size' and
@@ -48,21 +46,21 @@ tc::Error CreateSharedMemoryRegion(
 // \param byte_size The size in bytes of the shared memory region
 // \param shm_addr Returns the base address of the shared memory region
 // \return error Returns an error if unable to mmap shared memory region.
-tc::Error MapSharedMemory(
+ Error MapSharedMemory(
     int shm_fd, size_t offset, size_t byte_size, void** shm_addr);
 
 // Close the shared memory descriptor.
 // \param shm_fd The int descriptor of the created shared memory region
 // \return error Returns an error if unable to close shared memory descriptor.
-tc::Error CloseSharedMemory(int shm_fd);
+ Error CloseSharedMemory(int shm_fd);
 
 // Destory the shared memory region with the given name.
 // \return error Returns an error if unable to unlink shared memory region.
-tc::Error UnlinkSharedMemoryRegion(std::string shm_key);
+ Error UnlinkSharedMemoryRegion(std::string shm_key);
 
 // Munmap the shared memory region from the base address with the given
 // byte_size.
 // \return error Returns an error if unable to unmap shared memory region.
-tc::Error UnmapSharedMemory(void* shm_addr, size_t byte_size);
+ Error UnmapSharedMemory(void* shm_addr, size_t byte_size);
 
 }}  // namespace triton::client

--- a/src/c++/library/shm_utils.h
+++ b/src/c++/library/shm_utils.h
@@ -35,7 +35,7 @@ namespace triton { namespace client {
 // \param byte_size The size in bytes of the shared memory region
 // \param shm_fd Returns an int descriptor of the created shared memory region
 // \return error Returns an error if unable to open shared memory region.
- Error CreateSharedMemoryRegion(
+Error CreateSharedMemoryRegion(
     std::string shm_key, size_t byte_size, int* shm_fd);
 
 // Mmap the shared memory region with the given 'offset' and 'byte_size' and
@@ -46,21 +46,21 @@ namespace triton { namespace client {
 // \param byte_size The size in bytes of the shared memory region
 // \param shm_addr Returns the base address of the shared memory region
 // \return error Returns an error if unable to mmap shared memory region.
- Error MapSharedMemory(
+Error MapSharedMemory(
     int shm_fd, size_t offset, size_t byte_size, void** shm_addr);
 
 // Close the shared memory descriptor.
 // \param shm_fd The int descriptor of the created shared memory region
 // \return error Returns an error if unable to close shared memory descriptor.
- Error CloseSharedMemory(int shm_fd);
+Error CloseSharedMemory(int shm_fd);
 
 // Destory the shared memory region with the given name.
 // \return error Returns an error if unable to unlink shared memory region.
- Error UnlinkSharedMemoryRegion(std::string shm_key);
+Error UnlinkSharedMemoryRegion(std::string shm_key);
 
 // Munmap the shared memory region from the base address with the given
 // byte_size.
 // \return error Returns an error if unable to unmap shared memory region.
- Error UnmapSharedMemory(void* shm_addr, size_t byte_size);
+Error UnmapSharedMemory(void* shm_addr, size_t byte_size);
 
 }}  // namespace triton::client

--- a/src/c++/perf_analyzer/client_backend/client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/client_backend.cc
@@ -125,7 +125,7 @@ ClientBackend::Create(
         url, protocol, BackendToGrpcType(compression_algorithm), http_headers,
         verbose, &local_backend));
   } else if (kind == TENSORFLOW_SERVING) {
-    RETURN_IF_CB_ERROR(TFServeClientBackend::Create(
+    RETURN_IF_CB_ERROR(tfserving::TFServeClientBackend::Create(
         url, protocol, BackendToGrpcType(compression_algorithm), http_headers,
         verbose, &local_backend));
   } else if (kind == TORCHSERVE) {
@@ -316,7 +316,7 @@ InferInput::Create(
         TritonInferInput::Create(infer_input, name, dims, datatype));
   } else if (kind == TENSORFLOW_SERVING) {
     RETURN_IF_CB_ERROR(
-        TFServeInferInput::Create(infer_input, name, dims, datatype));
+        tfserving::TFServeInferInput::Create(infer_input, name, dims, datatype));
   } else if (kind == TORCHSERVE) {
     RETURN_IF_CB_ERROR(
         TorchServeInferInput::Create(infer_input, name, dims, datatype));
@@ -381,7 +381,7 @@ InferRequestedOutput::Create(
     RETURN_IF_CB_ERROR(
         TritonInferRequestedOutput::Create(infer_output, name, class_count));
   } else if (kind == TENSORFLOW_SERVING) {
-    RETURN_IF_CB_ERROR(TFServeInferRequestedOutput::Create(infer_output, name));
+    RETURN_IF_CB_ERROR(tfserving::TFServeInferRequestedOutput::Create(infer_output, name));
   } else {
     return Error(
         "unsupported client backend provided to create InferRequestedOutput "

--- a/src/c++/perf_analyzer/client_backend/client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/client_backend.cc
@@ -30,7 +30,7 @@
 #include "torchserve/torchserve_client_backend.h"
 #include "triton/triton_client_backend.h"
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 //================================================
 
@@ -404,4 +404,4 @@ InferRequestedOutput::InferRequestedOutput(const BackendKind kind) : kind_(kind)
 {
 }
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/client_backend.cc
@@ -121,7 +121,7 @@ ClientBackend::Create(
 {
   std::unique_ptr<ClientBackend> local_backend;
   if (kind == TRITON) {
-    RETURN_IF_CB_ERROR(TritonClientBackend::Create(
+    RETURN_IF_CB_ERROR(tritonremote::TritonClientBackend::Create(
         url, protocol, BackendToGrpcType(compression_algorithm), http_headers,
         verbose, &local_backend));
   } else if (kind == TENSORFLOW_SERVING) {
@@ -129,7 +129,7 @@ ClientBackend::Create(
         url, protocol, BackendToGrpcType(compression_algorithm), http_headers,
         verbose, &local_backend));
   } else if (kind == TORCHSERVE) {
-    RETURN_IF_CB_ERROR(TorchServeClientBackend::Create(
+    RETURN_IF_CB_ERROR(torchserve::TorchServeClientBackend::Create(
         url, protocol, http_headers, verbose, &local_backend));
   } else {
     return Error("unsupported client backend requested");
@@ -312,14 +312,14 @@ InferInput::Create(
     const std::vector<int64_t>& dims, const std::string& datatype)
 {
   if (kind == TRITON) {
-    RETURN_IF_CB_ERROR(
-        TritonInferInput::Create(infer_input, name, dims, datatype));
+    RETURN_IF_CB_ERROR(tritonremote::TritonInferInput::Create(
+        infer_input, name, dims, datatype));
   } else if (kind == TENSORFLOW_SERVING) {
-    RETURN_IF_CB_ERROR(
-        tfserving::TFServeInferInput::Create(infer_input, name, dims, datatype));
+    RETURN_IF_CB_ERROR(tfserving::TFServeInferInput::Create(
+        infer_input, name, dims, datatype));
   } else if (kind == TORCHSERVE) {
-    RETURN_IF_CB_ERROR(
-        TorchServeInferInput::Create(infer_input, name, dims, datatype));
+    RETURN_IF_CB_ERROR(torchserve::TorchServeInferInput::Create(
+        infer_input, name, dims, datatype));
   } else {
     return Error(
         "unsupported client backend provided to create InferInput object");
@@ -378,10 +378,11 @@ InferRequestedOutput::Create(
     const std::string& name, const size_t class_count)
 {
   if (kind == TRITON) {
-    RETURN_IF_CB_ERROR(
-        TritonInferRequestedOutput::Create(infer_output, name, class_count));
+    RETURN_IF_CB_ERROR(tritonremote::TritonInferRequestedOutput::Create(
+        infer_output, name, class_count));
   } else if (kind == TENSORFLOW_SERVING) {
-    RETURN_IF_CB_ERROR(tfserving::TFServeInferRequestedOutput::Create(infer_output, name));
+    RETURN_IF_CB_ERROR(
+        tfserving::TFServeInferRequestedOutput::Create(infer_output, name));
   } else {
     return Error(
         "unsupported client backend provided to create InferRequestedOutput "

--- a/src/c++/perf_analyzer/client_backend/client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/client_backend.h
@@ -44,7 +44,7 @@
     }                            \
   } while (false)
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 //==============================================================================
 /// Error status reported by backends
@@ -453,4 +453,4 @@ class InferResult {
   virtual Error RequestStatus() const = 0;
 };
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/client_backend.h
@@ -287,7 +287,7 @@ class ClientBackend {
   // Shared Memory Utilities
   //
   // FIXME: These should probably move to a common area with shm_utils not tied
-  // specifically to nvidia::inferenceserver.
+  // specifically to inferenceserver.
   // Create a shared memory region of the size 'byte_size' and return the unique
   // identifier.
   virtual Error CreateSharedMemoryRegion(

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
@@ -70,7 +70,7 @@ TFServeClientBackend::ModelMetadata(
   ::google::protobuf::util::MessageToJsonString(
       metadata_proto, &metadata, options);
 
-  RETURN_IF_TRITON_ERROR(nic::ParseJson(model_metadata, metadata));
+  RETURN_IF_TRITON_ERROR(tc::ParseJson(model_metadata, metadata));
 
   return Error::Success;
 }
@@ -115,7 +115,7 @@ TFServeClientBackend::ClientInferStat(InferStat* infer_stat)
 {
   // Reusing the common library utilities to collect and report the
   // client side statistics.
-  nic::InferStat client_infer_stat;
+  tc::InferStat client_infer_stat;
 
   RETURN_IF_TRITON_ERROR(grpc_client_->ClientInferStat(&client_infer_stat));
 
@@ -126,7 +126,7 @@ TFServeClientBackend::ClientInferStat(InferStat* infer_stat)
 
 void
 TFServeClientBackend::ParseInferStat(
-    const nic::InferStat& tfserve_infer_stat, InferStat* infer_stat)
+    const tc::InferStat& tfserve_infer_stat, InferStat* infer_stat)
 {
   infer_stat->completed_request_count =
       tfserve_infer_stat.completed_request_count;
@@ -147,9 +147,9 @@ TFServeInferRequestedOutput::Create(
   TFServeInferRequestedOutput* local_infer_output =
       new TFServeInferRequestedOutput();
 
-  nic::InferRequestedOutput* tfserve_infer_output;
+  tc::InferRequestedOutput* tfserve_infer_output;
   RETURN_IF_TRITON_ERROR(
-      nic::InferRequestedOutput::Create(&tfserve_infer_output, name));
+      tc::InferRequestedOutput::Create(&tfserve_infer_output, name));
   local_infer_output->output_.reset(tfserve_infer_output);
 
   *infer_output = local_infer_output;

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
@@ -28,7 +28,7 @@
 
 #include "json_utils.h"
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 //==============================================================================
 
@@ -186,4 +186,4 @@ TFServeInferResult::RequestStatus() const
 //==============================================================================
 
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
@@ -28,7 +28,7 @@
 
 #include "json_utils.h"
 
-namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend { namespace tfserving {
 
 //==============================================================================
 
@@ -46,7 +46,7 @@ TFServeClientBackend::Create(
   std::unique_ptr<TFServeClientBackend> tfserve_client_backend(
       new TFServeClientBackend(compression_algorithm, http_headers));
 
-  RETURN_IF_CB_ERROR(tfs::GrpcClient::Create(
+  RETURN_IF_CB_ERROR(GrpcClient::Create(
       &(tfserve_client_backend->grpc_client_), url, verbose));
 
   *client_backend = std::move(tfserve_client_backend);
@@ -77,7 +77,7 @@ TFServeClientBackend::ModelMetadata(
 
 Error
 TFServeClientBackend::Infer(
-    InferResult** result, const InferOptions& options,
+    cb::InferResult** result, const InferOptions& options,
     const std::vector<InferInput*>& inputs,
     const std::vector<const InferRequestedOutput*>& outputs)
 {
@@ -98,7 +98,7 @@ TFServeClientBackend::AsyncInfer(
     const std::vector<const InferRequestedOutput*>& outputs)
 {
   auto wrapped_callback = [callback](tfs::InferResult* client_result) {
-    InferResult* result = new TFServeInferResult(client_result);
+    cb::InferResult* result = new TFServeInferResult(client_result);
     callback(result);
   };
 
@@ -186,4 +186,4 @@ TFServeInferResult::RequestStatus() const
 //==============================================================================
 
 
-}}}  // namespace triton::perfanalyzer::clientbackend
+}}}}  // namespace triton::perfanalyzer::clientbackend::tfserving

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
@@ -28,7 +28,8 @@
 
 #include "json_utils.h"
 
-namespace triton { namespace perfanalyzer { namespace clientbackend { namespace tfserving {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace tfserving {
 
 //==============================================================================
 

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
@@ -32,13 +32,13 @@
 
 #define RETURN_IF_TRITON_ERROR(S)       \
   do {                                  \
-    const nic::Error& status__ = (S);   \
+    const tc::Error& status__ = (S);   \
     if (!status__.IsOk()) {             \
       return Error(status__.Message()); \
     }                                   \
   } while (false)
 
-namespace nic = triton::client;
+namespace tc = triton::client;
 namespace tfs = perfanalyzer::clientbackend::tfserving;
 
 namespace perfanalyzer { namespace clientbackend {
@@ -97,7 +97,7 @@ class TFServeClientBackend : public ClientBackend {
   }
 
   void ParseInferStat(
-      const nic::InferStat& tfserve_infer_stat, InferStat* infer_stat);
+      const tc::InferStat& tfserve_infer_stat, InferStat* infer_stat);
 
   std::unique_ptr<tfs::GrpcClient> grpc_client_;
 
@@ -115,12 +115,12 @@ class TFServeInferRequestedOutput : public InferRequestedOutput {
       InferRequestedOutput** infer_output, const std::string name);
   /// Returns the raw InferRequestedOutput object required by TFserving client
   /// library.
-  nic::InferRequestedOutput* Get() const { return output_.get(); }
+  tc::InferRequestedOutput* Get() const { return output_.get(); }
 
  private:
   explicit TFServeInferRequestedOutput();
 
-  std::unique_ptr<nic::InferRequestedOutput> output_;
+  std::unique_ptr<tc::InferRequestedOutput> output_;
 };
 
 //==============================================================

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
@@ -38,7 +38,7 @@
     }                                   \
   } while (false)
 
-namespace nic = inferenceserver::client;
+namespace nic = triton::client;
 namespace tfs = perfanalyzer::clientbackend::tfserving;
 
 namespace perfanalyzer { namespace clientbackend {

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
@@ -39,9 +39,9 @@
   } while (false)
 
 namespace tc = triton::client;
-namespace tfs = perfanalyzer::clientbackend::tfserving;
+namespace tfs = triton::perfanalyzer::clientbackend::tfserving;
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 //==============================================================================
 /// TFServeClientBackend is used to generate load on the TF serving isntance
@@ -139,4 +139,4 @@ class TFServeInferResult : public InferResult {
   std::unique_ptr<tfs::InferResult> result_;
 };
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
@@ -39,9 +39,12 @@
   } while (false)
 
 namespace tc = triton::client;
+namespace cb = triton::perfanalyzer::clientbackend;
 namespace tfs = triton::perfanalyzer::clientbackend::tfserving;
 
 namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace tfserving {
+
 
 //==============================================================================
 /// TFServeClientBackend is used to generate load on the TF serving isntance
@@ -73,7 +76,7 @@ class TFServeClientBackend : public ClientBackend {
 
   /// See ClientBackend::Infer()
   Error Infer(
-      InferResult** result, const InferOptions& options,
+      cb::InferResult** result, const InferOptions& options,
       const std::vector<InferInput*>& inputs,
       const std::vector<const InferRequestedOutput*>& outputs) override;
 
@@ -99,7 +102,7 @@ class TFServeClientBackend : public ClientBackend {
   void ParseInferStat(
       const tc::InferStat& tfserve_infer_stat, InferStat* infer_stat);
 
-  std::unique_ptr<tfs::GrpcClient> grpc_client_;
+  std::unique_ptr<GrpcClient> grpc_client_;
 
   grpc_compression_algorithm compression_algorithm_;
   std::shared_ptr<Headers> http_headers_;
@@ -127,7 +130,7 @@ class TFServeInferRequestedOutput : public InferRequestedOutput {
 /// TFServeInferResult is a wrapper around InferResult object of
 /// TF serving InferResult object.
 ///
-class TFServeInferResult : public InferResult {
+class TFServeInferResult : public cb::InferResult {
  public:
   explicit TFServeInferResult(tfs::InferResult* result);
   /// See InferResult::Id()
@@ -139,4 +142,4 @@ class TFServeInferResult : public InferResult {
   std::unique_ptr<tfs::InferResult> result_;
 };
 
-}}}  // namespace triton::perfanalyzer::clientbackend
+}}}}  // namespace triton::perfanalyzer::clientbackend::tfserving

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
@@ -38,7 +38,7 @@
     }                                   \
   } while (false)
 
-namespace nic = nvidia::inferenceserver::client;
+namespace nic = inferenceserver::client;
 namespace tfs = perfanalyzer::clientbackend::tfserving;
 
 namespace perfanalyzer { namespace clientbackend {

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
@@ -32,7 +32,7 @@
 
 #define RETURN_IF_TRITON_ERROR(S)       \
   do {                                  \
-    const tc::Error& status__ = (S);   \
+    const tc::Error& status__ = (S);    \
     if (!status__.IsOk()) {             \
       return Error(status__.Message()); \
     }                                   \

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.cc
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.cc
@@ -38,7 +38,7 @@
 typedef google::protobuf::Map<std::string, tensorflow::TensorProto>
     StringKeyedProtos;
 
-namespace perfanalyzer { namespace clientbackend { namespace tfserving {
+namespace triton { namespace perfanalyzer { namespace clientbackend { namespace tfserving {
 
 namespace {
 
@@ -719,4 +719,4 @@ InferResult::InferResult(
 
 //======================================================================
 
-}}}  // namespace perfanalyzer::clientbackend::tfserving
+}}}}  // namespace triton::perfanalyzer::clientbackend::tfserving

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.cc
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.cc
@@ -38,7 +38,8 @@
 typedef google::protobuf::Map<std::string, tensorflow::TensorProto>
     StringKeyedProtos;
 
-namespace triton { namespace perfanalyzer { namespace clientbackend { namespace tfserving {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace tfserving {
 
 namespace {
 

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.h
@@ -33,7 +33,8 @@
 
 namespace tc = triton::client;
 
-namespace triton { namespace perfanalyzer { namespace clientbackend { namespace tfserving {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace tfserving {
 
 struct SslOptions {
   explicit SslOptions() {}

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.h
@@ -33,7 +33,7 @@
 
 namespace tc = triton::client;
 
-namespace perfanalyzer { namespace clientbackend { namespace tfserving {
+namespace triton { namespace perfanalyzer { namespace clientbackend { namespace tfserving {
 
 struct SslOptions {
   explicit SslOptions() {}
@@ -215,4 +215,4 @@ class InferResult {
 
 //======================================================================
 
-}}}  // namespace perfanalyzer::clientbackend::tfserving
+}}}}  // namespace triton::perfanalyzer::clientbackend::tfserving

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.h
@@ -31,7 +31,7 @@
 #include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
 #include "tfserve_infer_input.h"
 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 namespace perfanalyzer { namespace clientbackend { namespace tfserving {
 
@@ -69,7 +69,7 @@ using TFServeOnCompleteFn = std::function<void(InferResult*)>;
 ///   ...
 /// \endcode
 ///
-class GrpcClient : public nic::InferenceServerClient {
+class GrpcClient : public tc::InferenceServerClient {
  public:
   ~GrpcClient();
 

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.h
@@ -31,7 +31,7 @@
 #include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
 #include "tfserve_infer_input.h"
 
-namespace nic = inferenceserver::client;
+namespace nic = triton::client;
 
 namespace perfanalyzer { namespace clientbackend { namespace tfserving {
 

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_grpc_client.h
@@ -31,7 +31,7 @@
 #include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
 #include "tfserve_infer_input.h"
 
-namespace nic = nvidia::inferenceserver::client;
+namespace nic = inferenceserver::client;
 
 namespace perfanalyzer { namespace clientbackend { namespace tfserving {
 

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.cc
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.cc
@@ -26,7 +26,8 @@
 
 #include "tfserve_infer_input.h"
 
-namespace triton { namespace perfanalyzer { namespace clientbackend { namespace tfserving {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace tfserving {
 
 Error
 TFServeInferInput::Create(

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.cc
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.cc
@@ -26,7 +26,7 @@
 
 #include "tfserve_infer_input.h"
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 Error
 TFServeInferInput::Create(
@@ -108,4 +108,4 @@ TFServeInferInput::TFServeInferInput(
 {
 }
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.cc
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.cc
@@ -26,7 +26,7 @@
 
 #include "tfserve_infer_input.h"
 
-namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend { namespace tfserving {
 
 Error
 TFServeInferInput::Create(
@@ -108,4 +108,4 @@ TFServeInferInput::TFServeInferInput(
 {
 }
 
-}}}  // namespace triton::perfanalyzer::clientbackend
+}}}}  // namespace triton::perfanalyzer::clientbackend::tfserving

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h
@@ -30,7 +30,7 @@
 #include "../client_backend.h"
 
 
-namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend { namespace tfserving {
 
 //==============================================================
 /// TFServeInferInput instance holds the information regarding
@@ -71,4 +71,4 @@ class TFServeInferInput : public InferInput {
   std::vector<size_t> buf_byte_sizes_;
 };
 
-}}}  // namespace triton::perfanalyzer::clientbackend
+}}}}  // namespace triton::perfanalyzer::clientbackend::tfserving

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h
@@ -30,7 +30,7 @@
 #include "../client_backend.h"
 
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 //==============================================================
 /// TFServeInferInput instance holds the information regarding
@@ -71,4 +71,4 @@ class TFServeInferInput : public InferInput {
   std::vector<size_t> buf_byte_sizes_;
 };
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h
@@ -30,7 +30,8 @@
 #include "../client_backend.h"
 
 
-namespace triton { namespace perfanalyzer { namespace clientbackend { namespace tfserving {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace tfserving {
 
 //==============================================================
 /// TFServeInferInput instance holds the information regarding

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.cc
@@ -29,6 +29,8 @@
 #include "json_utils.h"
 
 namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace torchserve {
+
 
 //==============================================================================
 
@@ -52,7 +54,7 @@ TorchServeClientBackend::Create(
 
 Error
 TorchServeClientBackend::Infer(
-    InferResult** result, const InferOptions& options,
+    cb::InferResult** result, const InferOptions& options,
     const std::vector<InferInput*>& inputs,
     const std::vector<const InferRequestedOutput*>& outputs)
 {
@@ -111,4 +113,4 @@ TorchServeInferResult::RequestStatus() const
 
 //==============================================================================
 
-}}}  // namespace triton::perfanalyzer::clientbackend
+}}}}  // namespace triton::perfanalyzer::clientbackend::torchserve

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.cc
@@ -68,7 +68,7 @@ TorchServeClientBackend::ClientInferStat(InferStat* infer_stat)
 {
   // Reusing the common library utilities to collect and report the
   // client side statistics.
-  nic::InferStat client_infer_stat;
+  tc::InferStat client_infer_stat;
   RETURN_IF_TRITON_ERROR(http_client_->ClientInferStat(&client_infer_stat));
   ParseInferStat(client_infer_stat, infer_stat);
   return Error::Success;
@@ -76,7 +76,7 @@ TorchServeClientBackend::ClientInferStat(InferStat* infer_stat)
 
 void
 TorchServeClientBackend::ParseInferStat(
-    const nic::InferStat& torchserve_infer_stat, InferStat* infer_stat)
+    const tc::InferStat& torchserve_infer_stat, InferStat* infer_stat)
 {
   infer_stat->completed_request_count =
       torchserve_infer_stat.completed_request_count;

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.cc
@@ -28,7 +28,7 @@
 
 #include "json_utils.h"
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 //==============================================================================
 
@@ -111,4 +111,4 @@ TorchServeInferResult::RequestStatus() const
 
 //==============================================================================
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
@@ -39,9 +39,12 @@
   } while (false)
 
 namespace tc = triton::client;
+namespace cb = triton::perfanalyzer::clientbackend;
 namespace ts = triton::perfanalyzer::clientbackend::torchserve;
 
 namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace torchserve {
+
 
 //==============================================================================
 /// TorchServeClientBackend is used to generate load on the Torchserve isntance
@@ -65,7 +68,7 @@ class TorchServeClientBackend : public ClientBackend {
 
   /// See ClientBackend::Infer()
   Error Infer(
-      InferResult** result, const InferOptions& options,
+      cb::InferResult** result, const InferOptions& options,
       const std::vector<InferInput*>& inputs,
       const std::vector<const InferRequestedOutput*>& outputs) override;
 
@@ -89,7 +92,7 @@ class TorchServeClientBackend : public ClientBackend {
 /// TorchServeInferResult is a wrapper around InferResult object of
 /// torchserve InferResult object.
 ///
-class TorchServeInferResult : public InferResult {
+class TorchServeInferResult : public cb::InferResult {
  public:
   explicit TorchServeInferResult(ts::InferResult* result);
   /// See InferResult::Id()
@@ -101,4 +104,4 @@ class TorchServeInferResult : public InferResult {
   std::unique_ptr<ts::InferResult> result_;
 };
 
-}}}  // namespace triton::perfanalyzer::clientbackend
+}}}}  // namespace triton::perfanalyzer::clientbackend::torchserve

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
@@ -39,9 +39,9 @@
   } while (false)
 
 namespace tc = triton::client;
-namespace ts = perfanalyzer::clientbackend::torchserve;
+namespace ts = triton::perfanalyzer::clientbackend::torchserve;
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 //==============================================================================
 /// TorchServeClientBackend is used to generate load on the Torchserve isntance
@@ -101,4 +101,4 @@ class TorchServeInferResult : public InferResult {
   std::unique_ptr<ts::InferResult> result_;
 };
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
@@ -32,13 +32,13 @@
 
 #define RETURN_IF_TRITON_ERROR(S)       \
   do {                                  \
-    const nic::Error& status__ = (S);   \
+    const tc::Error& status__ = (S);   \
     if (!status__.IsOk()) {             \
       return Error(status__.Message()); \
     }                                   \
   } while (false)
 
-namespace nic = triton::client;
+namespace tc = triton::client;
 namespace ts = perfanalyzer::clientbackend::torchserve;
 
 namespace perfanalyzer { namespace clientbackend {
@@ -79,7 +79,7 @@ class TorchServeClientBackend : public ClientBackend {
   }
 
   void ParseInferStat(
-      const nic::InferStat& torchserve_infer_stat, InferStat* infer_stat);
+      const tc::InferStat& torchserve_infer_stat, InferStat* infer_stat);
 
   std::unique_ptr<ts::HttpClient> http_client_;
   std::shared_ptr<Headers> http_headers_;

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
@@ -38,7 +38,7 @@
     }                                   \
   } while (false)
 
-namespace nic = inferenceserver::client;
+namespace nic = triton::client;
 namespace ts = perfanalyzer::clientbackend::torchserve;
 
 namespace perfanalyzer { namespace clientbackend {

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
@@ -38,7 +38,7 @@
     }                                   \
   } while (false)
 
-namespace nic = nvidia::inferenceserver::client;
+namespace nic = inferenceserver::client;
 namespace ts = perfanalyzer::clientbackend::torchserve;
 
 namespace perfanalyzer { namespace clientbackend {

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
@@ -32,7 +32,7 @@
 
 #define RETURN_IF_TRITON_ERROR(S)       \
   do {                                  \
-    const tc::Error& status__ = (S);   \
+    const tc::Error& status__ = (S);    \
     if (!status__.IsOk()) {             \
       return Error(status__.Message()); \
     }                                   \

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.cc
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.cc
@@ -30,7 +30,8 @@
 #include <cstdint>
 #include "torchserve_client_backend.h"
 
-namespace triton { namespace perfanalyzer { namespace clientbackend { namespace torchserve {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace torchserve {
 
 namespace {
 

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.cc
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.cc
@@ -30,7 +30,7 @@
 #include <cstdint>
 #include "torchserve_client_backend.h"
 
-namespace perfanalyzer { namespace clientbackend { namespace torchserve {
+namespace triton { namespace perfanalyzer { namespace clientbackend { namespace torchserve {
 
 namespace {
 
@@ -404,4 +404,4 @@ InferResult::InferResult(std::shared_ptr<HttpInferRequest> infer_request)
 
 //======================================================================
 
-}}}  // namespace perfanalyzer::clientbackend::torchserve
+}}}}  // namespace triton::perfanalyzer::clientbackend::torchserve

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.cc
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.cc
@@ -153,7 +153,7 @@ HttpClient::Infer(
 
   sync_request->Timer().Reset();
   sync_request->Timer().CaptureTimestamp(
-      nic::RequestTimers::Kind::REQUEST_START);
+      tc::RequestTimers::Kind::REQUEST_START);
 
   if (!curl_global.Status().IsOk()) {
     return curl_global.Status();
@@ -166,7 +166,7 @@ HttpClient::Infer(
     return err;
   }
 
-  sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::SEND_START);
+  sync_request->Timer().CaptureTimestamp(tc::RequestTimers::Kind::SEND_START);
 
   // During this call SEND_END (except in above case), RECV_START, and
   // RECV_END will be set.
@@ -183,9 +183,9 @@ HttpClient::Infer(
 
   InferResult::Create(result, sync_request);
 
-  sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::REQUEST_END);
+  sync_request->Timer().CaptureTimestamp(tc::RequestTimers::Kind::REQUEST_END);
 
-  nic::Error nic_err = UpdateInferStat(sync_request->Timer());
+  tc::Error nic_err = UpdateInferStat(sync_request->Timer());
   if (!nic_err.IsOk()) {
     std::cerr << "Failed to update context stat: " << nic_err << std::endl;
   }
@@ -203,7 +203,7 @@ HttpClient::ReadCallback(char* buffer, size_t size, size_t nitems, void* userp)
   if (retcode == 0) {
     ((HttpInferRequest*)userp)
         ->Timer()
-        .CaptureTimestamp(nic::RequestTimers::Kind::SEND_END);
+        .CaptureTimestamp(tc::RequestTimers::Kind::SEND_END);
   }
   return retcode;
 }
@@ -247,8 +247,8 @@ HttpClient::InferResponseHandler(
 {
   HttpInferRequest* request = reinterpret_cast<HttpInferRequest*>(userp);
 
-  if (request->Timer().Timestamp(nic::RequestTimers::Kind::RECV_START) == 0) {
-    request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::RECV_START);
+  if (request->Timer().Timestamp(tc::RequestTimers::Kind::RECV_START) == 0) {
+    request->Timer().CaptureTimestamp(tc::RequestTimers::Kind::RECV_START);
   }
 
   char* buf = reinterpret_cast<char*>(contents);
@@ -257,7 +257,7 @@ HttpClient::InferResponseHandler(
 
   // InferResponseHandler may be called multiple times so we overwrite
   // RECV_END so that we always have the time of the last.
-  request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::RECV_END);
+  request->Timer().CaptureTimestamp(tc::RequestTimers::Kind::RECV_END);
 
   return result_bytes;
 }

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.h
@@ -35,7 +35,8 @@
 
 namespace tc = triton::client;
 
-namespace triton { namespace perfanalyzer { namespace clientbackend { namespace torchserve {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace torchserve {
 
 class InferResult;
 class HttpInferRequest;

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.h
@@ -33,7 +33,7 @@
 #include "torchserve_infer_input.h"
 
 
-namespace nic = inferenceserver::client;
+namespace nic = triton::client;
 
 namespace perfanalyzer { namespace clientbackend { namespace torchserve {
 

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.h
@@ -33,7 +33,7 @@
 #include "torchserve_infer_input.h"
 
 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 namespace perfanalyzer { namespace clientbackend { namespace torchserve {
 
@@ -54,7 +54,7 @@ using TorchServeOnCompleteFn = std::function<void(InferResult*)>;
 ///   ...
 /// \endcode
 ///
-class HttpClient : public nic::InferenceServerClient {
+class HttpClient : public tc::InferenceServerClient {
  public:
   ~HttpClient();
 
@@ -129,7 +129,7 @@ class HttpInferRequest {
   Error OpenFileData(std::string& file_path);
   long FileSize();
   Error CloseFileData();
-  nic::RequestTimers& Timer() { return timer_; }
+  tc::RequestTimers& Timer() { return timer_; }
   std::string& DebugString() { return *infer_response_buffer_; }
   FILE* FilePtr() { return file_ptr_.get(); }
   friend HttpClient;
@@ -145,7 +145,7 @@ class HttpInferRequest {
   // Buffer that accumulates the response body.
   std::unique_ptr<std::string> infer_response_buffer_;
   // The timers for infer request.
-  nic::RequestTimers timer_;
+  tc::RequestTimers timer_;
 };
 
 //======================================================================

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.h
@@ -33,7 +33,7 @@
 #include "torchserve_infer_input.h"
 
 
-namespace nic = nvidia::inferenceserver::client;
+namespace nic = inferenceserver::client;
 
 namespace perfanalyzer { namespace clientbackend { namespace torchserve {
 

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_http_client.h
@@ -35,7 +35,7 @@
 
 namespace tc = triton::client;
 
-namespace perfanalyzer { namespace clientbackend { namespace torchserve {
+namespace triton { namespace perfanalyzer { namespace clientbackend { namespace torchserve {
 
 class InferResult;
 class HttpInferRequest;
@@ -170,4 +170,4 @@ class InferResult {
 
 //======================================================================
 
-}}}  // namespace perfanalyzer::clientbackend::torchserve
+}}}}  // namespace triton::perfanalyzer::clientbackend::torchserve

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.cc
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.cc
@@ -27,6 +27,8 @@
 #include "torchserve_infer_input.h"
 
 namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace torchserve {
+
 
 Error
 TorchServeInferInput::Create(
@@ -104,4 +106,4 @@ TorchServeInferInput::TorchServeInferInput(
 {
 }
 
-}}}  // namespace triton::perfanalyzer::clientbackend
+}}}}  // namespace triton::perfanalyzer::clientbackend::torchserve

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.cc
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.cc
@@ -26,7 +26,7 @@
 
 #include "torchserve_infer_input.h"
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 Error
 TorchServeInferInput::Create(
@@ -104,4 +104,4 @@ TorchServeInferInput::TorchServeInferInput(
 {
 }
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.h
@@ -29,7 +29,7 @@
 #include "../../perf_utils.h"
 #include "../client_backend.h"
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 //==============================================================
 /// TorchServeInferInput instance holds the information regarding
@@ -70,4 +70,4 @@ class TorchServeInferInput : public InferInput {
   std::vector<size_t> buf_byte_sizes_;
 };
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.h
+++ b/src/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.h
@@ -30,6 +30,8 @@
 #include "../client_backend.h"
 
 namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace torchserve {
+
 
 //==============================================================
 /// TorchServeInferInput instance holds the information regarding
@@ -70,4 +72,4 @@ class TorchServeInferInput : public InferInput {
   std::vector<size_t> buf_byte_sizes_;
 };
 
-}}}  // namespace triton::perfanalyzer::clientbackend
+}}}}  // namespace triton::perfanalyzer::clientbackend::torchserve

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
@@ -29,7 +29,7 @@
 #include "json_utils.h"
 
 namespace triton { namespace perfanalyzer { namespace clientbackend {
-
+namespace tritonremote {
 //==============================================================================
 
 Error
@@ -612,4 +612,4 @@ TritonInferResult::RequestStatus() const
 
 //==============================================================================
 
-}}}  // namespace triton::perfanalyzer::clientbackend
+}}}}  // namespace triton::perfanalyzer::clientbackend::tritonremote

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
@@ -28,7 +28,7 @@
 
 #include "json_utils.h"
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 //==============================================================================
 
@@ -612,4 +612,4 @@ TritonInferResult::RequestStatus() const
 
 //==============================================================================
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
@@ -42,10 +42,10 @@ TritonClientBackend::Create(
   std::unique_ptr<TritonClientBackend> triton_client_backend(
       new TritonClientBackend(protocol, compression_algorithm, http_headers));
   if (protocol == ProtocolType::HTTP) {
-    RETURN_IF_TRITON_ERROR(nic::InferenceServerHttpClient::Create(
+    RETURN_IF_TRITON_ERROR(tc::InferenceServerHttpClient::Create(
         &(triton_client_backend->client_.http_client_), url, verbose));
   } else {
-    RETURN_IF_TRITON_ERROR(nic::InferenceServerGrpcClient::Create(
+    RETURN_IF_TRITON_ERROR(tc::InferenceServerGrpcClient::Create(
         &(triton_client_backend->client_.grpc_client_), url, verbose));
   }
 
@@ -66,7 +66,7 @@ TritonClientBackend::ServerExtensions(std::set<std::string>* extensions)
 
     rapidjson::Document server_metadata_json;
     FAIL_IF_TRITON_ERR(
-        nic::ParseJson(&server_metadata_json, server_metadata),
+        tc::ParseJson(&server_metadata_json, server_metadata),
         "failed to parse server metadata");
     for (const auto& extension :
          server_metadata_json["extensions"].GetArray()) {
@@ -95,7 +95,7 @@ TritonClientBackend::ModelMetadata(
     std::string metadata;
     RETURN_IF_TRITON_ERROR(client_.http_client_->ModelMetadata(
         &metadata, model_name, model_version, *http_headers_));
-    RETURN_IF_TRITON_ERROR(nic::ParseJson(model_metadata, metadata));
+    RETURN_IF_TRITON_ERROR(tc::ParseJson(model_metadata, metadata));
   } else {
     inference::ModelMetadataResponse model_metadata_proto;
     RETURN_IF_TRITON_ERROR(client_.grpc_client_->ModelMetadata(
@@ -108,7 +108,7 @@ TritonClientBackend::ModelMetadata(
     ::google::protobuf::util::MessageToJsonString(
         model_metadata_proto, &metadata, options);
 
-    RETURN_IF_TRITON_ERROR(nic::ParseJson(model_metadata, metadata));
+    RETURN_IF_TRITON_ERROR(tc::ParseJson(model_metadata, metadata));
   }
 
   return Error::Success;
@@ -123,7 +123,7 @@ TritonClientBackend::ModelConfig(
     std::string config;
     RETURN_IF_TRITON_ERROR(client_.http_client_->ModelConfig(
         &config, model_name, model_version, *http_headers_));
-    RETURN_IF_TRITON_ERROR(nic::ParseJson(model_config, config));
+    RETURN_IF_TRITON_ERROR(tc::ParseJson(model_config, config));
   } else {
     inference::ModelConfigResponse model_config_proto;
     RETURN_IF_TRITON_ERROR(client_.grpc_client_->ModelConfig(
@@ -137,7 +137,7 @@ TritonClientBackend::ModelConfig(
         model_config_proto, &config, options);
 
     rapidjson::Document full_config;
-    RETURN_IF_TRITON_ERROR(nic::ParseJson(&full_config, config));
+    RETURN_IF_TRITON_ERROR(tc::ParseJson(&full_config, config));
     model_config->CopyFrom(full_config["config"], model_config->GetAllocator());
   }
   return Error::Success;
@@ -149,16 +149,16 @@ TritonClientBackend::Infer(
     const std::vector<InferInput*>& inputs,
     const std::vector<const InferRequestedOutput*>& outputs)
 {
-  std::vector<nic::InferInput*> triton_inputs;
+  std::vector<tc::InferInput*> triton_inputs;
   ParseInferInputToTriton(inputs, &triton_inputs);
 
-  std::vector<const nic::InferRequestedOutput*> triton_outputs;
+  std::vector<const tc::InferRequestedOutput*> triton_outputs;
   ParseInferRequestedOutputToTriton(outputs, &triton_outputs);
 
-  nic::InferOptions triton_options(options.model_name_);
+  tc::InferOptions triton_options(options.model_name_);
   ParseInferOptionsToTriton(options, &triton_options);
 
-  nic::InferResult* triton_result;
+  tc::InferResult* triton_result;
 
   if (protocol_ == ProtocolType::GRPC) {
     RETURN_IF_TRITON_ERROR(client_.grpc_client_->Infer(
@@ -181,18 +181,18 @@ TritonClientBackend::AsyncInfer(
     const std::vector<InferInput*>& inputs,
     const std::vector<const InferRequestedOutput*>& outputs)
 {
-  auto wrapped_callback = [callback](nic::InferResult* client_result) {
+  auto wrapped_callback = [callback](tc::InferResult* client_result) {
     InferResult* result = new TritonInferResult(client_result);
     callback(result);
   };
 
-  std::vector<nic::InferInput*> triton_inputs;
+  std::vector<tc::InferInput*> triton_inputs;
   ParseInferInputToTriton(inputs, &triton_inputs);
 
-  std::vector<const nic::InferRequestedOutput*> triton_outputs;
+  std::vector<const tc::InferRequestedOutput*> triton_outputs;
   ParseInferRequestedOutputToTriton(outputs, &triton_outputs);
 
-  nic::InferOptions triton_options(options.model_name_);
+  tc::InferOptions triton_options(options.model_name_);
   ParseInferOptionsToTriton(options, &triton_options);
 
   if (protocol_ == ProtocolType::GRPC) {
@@ -211,7 +211,7 @@ TritonClientBackend::AsyncInfer(
 Error
 TritonClientBackend::StartStream(OnCompleteFn callback, bool enable_stats)
 {
-  auto wrapped_callback = [callback](nic::InferResult* client_result) {
+  auto wrapped_callback = [callback](tc::InferResult* client_result) {
     InferResult* result = new TritonInferResult(client_result);
     callback(result);
   };
@@ -232,13 +232,13 @@ TritonClientBackend::AsyncStreamInfer(
     const InferOptions& options, const std::vector<InferInput*>& inputs,
     const std::vector<const InferRequestedOutput*>& outputs)
 {
-  std::vector<nic::InferInput*> triton_inputs;
+  std::vector<tc::InferInput*> triton_inputs;
   ParseInferInputToTriton(inputs, &triton_inputs);
 
-  std::vector<const nic::InferRequestedOutput*> triton_outputs;
+  std::vector<const tc::InferRequestedOutput*> triton_outputs;
   ParseInferRequestedOutputToTriton(outputs, &triton_outputs);
 
-  nic::InferOptions triton_options(options.model_name_);
+  tc::InferOptions triton_options(options.model_name_);
   ParseInferOptionsToTriton(options, &triton_options);
 
   if (protocol_ == ProtocolType::GRPC) {
@@ -254,7 +254,7 @@ TritonClientBackend::AsyncStreamInfer(
 Error
 TritonClientBackend::ClientInferStat(InferStat* infer_stat)
 {
-  nic::InferStat triton_infer_stat;
+  tc::InferStat triton_infer_stat;
   if (protocol_ == ProtocolType::GRPC) {
     RETURN_IF_TRITON_ERROR(
         client_.grpc_client_->ClientInferStat(&triton_infer_stat));
@@ -283,7 +283,7 @@ TritonClientBackend::ModelInferenceStatistics(
     RETURN_IF_TRITON_ERROR(client_.http_client_->ModelInferenceStatistics(
         &infer_stat, model_name, model_version, *http_headers_));
     rapidjson::Document infer_stat_json;
-    RETURN_IF_TRITON_ERROR(nic::ParseJson(&infer_stat_json, infer_stat));
+    RETURN_IF_TRITON_ERROR(tc::ParseJson(&infer_stat_json, infer_stat));
     ParseStatistics(infer_stat_json, model_stats);
   }
 
@@ -349,7 +349,7 @@ TritonClientBackend::CreateSharedMemoryRegion(
     std::string shm_key, size_t byte_size, int* shm_fd)
 {
   RETURN_IF_TRITON_ERROR(
-      nic::CreateSharedMemoryRegion(shm_key, byte_size, shm_fd));
+      tc::CreateSharedMemoryRegion(shm_key, byte_size, shm_fd));
 
   return Error::Success;
 }
@@ -360,7 +360,7 @@ TritonClientBackend::MapSharedMemory(
     int shm_fd, size_t offset, size_t byte_size, void** shm_addr)
 {
   RETURN_IF_TRITON_ERROR(
-      nic::MapSharedMemory(shm_fd, offset, byte_size, shm_addr));
+      tc::MapSharedMemory(shm_fd, offset, byte_size, shm_addr));
 
   return Error::Success;
 }
@@ -369,7 +369,7 @@ TritonClientBackend::MapSharedMemory(
 Error
 TritonClientBackend::CloseSharedMemory(int shm_fd)
 {
-  RETURN_IF_TRITON_ERROR(nic::CloseSharedMemory(shm_fd));
+  RETURN_IF_TRITON_ERROR(tc::CloseSharedMemory(shm_fd));
 
   return Error::Success;
 }
@@ -377,7 +377,7 @@ TritonClientBackend::CloseSharedMemory(int shm_fd)
 Error
 TritonClientBackend::UnlinkSharedMemoryRegion(std::string shm_key)
 {
-  RETURN_IF_TRITON_ERROR(nic::UnlinkSharedMemoryRegion(shm_key));
+  RETURN_IF_TRITON_ERROR(tc::UnlinkSharedMemoryRegion(shm_key));
 
   return Error::Success;
 }
@@ -385,7 +385,7 @@ TritonClientBackend::UnlinkSharedMemoryRegion(std::string shm_key)
 Error
 TritonClientBackend::UnmapSharedMemory(void* shm_addr, size_t byte_size)
 {
-  RETURN_IF_TRITON_ERROR(nic::UnmapSharedMemory(shm_addr, byte_size));
+  RETURN_IF_TRITON_ERROR(tc::UnmapSharedMemory(shm_addr, byte_size));
 
   return Error::Success;
 }
@@ -393,7 +393,7 @@ TritonClientBackend::UnmapSharedMemory(void* shm_addr, size_t byte_size)
 void
 TritonClientBackend::ParseInferInputToTriton(
     const std::vector<InferInput*>& inputs,
-    std::vector<nic::InferInput*>* triton_inputs)
+    std::vector<tc::InferInput*>* triton_inputs)
 {
   for (const auto input : inputs) {
     triton_inputs->push_back((dynamic_cast<TritonInferInput*>(input))->Get());
@@ -403,7 +403,7 @@ TritonClientBackend::ParseInferInputToTriton(
 void
 TritonClientBackend::ParseInferRequestedOutputToTriton(
     const std::vector<const InferRequestedOutput*>& outputs,
-    std::vector<const nic::InferRequestedOutput*>* triton_outputs)
+    std::vector<const tc::InferRequestedOutput*>* triton_outputs)
 {
   for (const auto output : outputs) {
     triton_outputs->push_back(
@@ -413,7 +413,7 @@ TritonClientBackend::ParseInferRequestedOutputToTriton(
 
 void
 TritonClientBackend::ParseInferOptionsToTriton(
-    const InferOptions& options, nic::InferOptions* triton_options)
+    const InferOptions& options, tc::InferOptions* triton_options)
 {
   triton_options->model_version_ = options.model_version_;
   triton_options->request_id_ = options.request_id_;
@@ -482,7 +482,7 @@ TritonClientBackend::ParseStatistics(
 
 void
 TritonClientBackend::ParseInferStat(
-    const nic::InferStat& triton_infer_stat, InferStat* infer_stat)
+    const tc::InferStat& triton_infer_stat, InferStat* infer_stat)
 {
   infer_stat->completed_request_count =
       triton_infer_stat.completed_request_count;
@@ -503,9 +503,9 @@ TritonInferInput::Create(
 {
   TritonInferInput* local_infer_input = new TritonInferInput(name, datatype);
 
-  nic::InferInput* triton_infer_input;
+  tc::InferInput* triton_infer_input;
   RETURN_IF_TRITON_ERROR(
-      nic::InferInput::Create(&triton_infer_input, name, dims, datatype));
+      tc::InferInput::Create(&triton_infer_input, name, dims, datatype));
   local_infer_input->input_.reset(triton_infer_input);
 
   *infer_input = local_infer_input;
@@ -564,8 +564,8 @@ TritonInferRequestedOutput::Create(
   TritonInferRequestedOutput* local_infer_output =
       new TritonInferRequestedOutput();
 
-  nic::InferRequestedOutput* triton_infer_output;
-  RETURN_IF_TRITON_ERROR(nic::InferRequestedOutput::Create(
+  tc::InferRequestedOutput* triton_infer_output;
+  RETURN_IF_TRITON_ERROR(tc::InferRequestedOutput::Create(
       &triton_infer_output, name, class_count));
   local_infer_output->output_.reset(triton_infer_output);
 
@@ -591,7 +591,7 @@ TritonInferRequestedOutput::TritonInferRequestedOutput()
 
 //==============================================================================
 
-TritonInferResult::TritonInferResult(nic::InferResult* result)
+TritonInferResult::TritonInferResult(tc::InferResult* result)
 {
   result_.reset(result);
 }

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -49,7 +49,7 @@
     }                                                              \
   }
 
-namespace nic = nvidia::inferenceserver::client;
+namespace nic = inferenceserver::client;
 
 namespace perfanalyzer { namespace clientbackend {
 

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -34,7 +34,7 @@
 
 #define RETURN_IF_TRITON_ERROR(S)       \
   do {                                  \
-    const tc::Error& status__ = (S);   \
+    const tc::Error& status__ = (S);    \
     if (!status__.IsOk()) {             \
       return Error(status__.Message()); \
     }                                   \
@@ -42,7 +42,7 @@
 
 #define FAIL_IF_TRITON_ERR(X, MSG)                                 \
   {                                                                \
-    const tc::Error err = (X);                                    \
+    const tc::Error err = (X);                                     \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -34,7 +34,7 @@
 
 #define RETURN_IF_TRITON_ERROR(S)       \
   do {                                  \
-    const nic::Error& status__ = (S);   \
+    const tc::Error& status__ = (S);   \
     if (!status__.IsOk()) {             \
       return Error(status__.Message()); \
     }                                   \
@@ -42,14 +42,14 @@
 
 #define FAIL_IF_TRITON_ERR(X, MSG)                                 \
   {                                                                \
-    const nic::Error err = (X);                                    \
+    const tc::Error err = (X);                                    \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
     }                                                              \
   }
 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 namespace perfanalyzer { namespace clientbackend {
 
@@ -72,7 +72,7 @@ class TritonClientBackend : public ClientBackend {
   static Error Create(
       const std::string& url, const ProtocolType protocol,
       const grpc_compression_algorithm compression_algorithm,
-      std::shared_ptr<nic::Headers> http_headers, const bool verbose,
+      std::shared_ptr<tc::Headers> http_headers, const bool verbose,
       std::unique_ptr<ClientBackend>* client_backend);
 
   /// See ClientBackend::ServerExtensions()
@@ -151,7 +151,7 @@ class TritonClientBackend : public ClientBackend {
   TritonClientBackend(
       const ProtocolType protocol,
       const grpc_compression_algorithm compression_algorithm,
-      std::shared_ptr<nic::Headers> http_headers)
+      std::shared_ptr<tc::Headers> http_headers)
       : ClientBackend(BackendKind::TRITON), protocol_(protocol),
         compression_algorithm_(compression_algorithm),
         http_headers_(http_headers)
@@ -160,12 +160,12 @@ class TritonClientBackend : public ClientBackend {
 
   void ParseInferInputToTriton(
       const std::vector<InferInput*>& inputs,
-      std::vector<nic::InferInput*>* triton_inputs);
+      std::vector<tc::InferInput*>* triton_inputs);
   void ParseInferRequestedOutputToTriton(
       const std::vector<const InferRequestedOutput*>& outputs,
-      std::vector<const nic::InferRequestedOutput*>* triton_outputs);
+      std::vector<const tc::InferRequestedOutput*>* triton_outputs);
   void ParseInferOptionsToTriton(
-      const InferOptions& options, nic::InferOptions* triton_options);
+      const InferOptions& options, tc::InferOptions* triton_options);
   void ParseStatistics(
       const inference::ModelStatisticsResponse& infer_stat,
       std::map<ModelIdentifier, ModelStatistics>* model_stats);
@@ -173,24 +173,24 @@ class TritonClientBackend : public ClientBackend {
       const rapidjson::Document& infer_stat,
       std::map<ModelIdentifier, ModelStatistics>* model_stats);
   void ParseInferStat(
-      const nic::InferStat& triton_infer_stat, InferStat* infer_stat);
+      const tc::InferStat& triton_infer_stat, InferStat* infer_stat);
 
   /// Union to represent the underlying triton client belonging to one of
   /// the protocols
   union TritonClient {
     TritonClient()
     {
-      new (&http_client_) std::unique_ptr<nic::InferenceServerHttpClient>{};
+      new (&http_client_) std::unique_ptr<tc::InferenceServerHttpClient>{};
     }
     ~TritonClient() {}
 
-    std::unique_ptr<nic::InferenceServerHttpClient> http_client_;
-    std::unique_ptr<nic::InferenceServerGrpcClient> grpc_client_;
+    std::unique_ptr<tc::InferenceServerHttpClient> http_client_;
+    std::unique_ptr<tc::InferenceServerGrpcClient> grpc_client_;
   } client_;
 
   const ProtocolType protocol_;
   const grpc_compression_algorithm compression_algorithm_;
-  std::shared_ptr<nic::Headers> http_headers_;
+  std::shared_ptr<tc::Headers> http_headers_;
 };
 
 //==============================================================
@@ -203,7 +203,7 @@ class TritonInferInput : public InferInput {
       InferInput** infer_input, const std::string& name,
       const std::vector<int64_t>& dims, const std::string& datatype);
   /// Returns the raw InferInput object required by triton client library.
-  nic::InferInput* Get() const { return input_.get(); }
+  tc::InferInput* Get() const { return input_.get(); }
   /// See InferInput::Shape()
   const std::vector<int64_t>& Shape() const override;
   /// See InferInput::SetShape()
@@ -220,7 +220,7 @@ class TritonInferInput : public InferInput {
   explicit TritonInferInput(
       const std::string& name, const std::string& datatype);
 
-  std::unique_ptr<nic::InferInput> input_;
+  std::unique_ptr<tc::InferInput> input_;
 };
 
 //==============================================================
@@ -234,7 +234,7 @@ class TritonInferRequestedOutput : public InferRequestedOutput {
       const size_t class_count = 0);
   /// Returns the raw InferRequestedOutput object required by triton client
   /// library.
-  nic::InferRequestedOutput* Get() const { return output_.get(); }
+  tc::InferRequestedOutput* Get() const { return output_.get(); }
   // See InferRequestedOutput::SetSharedMemory()
   Error SetSharedMemory(
       const std::string& region_name, const size_t byte_size,
@@ -243,7 +243,7 @@ class TritonInferRequestedOutput : public InferRequestedOutput {
  private:
   explicit TritonInferRequestedOutput();
 
-  std::unique_ptr<nic::InferRequestedOutput> output_;
+  std::unique_ptr<tc::InferRequestedOutput> output_;
 };
 
 //==============================================================
@@ -252,14 +252,14 @@ class TritonInferRequestedOutput : public InferRequestedOutput {
 ///
 class TritonInferResult : public InferResult {
  public:
-  explicit TritonInferResult(nic::InferResult* result);
+  explicit TritonInferResult(tc::InferResult* result);
   /// See InferResult::Id()
   Error Id(std::string* id) const override;
   /// See InferResult::RequestStatus()
   Error RequestStatus() const override;
 
  private:
-  std::unique_ptr<nic::InferResult> result_;
+  std::unique_ptr<tc::InferResult> result_;
 };
 
 }}  // namespace perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -49,7 +49,7 @@
     }                                                              \
   }
 
-namespace nic = inferenceserver::client;
+namespace nic = triton::client;
 
 namespace perfanalyzer { namespace clientbackend {
 

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -52,6 +52,7 @@
 namespace tc = triton::client;
 
 namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace tritonremote {
 
 //==============================================================================
 /// TritonClientBackend uses triton client C++ library to communicate with
@@ -262,4 +263,4 @@ class TritonInferResult : public InferResult {
   std::unique_ptr<tc::InferResult> result_;
 };
 
-}}}  // namespace triton::perfanalyzer::clientbackend
+}}}}  // namespace triton::perfanalyzer::clientbackend::tritonremote

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -51,7 +51,7 @@
 
 namespace tc = triton::client;
 
-namespace perfanalyzer { namespace clientbackend {
+namespace triton { namespace perfanalyzer { namespace clientbackend {
 
 //==============================================================================
 /// TritonClientBackend uses triton client C++ library to communicate with
@@ -262,4 +262,4 @@ class TritonInferResult : public InferResult {
   std::unique_ptr<tc::InferResult> result_;
 };
 
-}}  // namespace perfanalyzer::clientbackend
+}}}  // namespace triton::perfanalyzer::clientbackend

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -28,7 +28,7 @@
 
 #include <queue>
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 ConcurrencyManager::~ConcurrencyManager()
 {
@@ -424,4 +424,4 @@ ConcurrencyManager::Infer(
   } while (true);
 }
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -27,7 +27,7 @@
 
 #include "load_manager.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 //==============================================================================
 /// ConcurrencyManager is a helper class to send inference requests to inference
@@ -129,4 +129,4 @@ class ConcurrencyManager : public LoadManager {
   std::vector<std::shared_ptr<ThreadConfig>> threads_config_;
 };
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/custom_load_manager.cc
+++ b/src/c++/perf_analyzer/custom_load_manager.cc
@@ -26,7 +26,7 @@
 
 #include "custom_load_manager.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 cb::Error
 CustomLoadManager::Create(
@@ -115,4 +115,4 @@ CustomLoadManager::GetCustomRequestRate(double* request_rate)
   return cb::Error::Success;
 }
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -27,7 +27,7 @@
 
 #include "request_rate_manager.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 //==============================================================================
 /// CustomLoadManager is a helper class to send inference requests to
@@ -102,4 +102,4 @@ class CustomLoadManager : public RequestRateManager {
   std::vector<std::chrono::nanoseconds> custom_intervals_;
 };
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/data_loader.cc
+++ b/src/c++/perf_analyzer/data_loader.cc
@@ -30,7 +30,7 @@
 #include <rapidjson/filereadstream.h>
 #include <fstream>
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 DataLoader::DataLoader(const size_t batch_size)
     : batch_size_(batch_size), data_stream_cnt_(0)
@@ -384,4 +384,4 @@ DataLoader::ReadInputTensorData(
   return cb::Error::Success;
 }
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/data_loader.h
+++ b/src/c++/perf_analyzer/data_loader.h
@@ -29,7 +29,7 @@
 #include "model_parser.h"
 #include "perf_utils.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 class DataLoader {
  public:
@@ -137,4 +137,4 @@ class DataLoader {
   std::vector<uint8_t> input_buf_;
 };
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -32,7 +32,7 @@
 #include <queue>
 
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 namespace {
 
@@ -804,7 +804,7 @@ InferenceProfiler::SummarizeClientStat(
   summary.client_stats.delayed_request_count = delayed_request_count;
   summary.client_stats.duration_ns = duration_ns;
   float client_duration_sec =
-      (float)summary.client_stats.duration_ns / perfanalyzer::NANOS_PER_SECOND;
+      (float)summary.client_stats.duration_ns / NANOS_PER_SECOND;
   summary.client_stats.sequence_per_sec =
       valid_sequence_count / client_duration_sec;
   summary.client_stats.infer_per_sec =
@@ -940,4 +940,4 @@ InferenceProfiler::SummarizeServerStats(
   return cb::Error::Success;
 }
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -31,7 +31,7 @@
 #include "model_parser.h"
 #include "request_rate_manager.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 /// Constant parameters that determine the whether stopping criteria has met
 /// for the current phase of testing
@@ -433,4 +433,4 @@ class InferenceProfiler {
   bool include_server_stats_;
 };
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -44,7 +44,7 @@
 
 #endif  // TRITON_ENABLE_GPU
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 
 namespace {
@@ -741,4 +741,4 @@ LoadManager::StopWorkerThreads()
   }
 }
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/load_manager.h
+++ b/src/c++/perf_analyzer/load_manager.h
@@ -33,7 +33,7 @@
 #include "perf_utils.h"
 
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 class LoadManager {
  public:
@@ -260,4 +260,4 @@ class LoadManager {
   std::mutex wake_mutex_;
 };
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/main.cc
+++ b/src/c++/perf_analyzer/main.cc
@@ -34,7 +34,7 @@
 #include "perf_utils.h"
 #include "request_rate_manager.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 volatile bool early_exit = false;
 
@@ -53,7 +53,7 @@ SignalHandler(int signum)
     exit(0);
   }
 }
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer
 
 //==============================================================================
 // Perf Analyzer

--- a/src/c++/perf_analyzer/model_parser.cc
+++ b/src/c++/perf_analyzer/model_parser.cc
@@ -28,7 +28,7 @@
 
 #include "rapidjson/writer.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 namespace {
 // In the json produced by protobuf, int64 and uint64 values are
@@ -351,4 +351,4 @@ ModelParser::GetEnsembleSchedulerType(
   return cb::Error::Success;
 }
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/model_parser.h
+++ b/src/c++/perf_analyzer/model_parser.h
@@ -29,7 +29,7 @@
 #include "client_backend/client_backend.h"
 #include "perf_utils.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 struct ModelTensor {
   ModelTensor() : is_shape_tensor_(false) {}
   std::string name_;
@@ -167,4 +167,4 @@ class ModelParser {
   bool is_decoupled_;
 };
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/perf_utils.cc
+++ b/src/c++/perf_analyzer/perf_utils.cc
@@ -33,7 +33,7 @@
 #include <string>
 #include "client_backend/client_backend.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 cb::ProtocolType
 ParseProtocol(const std::string& str)
@@ -423,4 +423,4 @@ ScheduleDistribution<Distribution::CONSTANT>(const double request_rate)
   return [period](std::mt19937& /*gen*/) { return period; };
 }
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -64,8 +64,7 @@ constexpr uint64_t NANOS_PER_SECOND = 1000000000;
 constexpr uint64_t NANOS_PER_MILLIS = 1000000;
 #define TIMESPEC_TO_NANOS(TS) \
   ((TS).tv_sec * pa::NANOS_PER_SECOND + (TS).tv_nsec)
-#define TIMESPEC_TO_MILLIS(TS) \
-  (TIMESPEC_TO_NANOS(TS) / pa::NANOS_PER_MILLIS)
+#define TIMESPEC_TO_MILLIS(TS) (TIMESPEC_TO_NANOS(TS) / pa::NANOS_PER_MILLIS)
 
 //==============================================================================
 using TimestampVector =

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -55,17 +55,17 @@
     }                                                              \
   }
 
-namespace pa = perfanalyzer;
-namespace cb = perfanalyzer::clientbackend;
+namespace pa = triton::perfanalyzer;
+namespace cb = triton::perfanalyzer::clientbackend;
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 constexpr uint64_t NANOS_PER_SECOND = 1000000000;
 constexpr uint64_t NANOS_PER_MILLIS = 1000000;
 #define TIMESPEC_TO_NANOS(TS) \
-  ((TS).tv_sec * perfanalyzer::NANOS_PER_SECOND + (TS).tv_nsec)
+  ((TS).tv_sec * pa::NANOS_PER_SECOND + (TS).tv_nsec)
 #define TIMESPEC_TO_MILLIS(TS) \
-  (TIMESPEC_TO_NANOS(TS) / perfanalyzer::NANOS_PER_MILLIS)
+  (TIMESPEC_TO_NANOS(TS) / pa::NANOS_PER_MILLIS)
 
 //==============================================================================
 using TimestampVector =
@@ -163,4 +163,4 @@ template <Distribution distribution>
 std::function<std::chrono::nanoseconds(std::mt19937&)> ScheduleDistribution(
     const double request_rate);
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/c++/perf_analyzer/request_rate_manager.cc
@@ -26,7 +26,7 @@
 
 #include "request_rate_manager.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 RequestRateManager::~RequestRateManager()
 {
@@ -416,4 +416,4 @@ RequestRateManager::Request(
   }
 }
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/request_rate_manager.h
+++ b/src/c++/perf_analyzer/request_rate_manager.h
@@ -29,7 +29,7 @@
 #include <thread>
 #include "load_manager.h"
 
-namespace perfanalyzer {
+namespace triton { namespace perfanalyzer {
 
 //==============================================================================
 /// RequestRateManager is a helper class to send inference requests to
@@ -167,4 +167,4 @@ class RequestRateManager : public LoadManager {
   bool execute_;
 };
 
-}  // namespace perfanalyzer
+}}  // namespace triton::perfanalyzer

--- a/src/c++/tests/client_timeout_test.cc
+++ b/src/c++/tests/client_timeout_test.cc
@@ -32,8 +32,8 @@
 #include "grpc_client.h"
 #include "http_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/tests/client_timeout_test.cc
+++ b/src/c++/tests/client_timeout_test.cc
@@ -32,8 +32,8 @@
 #include "grpc_client.h"
 #include "http_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/tests/client_timeout_test.cc
+++ b/src/c++/tests/client_timeout_test.cc
@@ -32,12 +32,11 @@
 #include "grpc_client.h"
 #include "http_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -48,7 +47,7 @@ namespace {
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 {
   std::vector<int64_t> shape;
   FAIL_IF_ERR(
@@ -73,7 +72,7 @@ ValidateShapeAndDatatype(
 
 void
 ValidateResult(
-    const std::shared_ptr<nic::InferResult> result,
+    const std::shared_ptr<tc::InferResult> result,
     std::vector<int32_t>& input0_data)
 {
   // Validate the results...
@@ -106,14 +105,14 @@ ValidateResult(
 
 void
 RunSynchronousInference(
-    std::unique_ptr<nic::InferenceServerGrpcClient>& grpc_client,
-    std::unique_ptr<nic::InferenceServerHttpClient>& http_client,
-    uint32_t client_timeout, std::vector<nic::InferInput*>& inputs,
-    std::vector<const nic::InferRequestedOutput*>& outputs,
-    nic::InferOptions& options, std::vector<int32_t>& input0_data)
+    std::unique_ptr<tc::InferenceServerGrpcClient>& grpc_client,
+    std::unique_ptr<tc::InferenceServerHttpClient>& http_client,
+    uint32_t client_timeout, std::vector<tc::InferInput*>& inputs,
+    std::vector<const tc::InferRequestedOutput*>& outputs,
+    tc::InferOptions& options, std::vector<int32_t>& input0_data)
 {
   options.client_timeout_ = client_timeout;
-  nic::InferResult* results;
+  tc::InferResult* results;
   if (grpc_client.get() != nullptr) {
     FAIL_IF_ERR(
         grpc_client->Infer(&results, options, inputs, outputs),
@@ -123,7 +122,7 @@ RunSynchronousInference(
         http_client->Infer(&results, options, inputs, outputs),
         "unable to run model");
   }
-  std::shared_ptr<nic::InferResult> results_ptr;
+  std::shared_ptr<tc::InferResult> results_ptr;
   results_ptr.reset(results);
 
   // Validate results
@@ -138,19 +137,19 @@ RunSynchronousInference(
 
 void
 RunAsynchronousInference(
-    std::unique_ptr<nic::InferenceServerGrpcClient>& grpc_client,
-    std::unique_ptr<nic::InferenceServerHttpClient>& http_client,
-    uint32_t client_timeout, std::vector<nic::InferInput*>& inputs,
-    std::vector<const nic::InferRequestedOutput*>& outputs,
-    nic::InferOptions& options, std::vector<int32_t>& input0_data)
+    std::unique_ptr<tc::InferenceServerGrpcClient>& grpc_client,
+    std::unique_ptr<tc::InferenceServerHttpClient>& http_client,
+    uint32_t client_timeout, std::vector<tc::InferInput*>& inputs,
+    std::vector<const tc::InferRequestedOutput*>& outputs,
+    tc::InferOptions& options, std::vector<int32_t>& input0_data)
 {
   std::mutex mtx;
   std::condition_variable cv;
   bool done = false;
 
-  auto callback = [&](nic::InferResult* result) {
+  auto callback = [&](tc::InferResult* result) {
     {
-      std::shared_ptr<nic::InferResult> result_ptr;
+      std::shared_ptr<tc::InferResult> result_ptr;
       result_ptr.reset(result);
       std::lock_guard<std::mutex> lk(mtx);
       std::cout << "Callback called" << std::endl;
@@ -186,20 +185,20 @@ RunAsynchronousInference(
 
 void
 RunStreamingInference(
-    std::unique_ptr<nic::InferenceServerGrpcClient>& grpc_client,
-    uint32_t client_timeout, std::vector<nic::InferInput*>& inputs,
-    std::vector<const nic::InferRequestedOutput*>& outputs,
-    nic::InferOptions& options, std::vector<int32_t>& input0_data)
+    std::unique_ptr<tc::InferenceServerGrpcClient>& grpc_client,
+    uint32_t client_timeout, std::vector<tc::InferInput*>& inputs,
+    std::vector<const tc::InferRequestedOutput*>& outputs,
+    tc::InferOptions& options, std::vector<int32_t>& input0_data)
 {
   std::mutex mtx;
   std::condition_variable cv;
-  std::vector<std::shared_ptr<nic::InferResult>> result_list;
+  std::vector<std::shared_ptr<tc::InferResult>> result_list;
 
   FAIL_IF_ERR(
       grpc_client->StartStream(
-          [&](nic::InferResult* result) {
+          [&](tc::InferResult* result) {
             {
-              std::shared_ptr<nic::InferResult> result_ptr(result);
+              std::shared_ptr<tc::InferResult> result_ptr(result);
               std::lock_guard<std::mutex> lk(mtx);
               result_list.push_back(result_ptr);
             }
@@ -315,22 +314,22 @@ main(int argc, char** argv)
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
-  std::unique_ptr<nic::InferenceServerGrpcClient> grpc_client;
-  std::unique_ptr<nic::InferenceServerHttpClient> http_client;
+  std::unique_ptr<tc::InferenceServerGrpcClient> grpc_client;
+  std::unique_ptr<tc::InferenceServerHttpClient> http_client;
 
   if (protocol == "grpc") {
     if (url.empty()) {
       url = "localhost:8001";
     }
     FAIL_IF_ERR(
-        nic::InferenceServerGrpcClient::Create(&grpc_client, url, verbose),
+        tc::InferenceServerGrpcClient::Create(&grpc_client, url, verbose),
         "unable to create grpc client");
   } else {
     if (url.empty()) {
       url = "localhost:8000";
     }
     FAIL_IF_ERR(
-        nic::InferenceServerHttpClient::Create(&http_client, url, verbose),
+        tc::InferenceServerHttpClient::Create(&http_client, url, verbose),
         "unable to create grpc client");
   }
 
@@ -343,12 +342,12 @@ main(int argc, char** argv)
   std::vector<int64_t> shape{1, 16};
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
+  tc::InferInput* input0;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
 
   FAIL_IF_ERR(
@@ -358,21 +357,21 @@ main(int argc, char** argv)
       "unable to set data for INPUT0");
 
   // Generate the outputs to be requested.
-  nic::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output0;
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
       "unable to get 'OUTPUT0'");
-  std::shared_ptr<nic::InferRequestedOutput> output0_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
 
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
   options.client_timeout_ = client_timeout;
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get()};
-  std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get()};
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get()};
 
   // Send inference request to the inference server.
   if (streaming) {

--- a/src/c++/tests/memory_leak_test.cc
+++ b/src/c++/tests/memory_leak_test.cc
@@ -32,8 +32,8 @@
 #include "grpc_client.h"
 #include "http_client.h"
 
-namespace ni = inferenceserver;
-namespace nic = inferenceserver::client;
+ 
+namespace nic = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/tests/memory_leak_test.cc
+++ b/src/c++/tests/memory_leak_test.cc
@@ -32,8 +32,8 @@
 #include "grpc_client.h"
 #include "http_client.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = nvidia::inferenceserver::client;
+namespace ni = inferenceserver;
+namespace nic = inferenceserver::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \

--- a/src/c++/tests/memory_leak_test.cc
+++ b/src/c++/tests/memory_leak_test.cc
@@ -32,12 +32,11 @@
 #include "grpc_client.h"
 #include "http_client.h"
 
- 
-namespace nic = triton::client;
+namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    nic::Error err = (X);                                          \
+    tc::Error err = (X);                                          \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -51,7 +50,7 @@ namespace {
 
 void
 ValidateShapeAndDatatype(
-    const std::string& name, std::shared_ptr<nic::InferResult> result)
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
 {
   std::vector<int64_t> shape;
   FAIL_IF_ERR(
@@ -76,7 +75,7 @@ ValidateShapeAndDatatype(
 
 void
 ValidateResult(
-    const std::shared_ptr<nic::InferResult> result,
+    const std::shared_ptr<tc::InferResult> result,
     std::vector<int32_t>& input0_data)
 {
   // Validate the results...
@@ -109,31 +108,31 @@ ValidateResult(
 
 void
 RunSynchronousInference(
-    std::vector<nic::InferInput*>& inputs,
-    std::vector<const nic::InferRequestedOutput*>& outputs,
-    nic::InferOptions& options, std::vector<int32_t>& input0_data, bool reuse,
+    std::vector<tc::InferInput*>& inputs,
+    std::vector<const tc::InferRequestedOutput*>& outputs,
+    tc::InferOptions& options, std::vector<int32_t>& input0_data, bool reuse,
     std::string url, bool verbose, std::string protocol, uint32_t repetitions)
 {
   // If re-use is enabled then use these client objects else use new objects for
   // each inference request.
-  std::unique_ptr<nic::InferenceServerGrpcClient> grpc_client_reuse;
-  std::unique_ptr<nic::InferenceServerHttpClient> http_client_reuse;
+  std::unique_ptr<tc::InferenceServerGrpcClient> grpc_client_reuse;
+  std::unique_ptr<tc::InferenceServerHttpClient> http_client_reuse;
 
   for (size_t i = 0; i < repetitions; ++i) {
-    nic::InferResult* results;
+    tc::InferResult* results;
     if (!reuse) {
       if (protocol == "grpc") {
-        std::unique_ptr<nic::InferenceServerGrpcClient> grpc_client;
+        std::unique_ptr<tc::InferenceServerGrpcClient> grpc_client;
         FAIL_IF_ERR(
-            nic::InferenceServerGrpcClient::Create(&grpc_client, url, verbose),
+            tc::InferenceServerGrpcClient::Create(&grpc_client, url, verbose),
             "unable to create grpc client");
         FAIL_IF_ERR(
             grpc_client->Infer(&results, options, inputs, outputs),
             "unable to run model");
       } else {
-        std::unique_ptr<nic::InferenceServerHttpClient> http_client;
+        std::unique_ptr<tc::InferenceServerHttpClient> http_client;
         FAIL_IF_ERR(
-            nic::InferenceServerHttpClient::Create(&http_client, url, verbose),
+            tc::InferenceServerHttpClient::Create(&http_client, url, verbose),
             "unable to create http client");
         FAIL_IF_ERR(
             http_client->Infer(&results, options, inputs, outputs),
@@ -142,7 +141,7 @@ RunSynchronousInference(
     } else {
       if (protocol == "grpc") {
         FAIL_IF_ERR(
-            nic::InferenceServerGrpcClient::Create(
+            tc::InferenceServerGrpcClient::Create(
                 &grpc_client_reuse, url, verbose),
             "unable to create grpc client");
         FAIL_IF_ERR(
@@ -150,7 +149,7 @@ RunSynchronousInference(
             "unable to run model");
       } else {
         FAIL_IF_ERR(
-            nic::InferenceServerHttpClient::Create(
+            tc::InferenceServerHttpClient::Create(
                 &http_client_reuse, url, verbose),
             "unable to create http client");
         FAIL_IF_ERR(
@@ -159,7 +158,7 @@ RunSynchronousInference(
       }
     }
 
-    std::shared_ptr<nic::InferResult> results_ptr;
+    std::shared_ptr<tc::InferResult> results_ptr;
     results_ptr.reset(results);
 
     // Validate results
@@ -264,12 +263,12 @@ main(int argc, char** argv)
   std::vector<int64_t> shape{1, INPUT_DIM};
 
   // Initialize the inputs with the data.
-  nic::InferInput* input0;
+  tc::InferInput* input0;
 
   FAIL_IF_ERR(
-      nic::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
+      tc::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
       "unable to get INPUT0");
-  std::shared_ptr<nic::InferInput> input0_ptr;
+  std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
 
   FAIL_IF_ERR(
@@ -279,19 +278,19 @@ main(int argc, char** argv)
       "unable to set data for INPUT0");
 
   // Generate the outputs to be requested.
-  nic::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output0;
   FAIL_IF_ERR(
-      nic::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
       "unable to get 'OUTPUT0'");
-  std::shared_ptr<nic::InferRequestedOutput> output0_ptr;
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
 
   // The inference settings. Will be using default for now.
-  nic::InferOptions options(model_name);
+  tc::InferOptions options(model_name);
   options.model_version_ = model_version;
 
-  std::vector<nic::InferInput*> inputs = {input0_ptr.get()};
-  std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get()};
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get()};
 
   // Send 'repetitions' number of inference requests to the inference server.
   RunSynchronousInference(


### PR DESCRIPTION
Remove instances that use the `nvidia` namespace to use `triton` instead.
nvidia::inferenceserver::client -> triton::client
perfanalyzer -> triton::perfanalyzer