### PR TITLE
Soften grpcio requirement in python library

### DIFF
--- a/src/python/library/requirements/requirements_grpc.txt
+++ b/src/python/library/requirements/requirements_grpc.txt
@@ -28,6 +28,6 @@ protobuf>=3.5.0
 # There is memory leak in later Python GRPC (1.43.0 to be specific),
 # use known working version until the memory leak is resolved in the future
 # (see https://github.com/grpc/grpc/issues/28513)
-grpcio==1.41.0
+grpcio>=1.41.0
 numpy>=1.19.1
 python-rapidjson>=0.9.1

--- a/src/python/library/tritonclient/grpc/__init__.py
+++ b/src/python/library/tritonclient/grpc/__init__.py
@@ -38,6 +38,8 @@ except ModuleNotFoundError as error:
         'The installation does not include grpc support. Specify \'grpc\' or \'all\' while installing the tritonclient package to include the support'
     ) from error
 
+from packaging import version
+import warnings
 from tritonclient.grpc import model_config_pb2
 from tritonclient.grpc import service_pb2
 from tritonclient.grpc import service_pb2_grpc
@@ -50,6 +52,15 @@ from tritonclient.utils import *
 INT32_MAX = 2**(struct.Struct('i').size * 8 - 1) - 1
 MAX_GRPC_MESSAGE_SIZE = INT32_MAX
 
+# Check grpc version and issue warnings if grpc version is known to have
+# memory leakage issue.
+if version.parse(grpc.__version__) >= version.parse('1.43.0'):
+    warnings.warn(
+        f"Imported version of grpc is {grpc.__version__}. "
+        "There is memory leak in later Python GRPC (1.43.0 to be specific), "
+        "use known working version (such as 1.41.0) until the memory leak is resolved in the future."
+        "(see https://github.com/grpc/grpc/issues/28513)"
+    )
 
 def get_error_grpc(rpc_error):
     return InferenceServerException(


### PR DESCRIPTION
Show warning when the imported version has memory leakage issue, but do allow users to proceed on their own risk

As there are many packages depending on grpc, it is becoming exceedingly difficult to manage a pinned version. Also, depending on use case, memory leakage problem might be worked around if we regularly restart or otherwise manage servers and working nodes, which are often the case.