### PR TITLE
Remove CurlGlobal Race Condition

### DIFF
--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -73,7 +73,9 @@ class CurlGlobal {
   }
 
  private:
-  CurlGlobal() : Error err_;
+  CurlGlobal();
+
+  Error err_;
 };
 
 CurlGlobal::CurlGlobal() : err_(Error::Success)

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -62,13 +62,18 @@ constexpr char kContentLengthHTTPHeader[] = "Content-Length";
 // perform this initialization.
 class CurlGlobal {
  public:
-  CurlGlobal();
   ~CurlGlobal();
 
   const Error& Status() const { return err_; }
 
+  static const CurlGlobal& Get()
+  {
+    static CurlGlobal* curl_global = new CurlGlobal();
+    return *curl_global;
+  }
+
  private:
-  Error err_;
+  CurlGlobal() : Error err_;
 };
 
 CurlGlobal::CurlGlobal() : err_(Error::Success)
@@ -83,7 +88,12 @@ CurlGlobal::~CurlGlobal()
   curl_global_cleanup();
 }
 
-static CurlGlobal curl_global;
+class CurlGlobalDestroyer {
+ public:
+  ~CurlGlobalDestroyer() { delete &CurlGlobal::Get(); }
+};
+
+static CurlGlobalDestroyer curl_global_destroyer_;
 
 std::string
 GetQueryString(const Headers& query_params)
@@ -1324,8 +1334,8 @@ InferenceServerHttpClient::Infer(
   sync_request->Timer().Reset();
   sync_request->Timer().CaptureTimestamp(RequestTimers::Kind::REQUEST_START);
 
-  if (!curl_global.Status().IsOk()) {
-    return curl_global.Status();
+  if (!CurlGlobal::Get().Status().IsOk()) {
+    return CurlGlobal::Get().Status();
   }
 
   err = PreRunProcessing(
@@ -1761,8 +1771,8 @@ InferenceServerHttpClient::Get(
     request_uri = request_uri + "?" + GetQueryString(query_params);
   }
 
-  if (!curl_global.Status().IsOk()) {
-    return curl_global.Status();
+  if (!CurlGlobal::Get().Status().IsOk()) {
+    return CurlGlobal::Get().Status();
   }
 
   CURL* curl = curl_easy_init();
@@ -1837,8 +1847,8 @@ InferenceServerHttpClient::Post(
     request_uri = request_uri + "?" + GetQueryString(query_params);
   }
 
-  if (!curl_global.Status().IsOk()) {
-    return curl_global.Status();
+  if (!CurlGlobal::Get().Status().IsOk()) {
+    return CurlGlobal::Get().Status();
   }
 
   CURL* curl = curl_easy_init();


### PR DESCRIPTION
Currently, the [static CurlGlobal curl_global](https://github.com/triton-inference-server/client/blob/27522b01698b71b3fdb7ebe90ffe88e962b82789/src/c%2B%2B/library/http_client.cc#L86) instance expects to be constructed after Error::Success, since the [CurlGlobal constructor](https://github.com/triton-inference-server/client/blob/27522b01698b71b3fdb7ebe90ffe88e962b82789/src/c%2B%2B/library/http_client.cc#L74) references [Error::Success](https://github.com/triton-inference-server/client/blob/27522b01698b71b3fdb7ebe90ffe88e962b82789/src/c%2B%2B/library/common.cc#L33).

This leads to a race condition in Centos7, as the two global objects sit in separate translation units, http_client.cc and common.cc. This PR merges a fix to make the CurlGlobal object a singleton, so it is always initialized before being used.