### PR TITLE
Fix hang of turned off async threads

### DIFF
--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -320,6 +320,7 @@ ConcurrencyManager::Infer(
       wake_signal_.wait(lock, [&thread_config]() {
         return early_exit || (thread_config->concurrency_ > 0);
       });
+      if (early_exit) { break; }
     }
 
     size_t num_reqs = thread_config->concurrency_;


### PR DESCRIPTION
When running async with binary search, we could hang.  When we increase concurrency, we attempt to increase the number of threads (up to a max). When we decrease concurrency, we don't destroy threads, and we may end up with some threads responsible for 0 requests. For example, when we go to concurrency of 64, we create the max 16 threads, each of which is responsible for a concurrency of 4. If we then move down to concurrency of 12, then 12 of the threads are responsible for a concurrency of 1, and 4 of the threads are put to sleep.

When we finish the binary search, if we are in async mode and there are any threads responsible for 0 concurrency, they hang trying to shut down.

[This](https://github.com/triton-inference-server/client/blob/main/src/c%2B%2B/perf_analyzer/concurrency_manager.cc#L159) is the function that is assigned to each thread.
[Here](https://github.com/triton-inference-server/client/blob/main/src/c%2B%2B/perf_analyzer/concurrency_manager.cc#L320) is where the thread gets put to sleep if it has 0 concurrency
If it is woken up by early exit (the binary search is done), non-async cases would skip the rest of the code and [break](https://github.com/triton-inference-server/client/blob/main/src/c%2B%2B/perf_analyzer/concurrency_manager.cc#L505). 
However, async case will hit [this](https://github.com/triton-inference-server/client/blob/main/src/c%2B%2B/perf_analyzer/concurrency_manager.cc#L491) and hang.