### PR TITLE
Aggregate trial statistics

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -837,7 +837,6 @@ InferenceProfiler::MergePerfStatusReports(
   summary_status.client_stats.completed_count = 0;
   summary_status.stabilizing_latency_ns = 0;
 
-
   std::vector<ServerSideStats> server_side_stats;
   for (auto& perf_status : perf_status_reports) {
     // Aggregated Client Stats

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -298,11 +298,11 @@ class InferenceProfiler {
       bool* meets_threshold);
 
   /// Similar to above function, but instead of setting the concurrency, it
-  /// sets the specified request rate for measurements. \param request_rate
-  /// The request rate for inferences. \param summary Appends the
-  /// measurements summary at the end of this list. \param meets_threshold
-  /// Returns whether the setting meets the threshold. \return cb::Error
-  /// object indicating success or failure.
+  /// sets the specified request rate for measurements.
+  /// \param request_rate The request rate for inferences.
+  /// \param summary Appends the measurements summary at the end of this list.
+  /// \param meets_threshold Returns whether the setting meets the threshold.
+  /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
       const double request_rate, std::vector<PerfStatus>& summary,
       bool* meets_threshold);

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -297,9 +297,6 @@ class InferenceProfiler {
       const size_t concurrent_request_count, std::vector<PerfStatus>& summary,
       bool* meets_threshold);
 
-  cb::Error MergePerfStatusReports(
-      std::deque<PerfStatus>& perf_status, PerfStatus& summary_status);
-
   /// Similar to above function, but instead of setting the concurrency, it
   /// sets the specified request rate for measurements. \param request_rate
   /// The request rate for inferences. \param summary Appends the
@@ -450,6 +447,24 @@ class InferenceProfiler {
   /// \param current_rank_stability The stability of the current rank.
   /// \return True if all MPI ranks are stable.
   bool AllMPIRanksAreStable(bool current_rank_stability);
+
+  /// Merge individual perf status reports into a single perf status.  This
+  /// function is used to merge the results from multiple Measure runs into a
+  /// single report.
+  /// \param perf_status List of perf status reports to be merged.
+  /// \param summary_status Final merged summary status.
+  /// \return cb::Error object indicating success or failure.
+  cb::Error MergePerfStatusReports(
+      std::deque<PerfStatus>& perf_status, PerfStatus& summary_status);
+
+  /// Merge individual server side statistics into a single server side report.
+  /// \param server_side_stats List of server side statistics reports to be
+  /// merged.
+  /// \param server_side_summary Final merged summary status.
+  /// \return cb::Error object indicating success or failure.
+  cb::Error MergeServerSideStats(
+      std::vector<ServerSideStats>& server_side_stats,
+      ServerSideStats& server_side_summary);
 
   bool verbose_;
   uint64_t measurement_window_ms_;

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -82,6 +82,15 @@ SignalHandler(int signum)
 //     specified, the selected percentile value will be reported instead of
 //     average value.
 //
+// Perf Analyzer determines the stability of throughput and latency by observing
+// observing measurements in different trials. If the latency and throughput,
+// are within the stability percentage (see --stability-percentage option) Perf
+// Analyzer will report the average of the throughput and latency numbers
+// observed in the last three trials. All the measurements gathered during the
+// last three trials is aggregated to generate a single report. The number of
+// total requests is the sum of all the requests in the individual measurement
+// windows.
+//
 // There are broadly three ways to load server for the data collection using
 // perf_analyzer:
 // - Maintaining Target Concurrency:
@@ -172,8 +181,7 @@ SignalHandler(int signum)
 // --concurrency-range: The range of concurrency levels perf_analyzer will use.
 //    A concurrency level indicates the number of concurrent requests in queue.
 // --request-rate-range: The range of request rates perf_analyzer will use to
-// load
-//    the server.
+//    load the server.
 // --request-intervals: File containing time intervals (in microseconds) to use
 //    between successive requests.
 // --latency-threshold: latency threshold in msec.
@@ -181,7 +189,7 @@ SignalHandler(int signum)
 // --async: Enables Asynchronous inference calls.
 // --binary-search: Enables binary search within the specified range.
 // --request-distribution: Allows user to specify the distribution for selecting
-//     the time intervals between the request dispatch.
+//    the time intervals between the request dispatch.
 //
 // For detail of the options not listed, please refer to the usage.
 //
@@ -483,7 +491,10 @@ Usage(char** argv, const std::string& msg = std::string())
              "latency measurements when determining if a result is stable. The "
              "measurement is considered as stable if the recent 3 measurements "
              "are within +/- (stability percentage)% of their average in terms "
-             "of both infer per second and latency. Default is 10(%).",
+             "of both infer per second and latency. When perf analyzer "
+             "determines that the measurements are stable, it returns average "
+             "of the measurements collected in the last 3 windows. Default is "
+             "10(%).",
              18)
       << std::endl;
   std::cerr << FormatMessage(

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -83,13 +83,12 @@ SignalHandler(int signum)
 //     average value.
 //
 // Perf Analyzer determines the stability of throughput and latency by observing
-// observing measurements in different trials. If the latency and throughput,
-// are within the stability percentage (see --stability-percentage option) Perf
-// Analyzer will report the average of the throughput and latency numbers
-// observed in the last three trials. All the measurements gathered during the
-// last three trials is aggregated to generate a single report. The number of
-// total requests is the sum of all the requests in the individual measurement
-// windows.
+// measurements in different trials. If the latency and throughput, are within
+// the stability percentage (see --stability-percentage option) Perf Analyzer
+// will report the average of the throughput and latency numbers observed in the
+// last three trials. All the measurements gathered during the last three trials
+// is aggregated to generate a single report. The number of total requests is
+// the sum of all the requests in the individual measurement windows.
 //
 // There are broadly three ways to load server for the data collection using
 // perf_analyzer:


### PR DESCRIPTION
Aggregate trial statistics to report the average of trials instead of reporting the last trial.

## After

### Ensemble Model
#### PA Output
```
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Pass [1] throughput: 269.4 infer/sec. Avg latency: 3705 usec (std 220 usec)
  Pass [2] throughput: 267.4 infer/sec. Avg latency: 3733 usec (std 239 usec)
  Pass [3] throughput: 268.6 infer/sec. Avg latency: 3714 usec (std 228 usec)
  Client:
    Request count: 4027
    Throughput: 268.467 infer/sec
    Avg latency: 3717 usec (standard deviation 229 usec)
    p50 latency: 3736 usec
    p90 latency: 3983 usec
    p95 latency: 4010 usec
    p99 latency: 4049 usec
    Avg HTTP time: 3699 usec (send 148 usec + response wait 3550 usec + receive 1 usec)
  Server:
    Inference count: 4809
    Execution count: 4809
    Successful request count: 4809
    Avg request latency: 3089 usec (overhead 297 usec + queue 188 usec + compute 2604 usec)

  Composing models:
  add_sub_1, version:
      Inference count: 4809
      Execution count: 4809
      Successful request count: 4809
      Avg request latency: 1505 usec (overhead 167 usec + queue 87 usec + compute input 165 usec + compute infer 797 usec + compute output 288 usec)

  add_sub_2, version:
      Inference count: 4809
      Execution count: 4809
      Successful request count: 4809
      Avg request latency: 1624 usec (overhead 170 usec + queue 101 usec + compute input 164 usec + compute infer 813 usec + compute output 375 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 268.467 infer/sec, latency 3717 usec
```

#### Verbose CSV
```
Concurrency,Inferences/Second,Client Send,Network+Server Send/Recv,Server Queue,Server Compute Input,Server Compute Infer,Server Compute Output,Client Recv,p50 latency,p90 latency,p95 latency,p99 latency,Avg latency,request/response,response wait
1,268.467,148,956,6,330,1610,664,1,3736,3983,4010,4049,3717,149,3550
```
### Sequence Model
#### PA Output

```
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using asynchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Pass [1] throughput: 1546 infer/sec. Avg latency: 625 usec (std 37 usec)
  Pass [2] throughput: 1525.6 infer/sec. Avg latency: 632 usec (std 40 usec)
  Pass [3] throughput: 1512.8 infer/sec. Avg latency: 636 usec (std 55 usec)
  Client:
    Request count: 22922
    Sequence count: 1144 (76.2667 seq/sec)
    Throughput: 1528.13 infer/sec
    Avg latency: 631 usec (standard deviation 45 usec)
    p50 latency: 625 usec
    p90 latency: 653 usec
    p95 latency: 694 usec
    p99 latency: 825 usec
    Avg HTTP time: 596 usec (send 34 usec + response wait 562 usec + receive 0 usec)
  Server:
    Inference count: 27542
    Execution count: 27542
    Successful request count: 27542
    Avg request latency: 277 usec (overhead 57 usec + queue 58 usec + compute input 66 usec + compute infer 74 usec + compute output 21 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 1528.13 infer/sec, latency 631 usec
```

#### Verbose CSV
```
Concurrency,Inferences/Second,Client Send,Network+Server Send/Recv,Server Queue,Server Compute Input,Server Compute Infer,Server Compute Output,Client Recv,p50 latency,p90 latency,p95 latency,p99 latency,Avg latency,request/response,response wait
1,1528.13,34,376,58,66,74,21,0,625,653,694,825,631,34,562
```
### Normal Model
#### PA Output
```
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Pass [1] throughput: 489.8 infer/sec. Avg latency: 2033 usec (std 206 usec)
  Pass [2] throughput: 486 infer/sec. Avg latency: 2050 usec (std 172 usec)
  Pass [3] throughput: 490.8 infer/sec. Avg latency: 2030 usec (std 200 usec)
  Client:
    Request count: 7333
    Throughput: 488.867 infer/sec
    Avg latency: 2038 usec (standard deviation 194 usec)
    p50 latency: 2090 usec
    p90 latency: 2236 usec
    p95 latency: 2279 usec
    p99 latency: 2342 usec
    Avg HTTP time: 2000 usec (send 142 usec + response wait 1857 usec + receive 1 usec)
  Server:
    Inference count: 8806
    Execution count: 8806
    Successful request count: 8806
    Avg request latency: 1395 usec (overhead 167 usec + queue 80 usec + compute input 157 usec + compute infer 785 usec + compute output 206 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 488.867 infer/sec, latency 2038 usec
```
#### Verbose CSV
```
Concurrency,Inferences/Second,Client Send,Network+Server Send/Recv,Server Queue,Server Compute Input,Server Compute Infer,Server Compute Output,Client Recv,p50 latency,p90 latency,p95 latency,p99 latency,Avg latency,request/response,response wait
1,488.867,142,664,80,157,785,206,1,2090,2236,2279,2342,2038,143,1857
```
## Before
### Ensemble Model

#### PA Output
```
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Pass [1] throughput: 269.8 infer/sec. Avg latency: 3697 usec (std 230 usec)
  Pass [2] throughput: 266.8 infer/sec. Avg latency: 3739 usec (std 271 usec)
  Pass [3] throughput: 269.4 infer/sec. Avg latency: 3703 usec (std 267 usec)
  Client:
    Request count: 1347
    Throughput: 269.4 infer/sec
    Avg latency: 3703 usec (standard deviation 267 usec)
    p50 latency: 3740 usec
    p90 latency: 3986 usec
    p95 latency: 4005 usec
    p99 latency: 4070 usec
    Avg HTTP time: 3671 usec (send 141 usec + response wait 3529 usec + receive 1 usec)
  Server:
    Inference count: 1616
    Execution count: 1616
    Successful request count: 1616
    Avg request latency: 3075 usec (overhead 294 usec + queue 190 usec + compute 2591 usec)

  Composing models:
  add_sub_1, version:
      Inference count: 1616
      Execution count: 1616
      Successful request count: 1616
      Avg request latency: 1492 usec (overhead 166 usec + queue 88 usec + compute input 164 usec + compute infer 787 usec + compute output 286 usec)

  add_sub_2, version:
      Inference count: 1616
      Execution count: 1616
      Successful request count: 1616
      Avg request latency: 1622 usec (overhead 167 usec + queue 102 usec + compute input 164 usec + compute infer 815 usec + compute output 374 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 269.4 infer/sec, latency 3703 usec
```
#### Verbose CSV

```
Concurrency,Inferences/Second,Client Send,Network+Server Send/Recv,Server Queue,Server Compute Input,Server Compute Infer,Server Compute Output,Client Recv,p50 latency,p90 latency,p95 latency,p99 latency,Avg latency,request/response,response wait
1,269.4,141,962,6,328,1603,660,1,3740,3986,4005,4070,3703,142,3529
```

### Sequence Model
#### PA Output
```
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using asynchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Pass [1] throughput: 1541.8 infer/sec. Avg latency: 626 usec (std 33 usec)
  Pass [2] throughput: 1515.2 infer/sec. Avg latency: 636 usec (std 51 usec)
  Pass [3] throughput: 1510.4 infer/sec. Avg latency: 638 usec (std 49 usec)
  Client:
    Request count: 7552
    Sequence count: 379 (75.8 seq/sec)
    Throughput: 1510.4 infer/sec
    Avg latency: 638 usec (standard deviation 49 usec)
    p50 latency: 628 usec
    p90 latency: 677 usec
    p95 latency: 710 usec
    p99 latency: 877 usec
    Avg HTTP time: 601 usec (send 36 usec + response wait 565 usec + receive 0 usec)
  Server:
    Inference count: 9071
    Execution count: 9071
    Successful request count: 9071
    Avg request latency: 278 usec (overhead 58 usec + queue 59 usec + compute input 65 usec + compute infer 74 usec + compute output 21 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 1510.4 infer/sec, latency 638 usec
```
#### Verbose CSV
```
Concurrency,Inferences/Second,Client Send,Network+Server Send/Recv,Server Queue,Server Compute Input,Server Compute Infer,Server Compute Output,Client Recv,p50 latency,p90 latency,p95 latency,p99 latency,Avg latency,request/response,response wait
1,1510.4,36,380,59,65,74,21,0,628,677,710,877,638,36,565
```

### Normal Model
#### PA Output
```
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Pass [1] throughput: 492 infer/sec. Avg latency: 2024 usec (std 212 usec)
  Pass [2] throughput: 490.8 infer/sec. Avg latency: 2030 usec (std 174 usec)
  Pass [3] throughput: 495 infer/sec. Avg latency: 2012 usec (std 212 usec)
  Client:
    Request count: 2475
    Throughput: 495 infer/sec
    Avg latency: 2012 usec (standard deviation 212 usec)
    p50 latency: 2063 usec
    p90 latency: 2221 usec
    p95 latency: 2272 usec
    p99 latency: 2332 usec
    Avg HTTP time: 1978 usec (send 141 usec + response wait 1836 usec + receive 1 usec)
  Server:
    Inference count: 2969
    Execution count: 2969
    Successful request count: 2969
    Avg request latency: 1376 usec (overhead 165 usec + queue 79 usec + compute input 156 usec + compute infer 772 usec + compute output 204 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 495 infer/sec, latency 2012 usec
```
#### Verbose CSV
```
Concurrency,Inferences/Second,Client Send,Network+Server Send/Recv,Server Queue,Server Compute Input,Server Compute Infer,Server Compute Output,Client Recv,p50 latency,p90 latency,p95 latency,p99 latency,Avg latency,request/response,response wait
1,495,141,656,79,156,772,204,1,2063,2221,2272,2332,2012,142,1836
```