### PR TITLE
Update Protobuf Version Constraints

### DIFF
--- a/src/python/library/requirements/requirements_grpc.txt
+++ b/src/python/library/requirements/requirements_grpc.txt
@@ -26,8 +26,7 @@
 
 # Restrict maximum version due to breaking protobuf 4.21.0 changes
 # (see https://github.com/protocolbuffers/protobuf/issues/10051)
-# TODO: Update to be compatible wtih 4.0 release
-# https://jirasw.nvidia.com/browse/DLIS-3809
+# TODO: Update to be compatible with 4.0 release (DLIS-3809)
 protobuf>=3.5.0,<3.20
 # There is memory leak in later Python GRPC (1.43.0 to be specific),
 # use known working version until the memory leak is resolved in the future


### PR DESCRIPTION
Update protobuf version constraints to avoid latest breaking release (discussion here: https://github.com/protocolbuffers/protobuf/issues/10051).