### PR TITLE
Expose custom GRPC ChannelArguments in client libraries (#104)

### DIFF
--- a/src/c++/examples/CMakeLists.txt
+++ b/src/c++/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -149,6 +149,20 @@ if(TRITON_ENABLE_CC_GRPC)
   )
   install(
     TARGETS simple_grpc_keepalive_client
+    RUNTIME DESTINATION bin
+  )
+
+  #
+  # simple_grpc_custom_args_client
+  #
+  add_executable(simple_grpc_custom_args_client simple_grpc_custom_args_client.cc)
+  target_link_libraries(
+    simple_grpc_custom_args_client
+    PRIVATE
+      grpcclient_static
+  )
+  install(
+    TARGETS simple_grpc_custom_args_client
     RUNTIME DESTINATION bin
   )
 

--- a/src/c++/examples/simple_grpc_custom_args_client.cc
+++ b/src/c++/examples/simple_grpc_custom_args_client.cc
@@ -1,0 +1,275 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <getopt.h>
+#include <unistd.h>
+#include <iostream>
+#include <string>
+#include "grpc_client.h"
+
+namespace tc = triton::client;
+
+#define FAIL_IF_ERR(X, MSG)                                        \
+  {                                                                \
+    tc::Error err = (X);                                           \
+    if (!err.IsOk()) {                                             \
+      std::cerr << "error: " << (MSG) << ": " << err << std::endl; \
+      exit(1);                                                     \
+    }                                                              \
+  }
+
+namespace {
+
+void
+ValidateShapeAndDatatype(
+    const std::string& name, std::shared_ptr<tc::InferResult> result)
+{
+  std::vector<int64_t> shape;
+  FAIL_IF_ERR(
+      result->Shape(name, &shape), "unable to get shape for '" + name + "'");
+  // Validate shape
+  if ((shape.size() != 2) || (shape[0] != 1) || (shape[1] != 16)) {
+    std::cerr << "error: received incorrect shapes for '" << name << "'"
+              << std::endl;
+    exit(1);
+  }
+  std::string datatype;
+  FAIL_IF_ERR(
+      result->Datatype(name, &datatype),
+      "unable to get datatype for '" + name + "'");
+  // Validate datatype
+  if (datatype.compare("INT32") != 0) {
+    std::cerr << "error: received incorrect datatype for '" << name
+              << "': " << datatype << std::endl;
+    exit(1);
+  }
+}
+
+void
+Usage(char** argv, const std::string& msg = std::string())
+{
+  if (!msg.empty()) {
+    std::cerr << "error: " << msg << std::endl;
+  }
+
+  std::cerr << "Usage: " << argv[0] << " [options]" << std::endl;
+  std::cerr << "\t-v" << std::endl;
+  std::cerr << "\t-m <model name>" << std::endl;
+  std::cerr << "\t-u <URL for inference service>" << std::endl;
+  std::cerr << "\t-t <client timeout in microseconds>" << std::endl;
+  std::cerr << "\t-H <HTTP header>" << std::endl;
+  std::cerr << std::endl;
+  std::cerr
+      << "For -H, header must be 'Header:Value'. May be given multiple times."
+      << std::endl;
+
+  exit(1);
+}
+
+}  // namespace
+
+int
+main(int argc, char** argv)
+{
+  bool verbose = false;
+  std::string url("localhost:8001");
+  tc::Headers http_headers;
+  uint32_t client_timeout = 0;
+  bool use_ssl = false;
+  tc::SslOptions ssl_options;
+  grpc::ChannelArguments channel_args;
+  // Set any valid grpc::ChannelArguments here based on use case
+  channel_args.SetMaxSendMessageSize(1024 * 1024);
+  channel_args.SetMaxReceiveMessageSize(1024 * 1024);
+  // Setting KeepAlive options using new generic channel arguments option
+  // https://grpc.github.io/grpc/cpp/md_doc_keepalive.html
+  channel_args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, INT_MAX);
+  channel_args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 20000);
+  channel_args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, false);
+  channel_args.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA, 2);
+  // Example arg requested for the feature
+  channel_args.SetInt(GRPC_ARG_DNS_ENABLE_SRV_QUERIES, 1);
+
+  // Parse commandline...
+  int opt;
+  while ((opt = getopt_long(argc, argv, "vu:t:H:C:", NULL, NULL)) != -1) {
+    switch (opt) {
+      case 'v':
+        verbose = true;
+        break;
+      case 'u':
+        url = optarg;
+        break;
+      case 't':
+        client_timeout = std::stoi(optarg);
+        break;
+      case 'H': {
+        std::string arg = optarg;
+        std::string header = arg.substr(0, arg.find(":"));
+        http_headers[header] = arg.substr(header.size() + 1);
+        break;
+      }
+      case '?':
+        Usage(argv);
+        break;
+    }
+  }
+
+  // We use a simple model that takes 2 input tensors of 16 integers
+  // each and returns 2 output tensors of 16 integers each. One output
+  // tensor is the element-wise sum of the inputs and one output is
+  // the element-wise difference.
+  std::string model_name = "simple";
+  std::string model_version = "";
+
+  // Create a InferenceServerGrpcClient instance to communicate with the
+  // server using gRPC protocol.
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
+  FAIL_IF_ERR(
+      tc::InferenceServerGrpcClient::Create(
+          &client, url, channel_args, verbose, use_ssl, ssl_options),
+      "unable to create grpc client");
+
+  // Create the data for the two input tensors. Initialize the first
+  // to unique integers and the second to all ones.
+  std::vector<int32_t> input0_data(16);
+  std::vector<int32_t> input1_data(16);
+  for (size_t i = 0; i < 16; ++i) {
+    input0_data[i] = i;
+    input1_data[i] = 1;
+  }
+
+  std::vector<int64_t> shape{1, 16};
+
+  // Initialize the inputs with the data.
+  tc::InferInput* input0;
+  tc::InferInput* input1;
+
+  FAIL_IF_ERR(
+      tc::InferInput::Create(&input0, "INPUT0", shape, "INT32"),
+      "unable to get INPUT0");
+  std::shared_ptr<tc::InferInput> input0_ptr;
+  input0_ptr.reset(input0);
+  FAIL_IF_ERR(
+      tc::InferInput::Create(&input1, "INPUT1", shape, "INT32"),
+      "unable to get INPUT1");
+  std::shared_ptr<tc::InferInput> input1_ptr;
+  input1_ptr.reset(input1);
+
+  FAIL_IF_ERR(
+      input0_ptr->AppendRaw(
+          reinterpret_cast<uint8_t*>(&input0_data[0]),
+          input0_data.size() * sizeof(int32_t)),
+      "unable to set data for INPUT0");
+  FAIL_IF_ERR(
+      input1_ptr->AppendRaw(
+          reinterpret_cast<uint8_t*>(&input1_data[0]),
+          input1_data.size() * sizeof(int32_t)),
+      "unable to set data for INPUT1");
+
+  // Generate the outputs to be requested.
+  tc::InferRequestedOutput* output0;
+  tc::InferRequestedOutput* output1;
+
+  FAIL_IF_ERR(
+      tc::InferRequestedOutput::Create(&output0, "OUTPUT0"),
+      "unable to get 'OUTPUT0'");
+  std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
+  output0_ptr.reset(output0);
+  FAIL_IF_ERR(
+      tc::InferRequestedOutput::Create(&output1, "OUTPUT1"),
+      "unable to get 'OUTPUT1'");
+  std::shared_ptr<tc::InferRequestedOutput> output1_ptr;
+  output1_ptr.reset(output1);
+
+
+  // The inference settings. Will be using default for now.
+  tc::InferOptions options(model_name);
+  options.model_version_ = model_version;
+  options.client_timeout_ = client_timeout;
+
+  std::vector<tc::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
+  std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get(),
+                                                          output1_ptr.get()};
+
+  tc::InferResult* results;
+  FAIL_IF_ERR(
+      client->Infer(&results, options, inputs, outputs, http_headers),
+      "unable to run model");
+  std::shared_ptr<tc::InferResult> results_ptr;
+  results_ptr.reset(results);
+
+  // Validate the results...
+  ValidateShapeAndDatatype("OUTPUT0", results_ptr);
+  ValidateShapeAndDatatype("OUTPUT1", results_ptr);
+
+  // Get pointers to the result returned...
+  int32_t* output0_data;
+  size_t output0_byte_size;
+  FAIL_IF_ERR(
+      results_ptr->RawData(
+          "OUTPUT0", (const uint8_t**)&output0_data, &output0_byte_size),
+      "unable to get result data for 'OUTPUT0'");
+  if (output0_byte_size != 64) {
+    std::cerr << "error: received incorrect byte size for 'OUTPUT0': "
+              << output0_byte_size << std::endl;
+    exit(1);
+  }
+
+  int32_t* output1_data;
+  size_t output1_byte_size;
+  FAIL_IF_ERR(
+      results_ptr->RawData(
+          "OUTPUT1", (const uint8_t**)&output1_data, &output1_byte_size),
+      "unable to get result data for 'OUTPUT1'");
+  if (output1_byte_size != 64) {
+    std::cerr << "error: received incorrect byte size for 'OUTPUT1': "
+              << output1_byte_size << std::endl;
+    exit(1);
+  }
+
+  for (size_t i = 0; i < 16; ++i) {
+    std::cout << input0_data[i] << " + " << input1_data[i] << " = "
+              << *(output0_data + i) << std::endl;
+    std::cout << input0_data[i] << " - " << input1_data[i] << " = "
+              << *(output1_data + i) << std::endl;
+
+    if ((input0_data[i] + input1_data[i]) != *(output0_data + i)) {
+      std::cerr << "error: incorrect sum" << std::endl;
+      exit(1);
+    }
+    if ((input0_data[i] - input1_data[i]) != *(output1_data + i)) {
+      std::cerr << "error: incorrect difference" << std::endl;
+      exit(1);
+    }
+  }
+
+  // Get full response
+  std::cout << results_ptr->DebugString() << std::endl;
+  std::cout << "PASS : CustomArgs" << std::endl;
+
+  return 0;
+}

