### PR TITLE
 Updated c++/python clients and examples to use string sequence IDs 

### DIFF
--- a/src/c++/examples/simple_grpc_model_control.cc
+++ b/src/c++/examples/simple_grpc_model_control.cc
@@ -33,7 +33,7 @@ namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    tc::Error err = (X);                                          \
+    tc::Error err = (X);                                           \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -105,8 +105,8 @@ main(int argc, char** argv)
   FAIL_IF_ERR(
       client->ModelRepositoryIndex(&repository_index, http_headers),
       "Failed to get repository index");
-  if (repository_index.models().size() != 7) {
-    std::cerr << "expected number of models 7, got "
+  if (repository_index.models().size() != 8) {
+    std::cerr << "expected number of models 8, got "
               << repository_index.models().size() << std::endl;
     exit(1);
   }

--- a/src/c++/examples/simple_grpc_sequence_stream_infer_client.cc
+++ b/src/c++/examples/simple_grpc_sequence_stream_infer_client.cc
@@ -41,7 +41,7 @@ std::condition_variable cv_;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    tc::Error err = (X);                                          \
+    tc::Error err = (X);                                           \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -76,16 +76,8 @@ Usage(char** argv, const std::string& msg = std::string())
 void
 StreamSend(
     const std::unique_ptr<tc::InferenceServerGrpcClient>& client,
-    const std::string& model_name, int32_t value, const uint64_t sequence_id,
-    bool start_of_sequence, bool end_of_sequence, const int32_t index)
+    tc::InferOptions& options, int32_t value, const int32_t index)
 {
-  tc::InferOptions options(model_name);
-  options.sequence_id_ = sequence_id;
-  options.sequence_start_ = start_of_sequence;
-  options.sequence_end_ = end_of_sequence;
-  options.request_id_ =
-      std::to_string(sequence_id) + "_" + std::to_string(index);
-
   // Initialize the inputs with the data.
   tc::InferInput* input;
   std::vector<int64_t> shape{1, 1};
@@ -102,6 +94,40 @@ StreamSend(
 
   // Send inference request to the inference server.
   FAIL_IF_ERR(client->AsyncStreamInfer(options, inputs), "unable to run model");
+}
+
+void
+StreamSend(
+    const std::unique_ptr<tc::InferenceServerGrpcClient>& client,
+    const std::string& model_name, int32_t value, const uint64_t sequence_id,
+    bool start_of_sequence, bool end_of_sequence, const int32_t index)
+{
+  // Stream send for unsigned int sequence IDs
+  tc::InferOptions options(model_name);
+  options.sequence_id_ = sequence_id;
+  options.sequence_start_ = start_of_sequence;
+  options.sequence_end_ = end_of_sequence;
+  options.request_id_ =
+      std::to_string(sequence_id) + "_" + std::to_string(index);
+
+  StreamSend(client, options, value, index);
+}
+
+void
+StreamSend(
+    const std::unique_ptr<tc::InferenceServerGrpcClient>& client,
+    const std::string& model_name, int32_t value,
+    const std::string& sequence_id, bool start_of_sequence,
+    bool end_of_sequence, const int32_t index)
+{
+  // Stream send for string sequence IDs
+  tc::InferOptions options(model_name);
+  options.sequence_id_str_ = sequence_id;
+  options.sequence_start_ = start_of_sequence;
+  options.sequence_end_ = end_of_sequence;
+  options.request_id_ = sequence_id + "_" + std::to_string(index);
+
+  StreamSend(client, options, value, index);
 }
 
 }  // namespace
@@ -152,14 +178,24 @@ main(int argc, char** argv)
   // We use the custom "sequence" model which takes 1 input value. The
   // output is the accumulated value of the inputs. See
   // src/custom/sequence.
-  std::string model_name =
+  std::string int_model_name =
       dyna_sequence ? "simple_dyna_sequence" : "simple_sequence";
+  std::string string_model_name =
+      dyna_sequence ? "simple_string_dyna_sequence" : "simple_sequence";
 
+  const uint64_t int_sequence_id0 = 1 + sequence_id_offset * 2;
+  const uint64_t int_sequence_id1 = 2 + sequence_id_offset * 2;
 
