### PR TITLE
Update the jetson wheel platform name for pyPI support

### DIFF
--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
     print("=== Building wheel")
     if FLAGS.linux:
         if os.uname().machine == "aarch64":
-            platform_name = "linux_aarch64"
+            platform_name = "manylinux2014_aarch64"
         else:
             platform_name = "manylinux1_x86_64"
         args = ['python3', 'setup.py', 'bdist_wheel', '--plat-name', platform_name]


### PR DESCRIPTION
The `manylinux2014` policy which supports aarch64 is defined here: https://www.python.org/dev/peps/pep-0599/#id20


## Before:
### Uploading to PyPI:

```
Uploading tritonclient-2.14.0-py3-none-linux_aarch64.whl
100%|███████████████████████████████████████████████████████████| 7.18M/7.18M [00:01<00:00, 4.21MB/s]
NOTE: Try --verbose to see response content.
HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
Binary wheel 'tritonclient-2.14.0-py3-none-linux_aarch64.whl' has an unsupported platform tag 'linux_aarch64'.
```

## After:
### Uploading to PyPI:

```
Uploading tritonclient-2.5.0-py3-none-manylinux2014_aarch64.whl
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5.65M/5.65M [00:02<00:00, 2.32MB/s]

View at:
https://test.pypi.org/project/tritonclient/2.5.0/
```

### Installing from PyPI:

```
nvidia@dl-jetson-xavier-t002:~$ pip install  -i https://test.pypi.org/simple/  tritonclient[all]==2.5.0
Defaulting to user installation because normal site-packages is not writeable
Looking in indexes: https://test.pypi.org/simple/
Collecting tritonclient[all]==2.5.0
  Downloading https://test-files.pythonhosted.org/packages/d9/83/afe1310e83e55a1adfd955e555aa6d1ced24080bbc160c1f843dc4068256/tritonclient-2.5.0-py3-none-manylinux2014_aarch64.whl (5.9 MB)
     |████████████████████████████████| 5.9 MB 9.8 MB/s 
Requirement already satisfied: python-rapidjson>=0.9.1 in ./.local/lib/python3.6/site-packages (from tritonclient[all]==2.5.0) (0.9.3)
Requirement already satisfied: numpy>=1.19.1 in ./.local/lib/python3.6/site-packages (from tritonclient[all]==2.5.0) (1.19.4)
Requirement already satisfied: protobuf>=3.5.0 in ./.local/lib/python3.6/site-packages (from tritonclient[all]==2.5.0) (3.11.3)
Requirement already satisfied: geventhttpclient>=1.4.4 in ./.local/lib/python3.6/site-packages (from tritonclient[all]==2.5.0) (1.4.4)
Requirement already satisfied: grpcio>=1.31.0 in /usr/local/lib/python3.6/dist-packages (from tritonclient[all]==2.5.0) (1.35.0)
Requirement already satisfied: certifi in /usr/lib/python3/dist-packages (from geventhttpclient>=1.4.4->tritonclient[all]==2.5.0) (2018.1.18)
Requirement already satisfied: six in ./.local/lib/python3.6/site-packages (from geventhttpclient>=1.4.4->tritonclient[all]==2.5.0) (1.14.0)
Requirement already satisfied: gevent>=0.13 in ./.local/lib/python3.6/site-packages (from geventhttpclient>=1.4.4->tritonclient[all]==2.5.0) (20.9.0)
Requirement already satisfied: zope.event in ./.local/lib/python3.6/site-packages (from gevent>=0.13->geventhttpclient>=1.4.4->tritonclient[all]==2.5.0) (4.5.0)
Requirement already satisfied: zope.interface in /usr/lib/python3/dist-packages (from gevent>=0.13->geventhttpclient>=1.4.4->tritonclient[all]==2.5.0) (4.3.2)
Requirement already satisfied: greenlet>=0.4.17 in ./.local/lib/python3.6/site-packages (from gevent>=0.13->geventhttpclient>=1.4.4->tritonclient[all]==2.5.0) (0.4.17)
Requirement already satisfied: setuptools in ./.local/lib/python3.6/site-packages (from gevent>=0.13->geventhttpclient>=1.4.4->tritonclient[all]==2.5.0) (57.4.0)
Installing collected packages: tritonclient
Successfully installed tritonclient-2.5.0
```
