### PR TITLE
Adding DtoD cupport to CUDA shared memory feature

### DIFF
--- a/src/python/library/tritonclient/utils/cuda_shared_memory/cuda_shared_memory.cc
+++ b/src/python/library/tritonclient/utils/cuda_shared_memory/cuda_shared_memory.cc
@@ -158,6 +158,37 @@ CudaSharedMemoryRegionSet(
 }
 
 int
+CudaSharedMemoryRegionSetDptr(
+    void* cuda_shm_handle, size_t offset, size_t byte_size, const void* dptr)
+{
+  // remember previous device and set to new device
+  int previous_device;
+  cudaGetDevice(&previous_device);
+  cudaError_t err = cudaSetDevice(
+      reinterpret_cast<SharedMemoryHandle*>(cuda_shm_handle)->device_id_);
+  if (err != cudaSuccess) {
+    cudaSetDevice(previous_device);
+    return -1;
+  }
+
+  // Copy data into cuda shared memory
+  void* base_addr =
+      reinterpret_cast<SharedMemoryHandle*>(cuda_shm_handle)->base_addr_;
+  err = cudaMemcpy(
+      reinterpret_cast<uint8_t*>(base_addr) + offset, dptr, byte_size,
+      cudaMemcpyDeviceToDevice);
+  if (err != cudaSuccess) {
+    cudaSetDevice(previous_device);
+    return -3;
+  }
+
+  // Set device to previous GPU
+  cudaSetDevice(previous_device);
+
+  return 0;
+}
+
+int
 GetCudaSharedMemoryHandleInfo(
     void* shm_handle, char** shm_addr, size_t* offset, size_t* byte_size)
 {

--- a/src/python/library/tritonclient/utils/cuda_shared_memory/cuda_shared_memory.h
+++ b/src/python/library/tritonclient/utils/cuda_shared_memory/cuda_shared_memory.h
@@ -40,6 +40,8 @@ int CudaSharedMemoryGetRawHandle(
     void* cuda_shm_handle, char** serialized_raw_handle);
 int CudaSharedMemoryRegionSet(
     void* cuda_shm_handle, size_t offset, size_t byte_size, const void* data);
+int CudaSharedMemoryRegionSetDptr(
+    void* cuda_shm_handle, size_t offset, size_t byte_size, const void* dptr);
 int GetCudaSharedMemoryHandleInfo(
     void* shm_handle, char** shm_addr, size_t* offset, size_t* byte_size);
 int CudaSharedMemoryReleaseBuffer(char* ptr);


### PR DESCRIPTION
Hello world,

This patch:
- Adds DtoD CUDA memcopy support which allows to pass video frames decoded in CUDA memory to Triton.
- Changes API of `set_shared_memory_region` function to accept CUDA memory beside numpy arrays.

I'm not certain about changes in Python module API so please free to give me guidance on how to implement it better.