### PR TITLE
Add proxy settings in InferenceServerClient

### DIFF
--- a/src/python/examples/simple_http_infer_client.py
+++ b/src/python/examples/simple_http_infer_client.py
@@ -106,6 +106,12 @@ if __name__ == '__main__':
                         required=False,
                         default='localhost:8000',
                         help='Inference server URL. Default is localhost:8000.')
+    parser.add_argument('-p',
+                        '--proxy',
+                        type=str,
+                        required=False,
+                        default=None,
+                        help='Proxy URL and port (example www.proxy.com:80). Default is None.')
     parser.add_argument('-s',
                         '--ssl',
                         action="store_true",
@@ -138,6 +144,16 @@ if __name__ == '__main__':
     )
 
     FLAGS = parser.parse_args()
+
+    if FLAGS.proxy:
+        try:
+            proxy_host, proxy_port = FLAGS.proxy.split(':')
+        except ValueError:
+            print('Error in defining proxy address. It must be formatted as URL:port, example www.proxy.com:80')
+            exit(1)
+    else:
+        proxy_host, proxy_port = None, None
+
     try:
         if FLAGS.ssl:
             triton_client = httpclient.InferenceServerClient(
@@ -145,10 +161,12 @@ if __name__ == '__main__':
                 verbose=FLAGS.verbose,
                 ssl=True,
                 ssl_context_factory=gevent.ssl._create_unverified_context,
+                proxy_host=proxy_host, proxy_port=proxy_port,
                 insecure=True)
         else:
             triton_client = httpclient.InferenceServerClient(
-                url=FLAGS.url, verbose=FLAGS.verbose)
+                url=FLAGS.url, verbose=FLAGS.verbose,
+                proxy_host=proxy_host, proxy_port=proxy_port)
     except Exception as e:
         print("channel creation failed: " + str(e))
         sys.exit(1)

--- a/src/python/library/tritonclient/http/__init__.py
+++ b/src/python/library/tritonclient/http/__init__.py
@@ -177,6 +177,12 @@ class InferenceServerClient:
         this option is None which directly wraps the socket with
         the options provided via `ssl_options`. The argument is
         ignored if 'ssl' is specified False.
+    proxy_host : str
+        Address of the http proxy. If this is set, also proxy_port
+        must be set as well, or an exception will be raised. Default
+        None, which means no proxy.
+    proxy_port : int
+        If set, port of the http proxy. Default None.
     insecure : bool
         If True, then does not match the host name with the certificate.
         Default value is False. The argument is ignored if 'ssl' is
@@ -199,6 +205,8 @@ class InferenceServerClient:
                  ssl=False,
                  ssl_options=None,
                  ssl_context_factory=None,
+                 proxy_host=None,
+                 proxy_port=None,
                  insecure=False):
         if url.startswith("http://") or url.startswith("https://"):
             raise_error("url should not include the scheme")
@@ -212,6 +220,8 @@ class InferenceServerClient:
             network_timeout=network_timeout,
             ssl_options=ssl_options,
             ssl_context_factory=ssl_context_factory,
+            proxy_host=proxy_host,
+            proxy_port=proxy_port,
             insecure=insecure)
         self._pool = gevent.pool.Pool(max_greenlets)
         self._verbose = verbose


### PR DESCRIPTION
Allow InferenceServerClient to use a proxy by allowing the user to set `proxy_host` and `proxy_port`.