### PR TITLE
[python] add support for user provided ChannelCredentials

### DIFF
--- a/src/python/library/tritonclient/grpc/__init__.py
+++ b/src/python/library/tritonclient/grpc/__init__.py
@@ -184,6 +184,8 @@ class InferenceServerClient:
         Object encapsulating various GRPC KeepAlive options. See
         the class definition for more information. Default is None.
 
+    creds: grpc.ChannelCredentials
+        A grpc.ChannelCredentials object to use for the connection.
     Raises
     ------
     Exception
@@ -198,7 +200,8 @@ class InferenceServerClient:
                  root_certificates=None,
                  private_key=None,
                  certificate_chain=None,
-                 keepalive_options=None):
+                 keepalive_options=None,
+                 creds=None,):
         # Use GRPC KeepAlive client defaults if unspecified
         if not keepalive_options:
             keepalive_options = KeepAliveOptions()
@@ -216,8 +219,9 @@ class InferenceServerClient:
             ('grpc.http2.max_pings_without_data',
                 keepalive_options.http2_max_pings_without_data),
         ]
-
-        if ssl:
+        if creds:
+            grpc.secure_channel(url, creds, options=channel_opt)
+        elif ssl:
             rc_bytes = pk_bytes = cc_bytes = None
             if root_certificates is not None:
                 with open(root_certificates, 'rb') as rc_fs:

--- a/src/python/library/tritonclient/grpc/__init__.py
+++ b/src/python/library/tritonclient/grpc/__init__.py
@@ -180,12 +180,15 @@ class InferenceServerClient:
         to use or None if no certificate chain should be used. The
         option is ignored if `ssl` is False. Default is None.
 
+    creds: grpc.ChannelCredentials
+        A grpc.ChannelCredentials object to use for the connection.
+        The ssl, root_certificates, private_key and certificate_chain
+        options will be ignored when using this option. Default is None.
+
     keepalive_options: KeepAliveOptions
         Object encapsulating various GRPC KeepAlive options. See
         the class definition for more information. Default is None.
 
-    creds: grpc.ChannelCredentials
-        A grpc.ChannelCredentials object to use for the connection.
     Raises
     ------
     Exception
@@ -220,7 +223,7 @@ class InferenceServerClient:
                 keepalive_options.http2_max_pings_without_data),
         ]
         if creds:
-            grpc.secure_channel(url, creds, options=channel_opt)
+            self._channel = grpc.secure_channel(url, creds, options=channel_opt)
         elif ssl:
             rc_bytes = pk_bytes = cc_bytes = None
             if root_certificates is not None:

--- a/src/python/library/tritonclient/grpc/__init__.py
+++ b/src/python/library/tritonclient/grpc/__init__.py
@@ -203,8 +203,8 @@ class InferenceServerClient:
                  root_certificates=None,
                  private_key=None,
                  certificate_chain=None,
-                 keepalive_options=None,
-                 creds=None,):
+                 creds=None,
+                 keepalive_options=None):
         # Use GRPC KeepAlive client defaults if unspecified
         if not keepalive_options:
             keepalive_options = KeepAliveOptions()


### PR DESCRIPTION
This PR adds support for user provided grpc.ChannelCredentials to the python client library.