--- a/src/c++/library/grpc_client.h
+++ b/src/c++/library/grpc_client.h
@@ -27,6 +27,7 @@
 
 /// \file
 
+#include <grpcpp/grpcpp.h>
 #include <queue>
 #include "common.h"
 #include "grpc_service.grpc.pb.h"
@@ -101,6 +102,8 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   ~InferenceServerGrpcClient();
 
   /// Create a client that can be used to communicate with the server.
+  /// This is the expected method for most users to create a GRPC client with
+  /// the options directly exposed Triton.
   /// \param client Returns a new InferenceServerGrpcClient object.
   /// \param server_url The inference server name and port.
   /// \param verbose If true generate verbose output when contacting
@@ -119,6 +122,32 @@ class InferenceServerGrpcClient : public InferenceServerClient {
       const std::string& server_url, bool verbose = false, bool use_ssl = false,
       const SslOptions& ssl_options = SslOptions(),
       const KeepAliveOptions& keepalive_options = KeepAliveOptions(),
+      const bool use_cached_channel = true);
+
+  /// Create a client that can be used to communicate with the server.
+  /// This method is available for advanced users who need to specify custom
+  /// grpc::ChannelArguments not exposed by Triton, at their own risk.
+  /// \param client Returns a new InferenceServerGrpcClient object.
+  /// \param channel_args Exposes user-defined grpc::ChannelArguments to
+  /// be set for the client. Triton assumes that the "channel_args" passed
+  /// to this method are correct and complete, and are set at the user's
+  /// own risk. For example, GRPC KeepAlive options may be specified directly
+  /// in this argument rather than passing a KeepAliveOptions object.
+  /// \param server_url The inference server name and port.
+  /// \param verbose If true generate verbose output when contacting
+  /// the inference server.
+  /// \param use_ssl If true use encrypted channel to the server.
+  /// \param ssl_options Specifies the files required for
+  /// SSL encryption and authorization.
+  /// \param use_cached_channel If false, a new channel is created for each
+  /// new client instance. When true, re-use old channels from cache for new
+  /// client instances. The default value is true.
+  /// \return Error object indicating success or failure.
+  static Error Create(
+      std::unique_ptr<InferenceServerGrpcClient>* client,
+      const std::string& server_url, const grpc::ChannelArguments& channel_args,
+      bool verbose = false, bool use_ssl = false,
+      const SslOptions& ssl_options = SslOptions(),
       const bool use_cached_channel = true);
 
   /// Contact the inference server and get its liveness.
