### PR TITLE
Only merge the results if they are stable

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -702,7 +702,11 @@ InferenceProfiler::ProfileHelper(
       error.pop();
     }
   }
-  RETURN_IF_ERROR(MergePerfStatusReports(perf_status, status_summary));
+
+  // Only merge the results if the results have stabilized.
+  if (*is_stable) {
+    RETURN_IF_ERROR(MergePerfStatusReports(perf_status, status_summary));
+  }
 
   if (early_exit) {
     return cb::Error("Received exit signal.");
@@ -793,11 +797,6 @@ cb::Error
 InferenceProfiler::MergePerfStatusReports(
     std::deque<PerfStatus>& perf_status_reports, PerfStatus& summary_status)
 {
-  if (perf_status_reports.size() != load_parameters_.stability_window) {
-    return cb::Error(
-        "Perf Status reports size must match the stability window.");
-  }
-
   auto& perf_status = perf_status_reports[0];
 
   // Make sure that the perf status reports profiling settings match with each


### PR DESCRIPTION
Before:
```
root@itabrizian-dt:/opt/tritonserver/qa/L0_perf_nomodel# perf_analyzer -m identity_fp32 --shape INPUT0:1 -r 1
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
Perf Status reports size must match the stability window.
```
After:

```
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
Failed to obtain stable measurement within 1 measurement windows for concurrency 1. Please try to increase the --measurement-interval.
```