### PR TITLE
Updates documentation for tritonclient wheels to be published on pyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ It is also possible to build build the client libraries with
 ### Download Using Python Package Installer (pip)
 
 The GRPC and HTTP client libraries are available as a Python package
-that can be installed using a recent version of pip. **Currently pip
-install is only available on Linux**.
+that can be installed using a recent version of pip.
 
 ```
 $ pip install tritonclient[all]
@@ -144,6 +143,9 @@ following dependency must be installed:
 sudo apt update
 sudo apt install libb64-dev
 ```
+
+To reiterate, the installation on windows will not include perf_analyzer
+nor shared_memory/cuda_shared_memory components.
 
 ### Download From GitHub
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ that can be installed using a recent version of pip. **Currently pip
 install is only available on Linux**.
 
 ```
-$ pip install nvidia-pyindex
 $ pip install tritonclient[all]
 ```
 
@@ -126,7 +125,6 @@ protocol. For example, to install only the HTTP/REST client library
 use,
 
 ```
-$ pip install nvidia-pyindex
 $ pip install tritonclient[http]
 ```
 

--- a/src/python/library/setup.py
+++ b/src/python/library/setup.py
@@ -92,6 +92,11 @@ setup(
     author_email='sw-dl-triton@nvidia.com',
     description=
     "Python client library and utilities for communicating with Triton Inference Server",
+    long_description=
+    """See [download-using-python-package-installer-pip](https://github.com/triton-inference-server/client/tree/main#download-using-python-package-installer-pip) """
+    """for package details.\n\nThe [client examples](https://github.com/triton-inference-server/client/tree/main/src/python/examples) demonstrate how to use the """
+    """package to issue request to [triton inference server](https://github.com/triton-inference-server/server).""",
+    long_description_content_type='text/markdown',
     license='BSD',
     url='https://developer.nvidia.com/nvidia-triton-inference-server',
     keywords=[


### PR DESCRIPTION
The project page will look like:
https://test.pypi.org/project/tritonclient/

I have already uploaded the earlier wheels on the pyPI but currently it lacks the project description,
https://pypi.org/project/tritonclient/

@aramesh7 Similar changes will be needed for the triton-model-analyzer wheels as well..