@@ -508,7 +537,7 @@ class InferenceServerGrpcClient : public InferenceServerClient {
  private:
   InferenceServerGrpcClient(
       const std::string& url, bool verbose, bool use_ssl,
-      const SslOptions& ssl_options, const KeepAliveOptions& keepalive_options,
+      const SslOptions& ssl_options, const grpc::ChannelArguments& channel_args,
       const bool use_cached_channel);
 
   Error PreRunProcessing(

--- a/src/python/examples/CMakeLists.txt
+++ b/src/python/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -66,6 +66,8 @@ if(${TRITON_ENABLE_PYTHON_GRPC})
       simple_grpc_shm_client.py
       simple_grpc_shm_string_client.py
       simple_grpc_model_control.py
+      simple_grpc_keepalive_client.py
+      simple_grpc_custom_args_client.py
     DESTINATION python
   )
   if(${TRITON_ENABLE_GPU})

--- a/src/python/examples/simple_grpc_custom_args_client.py
+++ b/src/python/examples/simple_grpc_custom_args_client.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import numpy as np
+import sys
+
+import tritonclient.grpc as grpcclient
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v',
+                        '--verbose',
+                        action="store_true",
+                        required=False,
+                        default=False,
+                        help='Enable verbose output')
+    parser.add_argument('-u',
+                        '--url',
+                        type=str,
+                        required=False,
+                        default='localhost:8001',
+                        help='Inference server URL. Default is localhost:8001.')
+
+    FLAGS = parser.parse_args()
+    try:
+        # Example of setting custom GRPC ChannelArguments. Users can set any
+        # channel_args here at your own risk, Triton will assume they are
+        # correct and complete.
+        channel_args = [
+            # Define custom max message sizes: 1MB here is an arbitrary example.
+            ('grpc.max_send_message_length', 1024*1024),
+            ('grpc.max_receive_message_length', 1024*1024),
+            # Example of setting KeepAlive options through generic channel_args
+            ('grpc.keepalive_time_ms', 2**31-1),
+            ('grpc.keepalive_timeout_ms', 20000),
+            ('grpc.keepalive_permit_without_calls', False),
+            ('grpc.http2.max_pings_without_data', 2),
+            # Example arg requested for the feature
+            ('grpc.dns_enable_srv_queries', 1)
+        ]
+
+        triton_client = grpcclient.InferenceServerClient(
+            url=FLAGS.url,
+            verbose=FLAGS.verbose,
+            channel_args=channel_args
+        )
+    except Exception as e:
+        print("channel creation failed: " + str(e))
+        sys.exit()
+
+    model_name = "simple"
+
+    # Infer
+    inputs = []
+    outputs = []
+    inputs.append(grpcclient.InferInput('INPUT0', [1, 16], "INT32"))
+    inputs.append(grpcclient.InferInput('INPUT1', [1, 16], "INT32"))
+
+    # Create the data for the two input tensors. Initialize the first
+    # to unique integers and the second to all ones.
+    input0_data = np.arange(start=0, stop=16, dtype=np.int32)
+    input0_data = np.expand_dims(input0_data, axis=0)
+    input1_data = np.ones(shape=(1, 16), dtype=np.int32)
+
+    # Initialize the data
+    inputs[0].set_data_from_numpy(input0_data)
+    inputs[1].set_data_from_numpy(input1_data)
+
+    outputs.append(grpcclient.InferRequestedOutput('OUTPUT0'))
+    outputs.append(grpcclient.InferRequestedOutput('OUTPUT1'))
+
+    # Test with outputs
+    results = triton_client.infer(
+        model_name=model_name,
+        inputs=inputs,
+        outputs=outputs,
+        headers={'test': '1'})
+
+    # Get the output arrays from the results
+    output0_data = results.as_numpy('OUTPUT0')
+    output1_data = results.as_numpy('OUTPUT1')
+
+    for i in range(16):
+        print(
+            str(input0_data[0][i]) + " + " + str(input1_data[0][i]) + " = " +
+            str(output0_data[0][i]))
+        print(
+            str(input0_data[0][i]) + " - " + str(input1_data[0][i]) + " = " +
+            str(output1_data[0][i]))
+        if (input0_data[0][i] + input1_data[0][i]) != output0_data[0][i]:
+            print("sync infer error: incorrect sum")
+            sys.exit(1)
+        if (input0_data[0][i] - input1_data[0][i]) != output1_data[0][i]:
+            print("sync infer error: incorrect difference")
+            sys.exit(1)
+
+    print('PASS: CustomArgs')


### PR DESCRIPTION
* Add custom ChannelArguments parameter to grpc C++ client library for generic user-defined settings

* Add placeholder C++ example, followup on TODOs

* Add overloaded methods to accept grpc::ChannelArguments instead of KeepAliveOptions. Update cpp example to use new ChannelArguments for KeepAlive settings instead

* rename to channel_args, clang-format

* Expose channel_args option to python client for custom user-defined GRPC ChannelArguments

* Add python example of setting custom grpc channel arguments

* Add cached_channel param from merge conflict

* Add example channel argument requested for this feature

* update copyright

* Fix test name output typo

* Cleanup dupe constructors and GetStub per review comments

* Add new python example clients to install directory

* copyright

* remove extra line - review feedback