-  const uint64_t sequence_id0 = 1 + sequence_id_offset * 2;
-  const uint64_t sequence_id1 = 2 + sequence_id_offset * 2;
-  std::cout << "sequence ID " << sequence_id0 << " : "
-            << "sequence ID " << sequence_id1 << std::endl;
+  // For string sequence IDs, the dyna backend requires that the
+  // sequence id be decodable into an integer, otherwise we'll use
+  // a test string sequence id and a model that doesn't require corrid
+  // control.
+  const std::string string_sequence_id0 =
+      dyna_sequence ? std::to_string(3 + sequence_id_offset * 2) : "SEQ-3";
+
+  std::cout << "sequence ID " << int_sequence_id0 << " : "
+            << "sequence ID " << int_sequence_id1 << " : "
+            << "sequence ID " << string_sequence_id0 << std::endl;
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
@@ -189,20 +225,26 @@ main(int argc, char** argv)
   // Send requests, first reset accumulator for the sequence.
   int32_t index = 0;
   StreamSend(
-      client, model_name, 0, sequence_id0, true /* start-of-sequence */,
+      client, int_model_name, 0, int_sequence_id0, true /* start-of-sequence */,
       false /* end-of-sequence */, index++);
   StreamSend(
-      client, model_name, 100, sequence_id1, true /* start-of-sequence */,
-      false /* end-of-sequence */, index++);
+      client, int_model_name, 100, int_sequence_id1,
+      true /* start-of-sequence */, false /* end-of-sequence */, index++);
+  StreamSend(
+      client, string_model_name, 20, string_sequence_id0,
+      true /* start-of-sequence */, false /* end-of-sequence */, index++);
 
   // Now send a sequence of values...
   for (int32_t v : values) {
     StreamSend(
-        client, model_name, v, sequence_id0, false /* start-of-sequence */,
-        (v == 1) /* end-of-sequence */, index++);
+        client, int_model_name, v, int_sequence_id0,
+        false /* start-of-sequence */, (v == 1) /* end-of-sequence */, index++);
     StreamSend(
-        client, model_name, -v, sequence_id1, false /* start-of-sequence */,
-        (v == 1) /* end-of-sequence */, index++);
+        client, int_model_name, -v, int_sequence_id1,
+        false /* start-of-sequence */, (v == 1) /* end-of-sequence */, index++);
+    StreamSend(
+        client, string_model_name, -v, string_sequence_id0,
+        false /* start-of-sequence */, (v == 1) /* end-of-sequence */, index++);
   }
 
   if (stream_timeout == 0) {
@@ -210,7 +252,7 @@ main(int argc, char** argv)
     {
       std::unique_lock<std::mutex> lk(mutex_);
       cv_.wait(lk, [&]() {
-        if (result_list.size() > (2 * values.size() + 1)) {
+        if (result_list.size() > (3 * values.size() + 2)) {
           return true;
         } else {
           return false;
@@ -223,7 +265,7 @@ main(int argc, char** argv)
     {
       std::unique_lock<std::mutex> lk(mutex_);
       if (!cv_.wait_for(lk, timeout, [&]() {
-            return (result_list.size() > (2 * values.size() + 1));
+            return (result_list.size() > (3 * values.size() + 2));
           })) {
         std::cerr << "Stream has been closed" << std::endl;
         exit(1);
@@ -232,8 +274,9 @@ main(int argc, char** argv)
   }
 
   // Extract data from the result
-  std::vector<int32_t> result0_data;
-  std::vector<int32_t> result1_data;
+  std::vector<int32_t> int_result0_data;
+  std::vector<int32_t> int_result1_data;
+  std::vector<int32_t> string_result0_data;
   for (const auto& this_result : result_list) {
     auto err = this_result->RequestStatus();
     if (!err.IsOk()) {
@@ -256,36 +299,61 @@ main(int argc, char** argv)
     std::string request_id;
     FAIL_IF_ERR(
         this_result->Id(&request_id), "unable to get request id for response");
-    uint64_t this_sequence_id =
-        std::stoi(std::string(request_id, 0, request_id.find("_")));
-    if (this_sequence_id == sequence_id0) {
-      result0_data.push_back(*output_data);
-    } else if (this_sequence_id == sequence_id1) {
-      result1_data.push_back(*output_data);
-    } else {
-      std::cerr << "error: received incorrect sequence id in response: "
-                << this_sequence_id << std::endl;
-      exit(1);
+    try {
+      std::string this_sequence_id =
+          std::string(request_id, 0, request_id.find("_"));
+
+      if (std::stoi(this_sequence_id) == int_sequence_id0) {
+        int_result0_data.push_back(*output_data);
+      } else if (std::stoi(this_sequence_id) == int_sequence_id1) {
+        int_result1_data.push_back(*output_data);
+      } else if (this_sequence_id == string_sequence_id0) {
+        string_result0_data.push_back(*output_data);
+      } else {
+        std::cerr << "error: received incorrect sequence id in response: "
+                  << this_sequence_id << std::endl;
+        exit(1);
+      }
+    }
+    catch (std::invalid_argument& e) {
+      // stoi will throw this when called with the test sequence SEQ3
+      string_result0_data.push_back(*output_data);
     }
   }
 
+  for (size_t i = 0; i < int_result0_data.size(); i++) {
+    int32_t int_seq0_expected = (i == 0) ? 1 : values[i - 1];
+    int32_t int_seq1_expected = (i == 0) ? 101 : values[i - 1] * -1;
+    int32_t string_seq0_expected;
 
-  for (size_t i = 0; i < result0_data.size(); i++) {
-    int32_t seq0_expected = (i == 0) ? 1 : values[i - 1];
-    int32_t seq1_expected = (i == 0) ? 101 : values[i - 1] * -1;
+    // For string sequence ID case we are testing two different backends
+    if ((i == 0) && dyna_sequence) {
+      string_seq0_expected = 20;
+    } else if ((i == 0) && !dyna_sequence) {
+      string_seq0_expected = 21;
+    } else if ((i != 0) && dyna_sequence) {
+      string_seq0_expected = values[i - 1] * -1 + string_result0_data[i - 1];
+    } else {
+      string_seq0_expected = values[i - 1] * -1;
+    }
+
     // The dyna_sequence custom backend adds the sequence ID to
     // the last request in a sequence.
     if (dyna_sequence && (i != 0) && (values[i - 1] == 1)) {
-      seq0_expected += sequence_id0;
-      seq1_expected += sequence_id1;
+      int_seq0_expected += int_sequence_id0;
+      int_seq1_expected += int_sequence_id1;
+      string_seq0_expected += std::stoi(string_sequence_id0);
     }
 
-    std::cout << "[" << i << "] " << result0_data[i] << " : " << result1_data[i]
+    std::cout << "[" << i << "] " << int_result0_data[i] << " : "
+              << int_result1_data[i] << " : " << string_result0_data[i]
               << std::endl;
 
-    if ((seq0_expected != result0_data[i]) ||
-        (seq1_expected != result1_data[i])) {
-      std::cout << "[ expected ] " << seq0_expected << " : " << seq1_expected
+    if ((int_seq0_expected != int_result0_data[i]) ||
+        (int_seq1_expected != int_result1_data[i]) ||
+        (string_seq0_expected != string_result0_data[i])) {
+      std::cout << "[ expected ] " << int_seq0_expected << " : "
+                << int_seq1_expected << " : " << string_seq0_expected
                 << std::endl;
       return 1;
     }

--- a/src/c++/examples/simple_grpc_sequence_sync_infer_client.cc
+++ b/src/c++/examples/simple_grpc_sequence_sync_infer_client.cc
@@ -41,7 +41,7 @@ std::condition_variable cv_;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    tc::Error err = (X);                                          \
+    tc::Error err = (X);                                           \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -75,15 +75,9 @@ Usage(char** argv, const std::string& msg = std::string())
 void
 SyncSend(
     const std::unique_ptr<tc::InferenceServerGrpcClient>& client,
-    const std::string& model_name, int32_t value, const uint64_t sequence_id,
-    bool start_of_sequence, bool end_of_sequence,
-    std::vector<int32_t>& result_data, tc::Headers& http_headers)
+    tc::InferOptions& options, int32_t value, std::vector<int32_t>& result_data,
+    tc::Headers& http_headers)
 {
-  tc::InferOptions options(model_name);
-  options.sequence_id_ = sequence_id;
-  options.sequence_start_ = start_of_sequence;
-  options.sequence_end_ = end_of_sequence;
-
   // Initialize the inputs with the data.
   tc::InferInput* input;
   std::vector<int64_t> shape{1, 1};
@@ -130,6 +124,37 @@ SyncSend(
   result_data.push_back(*output_data);
 }
 
+void
+SyncSend(
+    const std::unique_ptr<tc::InferenceServerGrpcClient>& client,
+    const std::string& model_name, int32_t value, const uint64_t sequence_id,
+    bool start_of_sequence, bool end_of_sequence,
+    std::vector<int32_t>& result_data, tc::Headers& http_headers)
+{
+  tc::InferOptions options(model_name);
+  options.sequence_id_ = sequence_id;
+  options.sequence_start_ = start_of_sequence;
+  options.sequence_end_ = end_of_sequence;
+
+  SyncSend(client, options, value, result_data, http_headers);
+}
+
+void
+SyncSend(
+    const std::unique_ptr<tc::InferenceServerGrpcClient>& client,
+    const std::string& model_name, int32_t value,
+    const std::string& sequence_id, bool start_of_sequence,
+    bool end_of_sequence, std::vector<int32_t>& result_data,
+    tc::Headers& http_headers)
+{
+  tc::InferOptions options(model_name);
+  options.sequence_id_str_ = sequence_id;
+  options.sequence_start_ = start_of_sequence;
+  options.sequence_end_ = end_of_sequence;
+
+  SyncSend(client, options, value, result_data, http_headers);
+}
+
 }  // namespace
 
 int
@@ -174,14 +199,24 @@ main(int argc, char** argv)
   // We use the custom "sequence" model which takes 1 input value. The
   // output is the accumulated value of the inputs. See
   // src/custom/sequence.
-  std::string model_name =
+  std::string int_model_name =
       dyna_sequence ? "simple_dyna_sequence" : "simple_sequence";
+  std::string string_model_name =
+      dyna_sequence ? "simple_string_dyna_sequence" : "simple_sequence";
 
+  const uint64_t int_sequence_id0 = 1 + sequence_id_offset * 2;
+  const uint64_t int_sequence_id1 = 2 + sequence_id_offset * 2;
 
-  const uint64_t sequence_id0 = 1 + sequence_id_offset * 2;
-  const uint64_t sequence_id1 = 2 + sequence_id_offset * 2;
-  std::cout << "sequence ID " << sequence_id0 << " : "
-            << "sequence ID " << sequence_id1 << std::endl;
+  // For string sequence IDs, the dyna backend requires that the
+  // sequence id be decodable into an integer, otherwise we'll use
+  // a test string sequence id and a model that doesn't require corrid
+  // control.
+  const std::string string_sequence_id0 =
+      dyna_sequence ? std::to_string(3 + sequence_id_offset * 2) : "SEQ-3";
+
+  std::cout << "sequence ID " << int_sequence_id0 << " : "
+            << "sequence ID " << int_sequence_id1 << " : "
+            << "sequence ID " << string_sequence_id0 << std::endl;
 
   // Create a InferenceServerGrpcClient instance to communicate with the
   // server using gRPC protocol.
@@ -193,43 +228,72 @@ main(int argc, char** argv)
   // Now send the inference sequences..
   //
   std::vector<int32_t> values{11, 7, 5, 3, 2, 0, 1};
-  std::vector<int32_t> result0_data;
-  std::vector<int32_t> result1_data;
+  std::vector<int32_t> int_result0_data;
+  std::vector<int32_t> int_result1_data;
+  std::vector<int32_t> string_result0_data;
 
   // Send requests, first reset accumulator for the sequence.
   SyncSend(
-      client, model_name, 0, sequence_id0, true /* start-of-sequence */,
-      false /* end-of-sequence */, result0_data, http_headers);
+      client, int_model_name, 0, int_sequence_id0, true /* start-of-sequence */,
+      false /* end-of-sequence */, int_result0_data, http_headers);
   SyncSend(
-      client, model_name, 100, sequence_id1, true /* start-of-sequence */,
-      false /* end-of-sequence */, result1_data, http_headers);
+      client, int_model_name, 100, int_sequence_id1,
+      true /* start-of-sequence */, false /* end-of-sequence */,
+      int_result1_data, http_headers);
+  SyncSend(
+      client, string_model_name, 20, string_sequence_id0,
+      true /* start-of-sequence */, false /* end-of-sequence */,
+      string_result0_data, http_headers);
 
   // Now send a sequence of values...
   for (int32_t v : values) {
     SyncSend(
-        client, model_name, v, sequence_id0, false /* start-of-sequence */,
-        (v == 1) /* end-of-sequence */, result0_data, http_headers);
+        client, int_model_name, v, int_sequence_id0,
+        false /* start-of-sequence */, (v == 1) /* end-of-sequence */,
+        int_result0_data, http_headers);
     SyncSend(
-        client, model_name, -v, sequence_id1, false /* start-of-sequence */,
-        (v == 1) /* end-of-sequence */, result1_data, http_headers);
+        client, int_model_name, -v, int_sequence_id1,
+        false /* start-of-sequence */, (v == 1) /* end-of-sequence */,
+        int_result1_data, http_headers);
+    SyncSend(
+        client, string_model_name, -v, string_sequence_id0,
+        false /* start-of-sequence */, (v == 1) /* end-of-sequence */,
+        string_result0_data, http_headers);
   }
 
-  for (size_t i = 0; i < result0_data.size(); i++) {
-    int32_t seq0_expected = (i == 0) ? 1 : values[i - 1];
-    int32_t seq1_expected = (i == 0) ? 101 : values[i - 1] * -1;
+  for (size_t i = 0; i < int_result0_data.size(); i++) {
+    int32_t int_seq0_expected = (i == 0) ? 1 : values[i - 1];
+    int32_t int_seq1_expected = (i == 0) ? 101 : values[i - 1] * -1;
+    int32_t string_seq0_expected;
+
+    // For string sequence ID case we are testing two different backends
+    if ((i == 0) && dyna_sequence) {
+      string_seq0_expected = 20;
+    } else if ((i == 0) && !dyna_sequence) {
+      string_seq0_expected = 21;
+    } else if ((i != 0) && dyna_sequence) {
+      string_seq0_expected = values[i - 1] * -1 + string_result0_data[i - 1];
+    } else {
+      string_seq0_expected = values[i - 1] * -1;
+    }
+
     // The dyna_sequence custom backend adds the sequence ID to
     // the last request in a sequence.
     if (dyna_sequence && (i != 0) && (values[i - 1] == 1)) {
-      seq0_expected += sequence_id0;
-      seq1_expected += sequence_id1;
+      int_seq0_expected += int_sequence_id0;
+      int_seq1_expected += int_sequence_id1;
+      string_seq0_expected += std::stoi(string_sequence_id0);
     }
 
-    std::cout << "[" << i << "] " << result0_data[i] << " : " << result1_data[i]
+    std::cout << "[" << i << "] " << int_result0_data[i] << " : "
+              << int_result1_data[i] << " : " << string_result0_data[i]
               << std::endl;
 
-    if ((seq0_expected != result0_data[i]) ||
-        (seq1_expected != result1_data[i])) {
-      std::cout << "[ expected ] " << seq0_expected << " : " << seq1_expected
+    if ((int_seq0_expected != int_result0_data[i]) ||
+        (int_seq1_expected != int_result1_data[i]) ||
+        (string_seq0_expected != string_result0_data[i])) {
+      std::cout << "[ expected ] " << int_seq0_expected << " : "
+                << int_seq1_expected << " : " << string_seq0_expected
                 << std::endl;
       return 1;
     }

--- a/src/c++/examples/simple_http_model_control.cc
+++ b/src/c++/examples/simple_http_model_control.cc
@@ -34,7 +34,7 @@ namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    tc::Error err = (X);                                          \
+    tc::Error err = (X);                                           \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -111,8 +111,8 @@ main(int argc, char** argv)
     FAIL_IF_ERR(
         tc::ParseJson(&repository_index_json, repository_index),
         "failed to parse model config");
-    if (repository_index_json.Size() != 6) {
-      std::cerr << "expected number of models 6, got "
+    if (repository_index_json.Size() != 7) {
+      std::cerr << "expected number of models 7, got "
                 << repository_index_json.Size() << std::endl;
       exit(1);
     }

--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -42,7 +42,9 @@
 
 #ifdef TRITON_INFERENCE_SERVER_CLIENT_CLASS
 namespace triton { namespace perfanalyzer { namespace clientbackend {
-namespace tritoncapi {class TritonLoader;}}}}
+namespace tritoncapi {
+class TritonLoader;
+}}}}  // namespace triton::perfanalyzer::clientbackend::tritoncapi
 #endif
 
 namespace triton { namespace client {
@@ -156,8 +158,9 @@ class InferenceServerClient {
 struct InferOptions {
   explicit InferOptions(const std::string& model_name)
       : model_name_(model_name), model_version_(""), request_id_(""),
-        sequence_id_(0), sequence_start_(false), sequence_end_(false),
-        priority_(0), server_timeout_(0), client_timeout_(0)
+        sequence_id_(0), sequence_id_str_(""), sequence_start_(false),
+        sequence_end_(false), priority_(0), server_timeout_(0),
+        client_timeout_(0)
   {
   }
   /// The name of the model to run inference.
@@ -172,8 +175,14 @@ struct InferOptions {
   std::string request_id_;
   /// The unique identifier for the sequence being represented by the
   /// object. Default value is 0 which means that the request does not
-  /// belong to a sequence.
+  /// belong to a sequence. If this value is non-zero, then sequence_id_str_
+  /// MUST be set to "".
   uint64_t sequence_id_;
+  /// The unique identifier for the sequence being represented by the
+  /// object. Default value is "" which means that the request does not
+  /// belong to a sequence. If this value is non-empty, then sequence_id_
+  /// MUST be set to 0.
+  std::string sequence_id_str_;
   /// Indicates whether the request being added marks the start of the
   /// sequence. Default value is False. This argument is ignored if
   /// 'sequence_id' is 0.
@@ -366,7 +375,7 @@ class InferRequestedOutput {
   /// default value is 0 which means the classification results are not
   /// requested.
   /// \return Error object indicating success or failure.
- static Error Create(
+  static Error Create(
       InferRequestedOutput** infer_output, const std::string& name,
       const size_t class_count = 0);
 

--- a/src/c++/library/grpc_client.cc
+++ b/src/c++/library/grpc_client.cc
@@ -1091,15 +1091,20 @@ InferenceServerGrpcClient::PreRunProcessing(
   infer_request_.set_id(options.request_id_);
 
   infer_request_.mutable_parameters()->clear();
-  if (options.sequence_id_ != 0) {
-    (*infer_request_.mutable_parameters())["sequence_id"].set_int64_param(
-        options.sequence_id_);
-    (*infer_request_.mutable_parameters())["sequence_start"].set_bool_param(
-        options.sequence_start_);
-    (*infer_request_.mutable_parameters())["sequence_end"].set_bool_param(
-        options.sequence_end_);
-  }
-
+  if ((options.sequence_id_ != 0) || (options.sequence_id_str_ != ""))
+    {
+      if (options.sequence_id_ != 0) {
+        (*infer_request_.mutable_parameters())["sequence_id"].set_int64_param(
+            options.sequence_id_);
+      } else {
+        (*infer_request_.mutable_parameters())["sequence_id"].set_string_param(
+            options.sequence_id_str_);
+      }
+      (*infer_request_.mutable_parameters())["sequence_start"].set_bool_param(
+          options.sequence_start_);
+      (*infer_request_.mutable_parameters())["sequence_end"].set_bool_param(
+          options.sequence_end_);
+    }
   if (options.priority_ != 0) {
     (*infer_request_.mutable_parameters())["priority"].set_int64_param(
         options.priority_);

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -40,8 +40,7 @@ extern "C" {
 }
 
 #define TRITONJSON_STATUSTYPE triton::client::Error
-#define TRITONJSON_STATUSRETURN(M) \
-  return triton::client::Error(M)
+#define TRITONJSON_STATUSRETURN(M) return triton::client::Error(M)
 #define TRITONJSON_STATUSSUCCESS triton::client::Error::Success
 #include "triton/common/triton_json.h"
 
@@ -309,17 +308,24 @@ HttpInferRequest::PrepareRequestJson(
   request_json->AddStringRef(
       "id", options.request_id_.c_str(), options.request_id_.size());
 
-  if ((options.sequence_id_ != 0) || (options.priority_ != 0) ||
-      (options.server_timeout_ != 0) || outputs.empty()) {
+  if ((options.sequence_id_ != 0) || (options.sequence_id_str_ != "") ||
+      (options.priority_ != 0) || (options.server_timeout_ != 0) ||
+      outputs.empty()) {
     triton::common::TritonJson::Value parameters_json(
         *request_json, triton::common::TritonJson::ValueType::OBJECT);
     {
-      if (options.sequence_id_ != 0) {
-        parameters_json.AddUInt("sequence_id", options.sequence_id_);
-        parameters_json.AddBool("sequence_start", options.sequence_start_);
-        parameters_json.AddBool("sequence_end", options.sequence_end_);
-      }
-
+      if ((options.sequence_id_ != 0) || (options.sequence_id_str_ != ""))
+        {
+          if (options.sequence_id_ != 0) {
+            parameters_json.AddUInt("sequence_id", options.sequence_id_);
+          } else {
+            parameters_json.AddString(
+                "sequence_id", options.sequence_id_str_.c_str(),
+                options.sequence_id_str_.size());
+          }
+          parameters_json.AddBool("sequence_start", options.sequence_start_);
+          parameters_json.AddBool("sequence_end", options.sequence_end_);
+        }
       if (options.priority_ != 0) {
         parameters_json.AddUInt("priority", options.priority_);
       }

--- a/src/c++/perf_analyzer/client_backend/client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/client_backend.h
@@ -157,7 +157,8 @@ struct ModelStatistics {
 struct InferOptions {
   explicit InferOptions(const std::string& model_name)
       : model_name_(model_name), model_version_(""), request_id_(""),
-        sequence_id_(0), sequence_start_(false), sequence_end_(false)
+        sequence_id_(0), sequence_id_str_(""), sequence_start_(false),
+        sequence_end_(false)
   {
   }
   /// The name of the model to run inference.
@@ -170,8 +171,14 @@ struct InferOptions {
   std::string request_id_;
   /// The unique identifier for the sequence being represented by the
   /// object. Default value is 0 which means that the request does not
-  /// belong to a sequence.
+  /// belong to a sequence. If this value is set, then sequence_id_str_ 
+  /// MUST be set to "".
   uint64_t sequence_id_;
+  /// The unique identifier for the sequence being represented by the
+  /// object. Default value is "" which means that the request does not
+  /// belong to a sequence. If this value is set, then sequence_id_ MUST
+  /// be set to 0.
+  std::string sequence_id_str_;
   /// Indicates whether the request being added marks the start of the
   /// sequence. Default value is False. This argument is ignored if
   /// 'sequence_id' is 0.

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
@@ -417,9 +417,16 @@ TritonClientBackend::ParseInferOptionsToTriton(
 {
   triton_options->model_version_ = options.model_version_;
   triton_options->request_id_ = options.request_id_;
-  triton_options->sequence_id_ = options.sequence_id_;
-  triton_options->sequence_start_ = options.sequence_start_;
-  triton_options->sequence_end_ = options.sequence_end_;
+  if ((options.sequence_id_ != 0) || (options.sequence_id_str_ != ""))
+    {
+      if (options.sequence_id_ != 0) {
+        triton_options->sequence_id_ = options.sequence_id_;
+      } else {
+        triton_options->sequence_id_str_ = options.sequence_id_str_;
+      }
+      triton_options->sequence_start_ = options.sequence_start_;
+      triton_options->sequence_end_ = options.sequence_end_;
+    }
 }
 
 

--- a/src/c++/perf_analyzer/client_backend/triton_c_api/triton_c_api_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/triton_c_api/triton_c_api_backend.cc
@@ -168,9 +168,16 @@ TritonCApiClientBackend::ParseInferOptionsToTriton(
 {
   triton_options->model_version_ = options.model_version_;
   triton_options->request_id_ = options.request_id_;
-  triton_options->sequence_id_ = options.sequence_id_;
-  triton_options->sequence_start_ = options.sequence_start_;
-  triton_options->sequence_end_ = options.sequence_end_;
+  if ((options.sequence_id_ != 0) || (options.sequence_id_str_ != ""))
+    {
+      if (options.sequence_id_ != 0) {
+        triton_options->sequence_id_ = options.sequence_id_;
+      } else {
+        triton_options->sequence_id_str_ = options.sequence_id_str_;
+      }
+      triton_options->sequence_start_ = options.sequence_start_;
+      triton_options->sequence_end_ = options.sequence_end_;
+    }
 }
 
 void

--- a/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.h
+++ b/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.h
@@ -277,7 +277,11 @@ class TritonLoader : public tc::InferenceServerClient {
       *TritonServerInferenceRequestSetCorrelationIdFn_t)(
       TRITONSERVER_InferenceRequest* inference_request,
       uint64_t correlation_id);
-
+  // TRITONSERVER_InferenceRequestSetCorrelationId
+  typedef TRITONSERVER_Error* (
+      *TritonServerInferenceRequestSetStringCorrelationIdFn_t)(
+      TRITONSERVER_InferenceRequest* inference_request,
+      const char* correlation_id);
   // TRITONSERVER_InferenceRequestSetFlags
   typedef TRITONSERVER_Error* (*TritonServerInferenceRequestSetFlagsFn_t)(
       TRITONSERVER_InferenceRequest* inference_request, uint32_t flags);
@@ -415,6 +419,8 @@ class TritonLoader : public tc::InferenceServerClient {
   TritonServerErrorCodeToStringFn_t error_code_to_string_fn_;
   TritonServerModelConfigFn_t model_config_fn_;
   TritonServerInferenceRequestSetCorrelationIdFn_t set_correlation_id_fn_;
+  TritonServerInferenceRequestSetStringCorrelationIdFn_t
+      set_string_correlation_id_fn_;
 
   TritonServerInferenceRequestSetFlagsFn_t set_flags_fn_;
   TritonServerInferenceRequestSetPriorityFn_t set_priority_fn_;

--- a/src/python/examples/simple_grpc_sequence_stream_infer_client.py
+++ b/src/python/examples/simple_grpc_sequence_stream_infer_client.py
@@ -30,6 +30,7 @@ import argparse
 import numpy as np
 import sys
 import queue
+import uuid
 
 import tritonclient.grpc as grpcclient
 from tritonclient.utils import InferenceServerException
@@ -119,10 +120,11 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
 
-    # We use the custom "sequence" model which takes 1 input
+    # We use custom "sequence" models which take 1 input
     # value. The output is the accumulated value of the inputs. See
     # src/custom/sequence.
-    model_name = "simple_dyna_sequence" if FLAGS.dyna else "simple_sequence"
+    int_sequence_model_name = "simple_dyna_sequence" if FLAGS.dyna else "simple_sequence"
+    string_sequence_model_name = "simple_string_dyna_sequence" if FLAGS.dyna else "simple_sequence"
     model_version = ""
     batch_size = 1
 
@@ -131,11 +133,20 @@ if __name__ == '__main__':
     # Will use two sequences and send them asynchronously. Note the
     # sequence IDs should be non-zero because zero is reserved for
     # non-sequence requests.
-    sequence_id0 = 1000 + FLAGS.offset * 2
-    sequence_id1 = 1001 + FLAGS.offset * 2
+    int_sequence_id0 = 1000 + FLAGS.offset * 2
+    int_sequence_id1 = 1001 + FLAGS.offset * 2
 
-    result0_list = []
-    result1_list = []
+    # For string sequence IDs, the dyna backend requires that the
+    # sequence id be decodable into an integer, otherwise we'll use
+    # a UUID4 sequence id and a model that doesn't require corrid
+    # control.
+    string_sequence_id0 = str(1002 +
+                              FLAGS.offset) if FLAGS.dyna else str(uuid.uuid4())
+
+    int_result0_list = []
+    int_result1_list = []
+
+    string_result0_list = []
 
     user_data = UserData()
 
@@ -150,49 +161,77 @@ if __name__ == '__main__':
                                        stream_timeout=FLAGS.stream_timeout)
             # Now send the inference sequences...
             async_stream_send(triton_client, [0] + values, batch_size,
-                              sequence_id0, model_name, model_version)
+                              int_sequence_id0, int_sequence_model_name,
+                              model_version)
             async_stream_send(triton_client,
                               [100] + [-1 * val for val in values], batch_size,
-                              sequence_id1, model_name, model_version)
+                              int_sequence_id1, int_sequence_model_name,
+                              model_version)
+            async_stream_send(triton_client,
+                              [20] + [-1 * val for val in values], batch_size,
+                              string_sequence_id0, string_sequence_model_name,
+                              model_version)
         except InferenceServerException as error:
             print(error)
             sys.exit(1)
 
         # Retrieve results...
         recv_count = 0
-        while recv_count < (2 * (len(values) + 1)):
+        while recv_count < (3 * (len(values) + 1)):
             data_item = user_data._completed_requests.get()
             if type(data_item) == InferenceServerException:
                 print(data_item)
                 sys.exit(1)
             else:
-                this_id = int(data_item.get_response().id.split('_')[0])
-                if this_id == sequence_id0:
-                    result0_list.append(data_item.as_numpy('OUTPUT'))
-                elif this_id == sequence_id1:
-                    result1_list.append(data_item.as_numpy('OUTPUT'))
-                else:
-                    print("unexpected sequence id returned by the server: {}".
-                          format(this_id))
-                    sys.exit(1)
+                try:
+                    this_id = data_item.get_response().id.split('_')[0]
+                    if int(this_id) == int_sequence_id0:
+                        int_result0_list.append(data_item.as_numpy('OUTPUT'))
+                    elif int(this_id) == int_sequence_id1:
+                        int_result1_list.append(data_item.as_numpy('OUTPUT'))
+                    elif this_id == string_sequence_id0:
+                        string_result0_list.append(data_item.as_numpy('OUTPUT'))
+                    else:
+                        print(
+                            "unexpected sequence id returned by the server: {}".
+                            format(this_id))
+                        sys.exit(1)
+                except ValueError:
+                    string_result0_list.append(data_item.as_numpy('OUTPUT'))
+
             recv_count = recv_count + 1
 
-    for i in range(len(result0_list)):
-        seq0_expected = 1 if (i == 0) else values[i - 1]
-        seq1_expected = 101 if (i == 0) else values[i - 1] * -1
+    for i in range(len(int_result0_list)):
+        int_seq0_expected = 1 if (i == 0) else values[i - 1]
+        int_seq1_expected = 101 if (i == 0) else values[i - 1] * -1
+
+        # For string sequence ID we are testing two different backends
+        if i == 0 and FLAGS.dyna:
+            string_seq0_expected = 20
+        elif i == 0 and not FLAGS.dyna:
+            string_seq0_expected = 21
+        elif i != 0 and FLAGS.dyna:
+            string_seq0_expected = values[i - 1] * -1 + int(
+                string_result0_list[i - 1][0][0])
+        else:
+            string_seq0_expected = values[i - 1] * -1
+
         # The dyna_sequence custom backend adds the correlation ID
         # to the last request in a sequence.
         if FLAGS.dyna and (i != 0) and (values[i - 1] == 1):
-            seq0_expected += sequence_id0
-            seq1_expected += sequence_id1
+            int_seq0_expected += int_sequence_id0
+            int_seq1_expected += int_sequence_id1
+            string_seq0_expected += int(string_sequence_id0)
 
-        print("[" + str(i) + "] " + str(result0_list[i][0][0]) + " : " +
-              str(result1_list[i][0][0]))
+        print("[" + str(i) + "] " + str(int_result0_list[i][0][0]) + " : " +
+              str(int_result1_list[i][0][0]) + " : " +
+              str(string_result0_list[i][0][0]))
 
-        if ((seq0_expected != result0_list[i][0][0]) or
-            (seq1_expected != result1_list[i][0][0])):
-            print("[ expected ] " + str(seq0_expected) + " : " +
-                  str(seq1_expected))
+        if ((int_seq0_expected != int_result0_list[i][0][0]) or
+            (int_seq1_expected != int_result1_list[i][0][0]) or
+            (string_seq0_expected != string_result0_list[i][0][0])):
+            print("[ expected ] " + str(int_seq0_expected) + " : " +
+                  str(int_seq1_expected) + " : " + str(string_seq0_expected))
             sys.exit(1)
 
-    print("PASS: Sequence + Streaming")
+    print("PASS: Sequence")

--- a/src/python/examples/simple_grpc_sequence_sync_infer_client.py
+++ b/src/python/examples/simple_grpc_sequence_sync_infer_client.py
@@ -29,6 +29,7 @@ import argparse
 import numpy as np
 import sys
 import queue
+import uuid
 
 import tritonclient.grpc as grpcclient
 from tritonclient.utils import InferenceServerException
@@ -106,10 +107,11 @@ if __name__ == '__main__':
         print("context creation failed: " + str(e))
         sys.exit()
 
-    # We use the custom "sequence" model which takes 1 input
+    # We use custom "sequence" models which take 1 input
     # value. The output is the accumulated value of the inputs. See
     # src/custom/sequence.
-    model_name = "simple_dyna_sequence" if FLAGS.dyna else "simple_sequence"
+    int_sequence_model_name = "simple_dyna_sequence" if FLAGS.dyna else "simple_sequence"
+    string_sequence_model_name = "simple_string_dyna_sequence" if FLAGS.dyna else "simple_sequence"
     model_version = ""
     batch_size = 1
 
@@ -118,40 +120,67 @@ if __name__ == '__main__':
     # Will use two sequences and send them synchronously. Note the
     # sequence IDs should be non-zero because zero is reserved for
     # non-sequence requests.
-    sequence_id0 = 1000 + FLAGS.offset * 2
-    sequence_id1 = 1001 + FLAGS.offset * 2
+    int_sequence_id0 = 1000 + FLAGS.offset * 2
+    int_sequence_id1 = 1001 + FLAGS.offset * 2
 
-    result0_list = []
-    result1_list = []
+    # For string sequence IDs, the dyna backend requires that the
+    # sequence id be decodable into an integer, otherwise we'll use
+    # a UUID4 sequence id and a model that doesn't require corrid
+    # control.
+    string_sequence_id0 = str(1002) if FLAGS.dyna else str(uuid.uuid4())
+
+    int_result0_list = []
+    int_result1_list = []
+
+    string_result0_list = []
 
     user_data = UserData()
 
     try:
-        sync_send(triton_client, result0_list, [0] + values, batch_size,
-                  sequence_id0, model_name, model_version)
-        sync_send(triton_client, result1_list,
+        sync_send(triton_client, int_result0_list, [0] + values, batch_size,
+                  int_sequence_id0, int_sequence_model_name, model_version)
+        sync_send(triton_client, int_result1_list,
                   [100] + [-1 * val for val in values], batch_size,
-                  sequence_id1, model_name, model_version)
+                  int_sequence_id1, int_sequence_model_name, model_version)
+        sync_send(triton_client, string_result0_list,
+                  [20] + [-1 * val for val in values], batch_size,
+                  string_sequence_id0, string_sequence_model_name,
+                  model_version)
     except InferenceServerException as error:
         print(error)
         sys.exit(1)
 
-    for i in range(len(result0_list)):
-        seq0_expected = 1 if (i == 0) else values[i - 1]
-        seq1_expected = 101 if (i == 0) else values[i - 1] * -1
+    for i in range(len(int_result0_list)):
+        int_seq0_expected = 1 if (i == 0) else values[i - 1]
+        int_seq1_expected = 101 if (i == 0) else values[i - 1] * -1
+
+        # For string sequence ID we are testing two different backends
+        if i == 0 and FLAGS.dyna:
+            string_seq0_expected = 20
+        elif i == 0 and not FLAGS.dyna:
+            string_seq0_expected = 21
+        elif i != 0 and FLAGS.dyna:
+            string_seq0_expected = values[i - 1] * -1 + int(
+                string_result0_list[i - 1][0][0])
+        else:
+            string_seq0_expected = values[i - 1] * -1
+
         # The dyna_sequence custom backend adds the correlation ID
         # to the last request in a sequence.
         if FLAGS.dyna and (i != 0) and (values[i - 1] == 1):
-            seq0_expected += sequence_id0
-            seq1_expected += sequence_id1
+            int_seq0_expected += int_sequence_id0
+            int_seq1_expected += int_sequence_id1
+            string_seq0_expected += int(string_sequence_id0)
 
-        print("[" + str(i) + "] " + str(result0_list[i][0][0]) + " : " +
-              str(result1_list[i][0][0]))
+        print("[" + str(i) + "] " + str(int_result0_list[i][0][0]) + " : " +
+              str(int_result1_list[i][0][0]) + " : " +
+              str(string_result0_list[i][0][0]))
 
-        if ((seq0_expected != result0_list[i][0][0]) or
-            (seq1_expected != result1_list[i][0][0])):
-            print("[ expected ] " + str(seq0_expected) + " : " +
-                  str(seq1_expected))
+        if ((int_seq0_expected != int_result0_list[i][0][0]) or
+            (int_seq1_expected != int_result1_list[i][0][0]) or
+            (string_seq0_expected != string_result0_list[i][0][0])):
+            print("[ expected ] " + str(int_seq0_expected) + " : " +
+                  str(int_seq1_expected) + " : " + str(string_seq0_expected))
             sys.exit(1)
 
     print("PASS: Sequence")


### PR DESCRIPTION
* Updated c++/python clients and examples to use string sequence IDs

* Removed SequenceId class to maintain backwards compat

* Renamed example send functions, adjusted sequence_id type checking