### PR TITLE
Support non-zero shm offset in tritonclient.utils.shared_memory

### DIFF
--- a/src/python/library/tritonclient/http/__init__.py
+++ b/src/python/library/tritonclient/http/__init__.py
@@ -1757,7 +1757,7 @@ class InferInput:
         self._parameters['shared_memory_region'] = region_name
         self._parameters['shared_memory_byte_size'] = byte_size
         if offset != 0:
-            self._parameters['shared_memory_offset'].int64_param = offset
+            self._parameters['shared_memory_offset'] = offset
 
     def _get_binary_data(self):
         """Returns the raw binary data if available


### PR DESCRIPTION
[Bug] Exception was raised when using offset !=0 in set_shared _memory of InferInput of Http client
https://github.com/triton-inference-server/server/issues/3986

[Feature] support offset for get_contents_as_numpy and set_shared_memory_region of shm lib
https://github.com/triton-inference-server/server/issues/3987