### PR TITLE
Fix Async PA with binary search 

### DIFF
--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -320,7 +320,8 @@ ConcurrencyManager::Infer(
       wake_signal_.wait(lock, [&thread_config]() {
         return early_exit || (thread_config->concurrency_ > 0);
       });
-      if (early_exit) { break; }
+      // Stop executing if concurrency is 0 and early exit is requested 
+      if (early_exit && thread_config->concurrency_ == 0) { break; }
     }
 
     size_t num_reqs = thread_config->concurrency_;

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -320,6 +320,7 @@ ConcurrencyManager::Infer(
       wake_signal_.wait(lock, [&thread_config]() {
         return early_exit || (thread_config->concurrency_ > 0);
       });
+      if (early_exit) { break; }
     }
 
     size_t num_reqs = thread_config->concurrency_;


### PR DESCRIPTION
Fix async PA with binary search in concurrency mode. 
Server side test: https://github.com/triton-inference-server/server/pull/3982
Same as https://github.com/triton-inference-server/client/pull/66. 