### PR TITLE
Expose SSL options in HTTP C++ library and client examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,23 @@ to the [Java client directory](src/java).
 
 ### HTTP Options
 
+#### SSL/TLS
+
+The client library allows communication across a secured channel using HTTPS protocol. Just setting these SSL options do not ensure the secure communication. Triton server should be running behind `https://` proxy such as nginx. The client can then establish a secure channel till the proxy.The [`qa/L0_https`](https://github.com/triton-inference-server/server/blob/main/qa/L0_https/test.sh) in the server repository demostrates how this can be acheived. 
+
+For C++ client, see `HttpSslOptions` struct that encapsulates these options in [http_client.h](src/c%2B%2B/library/http_client.h).
+
+For Python client, look for the following options in [http/\_\_init\_\_.py](src/python/library/tritonclient/http/__init__.py):
+
+* ssl
+* ssl_options
+* ssl_context_factory
+* insecure
+
+The [C++](src/c%2B%2B/examples/simple_http_infer_client.cc) and [Python](src/python/examples/simple_http_infer_client.py) examples
+demonstrates how to use SSL/TLS settings on client side.
+
+
 #### Compression
 
 The client library enables on-wire compression for HTTP transactions.

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ to the [Java client directory](src/java).
 
 #### SSL/TLS
 
-The client library allows communication across a secured channel using HTTPS protocol. Just setting these SSL options do not ensure the secure communication. Triton server should be running behind `https://` proxy such as nginx. The client can then establish a secure channel till the proxy.The [`qa/L0_https`](https://github.com/triton-inference-server/server/blob/main/qa/L0_https/test.sh) in the server repository demostrates how this can be acheived. 
+The client library allows communication across a secured channel using HTTPS protocol. Just setting these SSL options do not ensure the secure communication. Triton server should be running behind `https://` proxy such as nginx. The client can then establish a secure channel to the proxy. The [`qa/L0_https`](https://github.com/triton-inference-server/server/blob/main/qa/L0_https/test.sh) in the server repository demostrates how this can be acheived. 
 
 For C++ client, see `HttpSslOptions` struct that encapsulates these options in [http_client.h](src/c%2B%2B/library/http_client.h).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/c++/examples/simple_http_infer_client.cc
+++ b/src/c++/examples/simple_http_infer_client.cc
@@ -24,6 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <getopt.h>
 #include <unistd.h>
 #include <iostream>
 #include <string>
@@ -33,7 +34,7 @@ namespace tc = triton::client;
 
 #define FAIL_IF_ERR(X, MSG)                                        \
   {                                                                \
-    tc::Error err = (X);                                          \
+    tc::Error err = (X);                                           \
     if (!err.IsOk()) {                                             \
       std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
       exit(1);                                                     \
@@ -82,6 +83,11 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-i <none|gzip|deflate>" << std::endl;
   std::cerr << "\t-o <none|gzip|deflate>" << std::endl;
   std::cerr << std::endl;
+  std::cerr << "\t--verifypeer" << std::endl;
+  std::cerr << "\t--verifyhost" << std::endl;
+  std::cerr << "\t--cacerts" << std::endl;
+  std::cerr << "\t--certfile" << std::endl;
+  std::cerr << "\t--keyfile" << std::endl;
   std::cerr
       << "For -H, header must be 'Header:Value'. May be given multiple times."
       << std::endl
@@ -107,11 +113,37 @@ main(int argc, char** argv)
       tc::InferenceServerHttpClient::CompressionType::NONE;
   auto response_compression_algorithm =
       tc::InferenceServerHttpClient::CompressionType::NONE;
+  long verify_peer = 1;
+  long verify_host = 2;
+  std::string cacerts;
+  std::string certfile;
+  std::string keyfile;
+
+  // {name, has_arg, *flag, val}
+  static struct option long_options[] = {
+      {"verifypeer", 1, 0, 0}, {"verifyhost", 1, 0, 1}, {"cacerts", 1, 0, 2},
+      {"certfile", 1, 0, 3},   {"keyfile", 1, 0, 4},    {0, 0, 0, 0}};
 
   // Parse commandline...
   int opt;
-  while ((opt = getopt(argc, argv, "vu:t:H:i:o:")) != -1) {
+  while ((opt = getopt_long(argc, argv, "vu:t:H:i:o:", long_options, NULL)) !=
+         -1) {
     switch (opt) {
+      case 0:
+        verify_peer = std::atoi(optarg);
+        break;
+      case 1:
+        verify_host = std::atoi(optarg);
+        break;
+      case 2:
+        cacerts = optarg;
+        break;
+      case 3:
+        certfile = optarg;
+        break;
+      case 4:
+        keyfile = optarg;
+        break;
       case 'v':
         verbose = true;
         break;
@@ -162,11 +194,17 @@ main(int argc, char** argv)
   std::string model_name = "simple";
   std::string model_version = "";
 
+  tc::HttpSslOptions ssl_options;
+  ssl_options.verify_peer = verify_peer;
+  ssl_options.verify_host = verify_host;
+  ssl_options.ca_info = cacerts;
+  ssl_options.cert = certfile;
+  ssl_options.key = keyfile;
   // Create a InferenceServerHttpClient instance to communicate with the
   // server using HTTP protocol.
   std::unique_ptr<tc::InferenceServerHttpClient> client;
   FAIL_IF_ERR(
-      tc::InferenceServerHttpClient::Create(&client, url, verbose),
+      tc::InferenceServerHttpClient::Create(&client, url, verbose, ssl_options),
       "unable to create http client");
 
   // Create the data for the two input tensors. Initialize the first

--- a/src/c++/examples/simple_http_infer_client.cc
+++ b/src/c++/examples/simple_http_infer_client.cc
@@ -83,11 +83,11 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-i <none|gzip|deflate>" << std::endl;
   std::cerr << "\t-o <none|gzip|deflate>" << std::endl;
   std::cerr << std::endl;
-  std::cerr << "\t--verifypeer" << std::endl;
-  std::cerr << "\t--verifyhost" << std::endl;
-  std::cerr << "\t--cacerts" << std::endl;
-  std::cerr << "\t--certfile" << std::endl;
-  std::cerr << "\t--keyfile" << std::endl;
+  std::cerr << "\t--verify-peer" << std::endl;
+  std::cerr << "\t--verify-host" << std::endl;
+  std::cerr << "\t--ca-certs" << std::endl;
+  std::cerr << "\t--cert-file" << std::endl;
+  std::cerr << "\t--key-file" << std::endl;
   std::cerr
       << "For -H, header must be 'Header:Value'. May be given multiple times."
       << std::endl
@@ -121,8 +121,8 @@ main(int argc, char** argv)
 
   // {name, has_arg, *flag, val}
   static struct option long_options[] = {
-      {"verifypeer", 1, 0, 0}, {"verifyhost", 1, 0, 1}, {"cacerts", 1, 0, 2},
-      {"certfile", 1, 0, 3},   {"keyfile", 1, 0, 4},    {0, 0, 0, 0}};
+      {"verify-peer", 1, 0, 0}, {"verify-host", 1, 0, 1}, {"ca-certs", 1, 0, 2},
+      {"cert-file", 1, 0, 3},   {"key-file", 1, 0, 4},    {0, 0, 0, 0}};
 
   // Parse commandline...
   int opt;

--- a/src/c++/examples/simple_http_infer_client.cc
+++ b/src/c++/examples/simple_http_infer_client.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -196,6 +196,73 @@ CompressData(
   return Error::Success;
 }
 
+Error
+ParseSslCertType(
+    HttpSslOptions::CERTTYPE cert_type, std::string* curl_cert_type)
+{
+  switch (cert_type) {
+    case HttpSslOptions::CERTTYPE::CERT_PEM:
+      *curl_cert_type = "PEM";
+      break;
+    case HttpSslOptions::CERTTYPE::CERT_DER:
+      *curl_cert_type = "DER";
+      break;
+    default:
+      return Error(
+          "unsupported ssl certificate type encountered. Only PEM and DER are "
+          "supported.");
+  }
+  return Error::Success;
+}
+
+Error
+ParseSslKeyType(HttpSslOptions::KEYTYPE key_type, std::string* curl_key_type)
+{
+  switch (key_type) {
+    case HttpSslOptions::KEYTYPE::KEY_PEM:
+      *curl_key_type = "PEM";
+      break;
+    case HttpSslOptions::KEYTYPE::KEY_DER:
+      *curl_key_type = "DER";
+      break;
+    default:
+      return Error(
+          "unsupported ssl key type encountered. Only PEM and DER are "
+          "supported.");
+  }
+  return Error::Success;
+}
+
+Error
+SetSSLCurlOptions(CURL** curl, const HttpSslOptions& ssl_options)
+{
+  curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYPEER, ssl_options.verify_peer);
+  curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYHOST, ssl_options.verify_host);
+  if (!ssl_options.ca_info.empty()) {
+    curl_easy_setopt(*curl, CURLOPT_CAINFO, ssl_options.ca_info.c_str());
+  }
+  std::string curl_cert_type;
+  Error err = ParseSslCertType(ssl_options.cert_type, &curl_cert_type);
+  if (!err.IsOk()) {
+    return err;
+  }
+  curl_easy_setopt(*curl, CURLOPT_SSLCERTTYPE, curl_cert_type.c_str());
+  if (!ssl_options.cert.empty()) {
+    curl_easy_setopt(*curl, CURLOPT_SSLCERT, ssl_options.cert.c_str());
+  }
+  std::string curl_key_type;
+  err = ParseSslKeyType(ssl_options.key_type, &curl_key_type);
+  if (!err.IsOk()) {
+    return err;
+  }
+  curl_easy_setopt(*curl, CURLOPT_SSLKEYTYPE, curl_key_type.c_str());
+  if (!ssl_options.key.empty()) {
+    curl_easy_setopt(*curl, CURLOPT_SSLKEY, ssl_options.key.c_str());
+  }
+
+  return Error::Success;
+}
+
 }  // namespace
 
 //==============================================================================
@@ -314,18 +381,17 @@ HttpInferRequest::PrepareRequestJson(
     triton::common::TritonJson::Value parameters_json(
         *request_json, triton::common::TritonJson::ValueType::OBJECT);
     {
-      if ((options.sequence_id_ != 0) || (options.sequence_id_str_ != ""))
-        {
-          if (options.sequence_id_ != 0) {
-            parameters_json.AddUInt("sequence_id", options.sequence_id_);
-          } else {
-            parameters_json.AddString(
-                "sequence_id", options.sequence_id_str_.c_str(),
-                options.sequence_id_str_.size());
-          }
-          parameters_json.AddBool("sequence_start", options.sequence_start_);
-          parameters_json.AddBool("sequence_end", options.sequence_end_);
+      if ((options.sequence_id_ != 0) || (options.sequence_id_str_ != "")) {
+        if (options.sequence_id_ != 0) {
+          parameters_json.AddUInt("sequence_id", options.sequence_id_);
+        } else {
+          parameters_json.AddString(
+              "sequence_id", options.sequence_id_str_.c_str(),
+              options.sequence_id_str_.size());
         }
+        parameters_json.AddBool("sequence_start", options.sequence_start_);
+        parameters_json.AddBool("sequence_end", options.sequence_end_);
+      }
       if (options.priority_ != 0) {
         parameters_json.AddUInt("priority", options.priority_);
       }
@@ -910,15 +976,17 @@ InferenceServerHttpClient::ParseResponseBody(
 Error
 InferenceServerHttpClient::Create(
     std::unique_ptr<InferenceServerHttpClient>* client,
-    const std::string& server_url, bool verbose)
+    const std::string& server_url, bool verbose,
+    const HttpSslOptions& ssl_options)
 {
-  client->reset(new InferenceServerHttpClient(server_url, verbose));
+  client->reset(
+      new InferenceServerHttpClient(server_url, verbose, ssl_options));
   return Error::Success;
 }
 
 InferenceServerHttpClient::InferenceServerHttpClient(
-    const std::string& url, bool verbose)
-    : InferenceServerClient(verbose), url_(url),
+    const std::string& url, bool verbose, const HttpSslOptions& ssl_options)
+    : InferenceServerClient(verbose), url_(url), ssl_options_(ssl_options),
       easy_handle_(reinterpret_cast<void*>(curl_easy_init())),
       multi_handle_(curl_multi_init())
 {
@@ -1529,6 +1597,11 @@ InferenceServerHttpClient::PreRunProcessing(
   const curl_off_t post_byte_size = http_request->total_input_byte_size_;
   curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, post_byte_size);
 
+  err = SetSSLCurlOptions(&curl, ssl_options_);
+  if (!err.IsOk()) {
+    return err;
+  }
+
   struct curl_slist* list = nullptr;
 
   std::string infer_hdr{std::string(kInferHeaderContentLengthHTTPHeader) +
@@ -1710,6 +1783,11 @@ InferenceServerHttpClient::Get(
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, ResponseHandler);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, response);
 
+  Error err = SetSSLCurlOptions(&curl, ssl_options_);
+  if (!err.IsOk()) {
+    return err;
+  }
+
   // Add user provided headers...
   struct curl_slist* header_list = nullptr;
   for (const auto& pr : headers) {
@@ -1782,6 +1860,11 @@ InferenceServerHttpClient::Post(
   response->reserve(1024);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, ResponseHandler);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, response);
+
+  Error err = SetSSLCurlOptions(&curl, ssl_options_);
+  if (!err.IsOk()) {
+    return err;
+  }
 
   // Add user provided headers...
   struct curl_slist* header_list = nullptr;

--- a/src/c++/library/http_client.h
+++ b/src/c++/library/http_client.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. 
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/library/http_client.h
+++ b/src/c++/library/http_client.h
@@ -42,7 +42,7 @@ typedef std::map<std::string, std::string> Headers;
 /// The key-value map type to be included as URL parameters.
 typedef std::map<std::string, std::string> Parameters;
 
-// The options for authorizing and authenticating SSL/TLS connections
+// The options for authorizing and authenticating SSL/TLS connections.
 struct HttpSslOptions {
   enum CERTTYPE { CERT_PEM = 0, CERT_DER = 1 };
   enum KEYTYPE {
@@ -139,12 +139,17 @@ class InferenceServerHttpClient : public InferenceServerClient {
 
   /// Create a client that can be used to communicate with the server.
   /// \param client Returns a new InferenceServerHttpClient object.
-  /// \param server_url The inference server name, port and optional
-  /// base path in the following format: host:port/<base-path>.
+  /// \param server_url The inference server name, port, optional
+  /// scheme and optional base path in the following format:
+  /// <scheme://>host:port/<base-path>.
   /// \param verbose If true generate verbose output when contacting
   /// the inference server.
   /// \param ssl_options Specifies the settings for configuring
-  /// SSL encryption and authorization.
+  /// SSL encryption and authorization. Providing these options
+  /// do not ensure that SSL/TLS will be used in communication.
+  /// The use of SSL/TLS depends entirely on the server endpoint.
+  /// These options will be ignored if the server_url does not
+  /// expose `https://` scheme.
   /// \return Error object indicating success or failure.
   static Error Create(
       std::unique_ptr<InferenceServerHttpClient>* client,

--- a/src/python/examples/simple_http_infer_client.py
+++ b/src/python/examples/simple_http_infer_client.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/python/examples/simple_http_infer_client.py
+++ b/src/python/examples/simple_http_infer_client.py
@@ -113,6 +113,31 @@ if __name__ == '__main__':
                         default=False,
                         help='Enable encrypted link to the server using HTTPS')
     parser.add_argument(
+        '--keyfile',
+        type=str,
+        required=False,
+        default=None,
+        help='File holding client private key. Default is None.')
+    parser.add_argument(
+        '--certfile',
+        type=str,
+        required=False,
+        default=None,
+        help='File holding client certificate. Default is None.')
+    parser.add_argument('--cacerts',
+                        type=str,
+                        required=False,
+                        default=None,
+                        help='File holding ca certificate. Default is None.')
+    parser.add_argument(
+        '--insecure',
+        action="store_true",
+        required=False,
+        default=False,
+        help=
+        'Use no peer verification in SSL communications. Use with caution. Default is False.'
+    )
+    parser.add_argument(
         '-H',
         dest='http_headers',
         metavar="HTTP_HEADER",
@@ -140,12 +165,23 @@ if __name__ == '__main__':
     FLAGS = parser.parse_args()
     try:
         if FLAGS.ssl:
+            ssl_options = {}
+            if FLAGS.keyfile is not None:
+                ssl_options['keyfile'] = FLAGS.keyfile
+            if FLAGS.certfile is not None:
+                ssl_options['certfile'] = FLAGS.certfile
+            if FLAGS.cacerts is not None:
+                ssl_options['ca_certs'] = FLAGS.cacerts
+            ssl_context_factory = None
+            if FLAGS.insecure:
+                ssl_context_factory = gevent.ssl._create_unverified_context
             triton_client = httpclient.InferenceServerClient(
                 url=FLAGS.url,
                 verbose=FLAGS.verbose,
                 ssl=True,
-                ssl_context_factory=gevent.ssl._create_unverified_context,
-                insecure=True)
+                ssl_options=ssl_options,
+                insecure=FLAGS.insecure,
+                ssl_context_factory=ssl_context_factory)
         else:
             triton_client = httpclient.InferenceServerClient(
                 url=FLAGS.url, verbose=FLAGS.verbose)

--- a/src/python/examples/simple_http_infer_client.py
+++ b/src/python/examples/simple_http_infer_client.py
@@ -113,18 +113,18 @@ if __name__ == '__main__':
                         default=False,
                         help='Enable encrypted link to the server using HTTPS')
     parser.add_argument(
-        '--keyfile',
+        '--key-file',
         type=str,
         required=False,
         default=None,
         help='File holding client private key. Default is None.')
     parser.add_argument(
-        '--certfile',
+        '--cert-file',
         type=str,
         required=False,
         default=None,
         help='File holding client certificate. Default is None.')
-    parser.add_argument('--cacerts',
+    parser.add_argument('--ca-certs',
                         type=str,
                         required=False,
                         default=None,
@@ -166,12 +166,12 @@ if __name__ == '__main__':
     try:
         if FLAGS.ssl:
             ssl_options = {}
-            if FLAGS.keyfile is not None:
-                ssl_options['keyfile'] = FLAGS.keyfile
-            if FLAGS.certfile is not None:
-                ssl_options['certfile'] = FLAGS.certfile
-            if FLAGS.cacerts is not None:
-                ssl_options['ca_certs'] = FLAGS.cacerts
+            if FLAGS.key_file is not None:
+                ssl_options['keyfile'] = FLAGS.key_file
+            if FLAGS.cert_file is not None:
+                ssl_options['certfile'] = FLAGS.cert_file
+            if FLAGS.ca_certs is not None:
+                ssl_options['ca_certs'] = FLAGS.ca_certs
             ssl_context_factory = None
             if FLAGS.insecure:
                 ssl_context_factory = gevent.ssl._create_unverified_context


### PR DESCRIPTION
I have exposed decent SSL curl options in our HTTP  C++ client library to bring it upto the parity with python client and grpc library.
There are many other settings that can be exposed like loading a key from crypto engine etc. which most likely goes beyond the scope of the requirement. 

@matthewkotila  Look at the options exposed in `simple_http_infer_client.cc`. Something very similar needs to be done for the perf_analyzer to work with SSL settings.  

Tests are added here: https://github.com/triton-inference-server/server/pull/3862