### PR TITLE
Add bfloat to client utils

### DIFF
--- a/src/python/library/requirements/requirements.txt
+++ b/src/python/library/requirements/requirements.txt
@@ -26,3 +26,4 @@
 
 numpy>=1.19.1
 python-rapidjson>=0.9.1
+bfloat16>=1.1

--- a/src/python/library/requirements/requirements_grpc.txt
+++ b/src/python/library/requirements/requirements_grpc.txt
@@ -34,3 +34,4 @@ protobuf>=3.5.0,<3.20
 grpcio==1.41.0
 numpy>=1.19.1
 python-rapidjson>=0.9.1
+bfloat16>=1.1

--- a/src/python/library/requirements/requirements_http.txt
+++ b/src/python/library/requirements/requirements_http.txt
@@ -27,3 +27,4 @@
 geventhttpclient>=1.4.4
 numpy>=1.19.1
 python-rapidjson>=0.9.1
+bfloat16>=1.1

--- a/src/python/library/tritonclient/utils/__init__.py
+++ b/src/python/library/tritonclient/utils/__init__.py
@@ -125,6 +125,7 @@ class InferenceServerException(Exception):
 
 
 def np_to_triton_dtype(np_dtype):
+    from bfloat16 import bfloat16
     if np_dtype == bool:
         return "BOOL"
     elif np_dtype == np.int8:
@@ -149,12 +150,15 @@ def np_to_triton_dtype(np_dtype):
         return "FP32"
     elif np_dtype == np.float64:
         return "FP64"
+    elif np_dtype == bfloat16:
+        return "BF16"
     elif np_dtype == np.object_ or np_dtype.type == np.bytes_:
         return "BYTES"
     return None
 
 
 def triton_to_np_dtype(dtype):
+    from bfloat16 import bfloat16
     if dtype == "BOOL":
         return bool
     elif dtype == "INT8":
@@ -175,6 +179,8 @@ def triton_to_np_dtype(dtype):
         return np.uint64
     elif dtype == "FP16":
         return np.float16
+    elif dtype == "BF16":
+        return bfloat16
     elif dtype == "FP32":
         return np.float32
     elif dtype == "FP64":

--- a/src/python/library/tritonclient/utils/__init__.py
+++ b/src/python/library/tritonclient/utils/__init__.py
@@ -152,6 +152,13 @@ def np_to_triton_dtype(np_dtype):
     elif np_dtype == np.object_ or np_dtype.type == np.bytes_:
         return "BYTES"
     elif (str(np_dtype) == "<class 'bfloat16'>"):
+    # Assumed bfloat16 package in use: https://pypi.org/project/bfloat16/
+    # Code is avoiding import requirement due known incompatability issue
+    # between this package and tensorflow: 
+    # https://github.com/GreenWaves-Technologies/bfloat16/issues/2
+    # 
+    # Can clean up code when numpy officially supports bfloat16
+    # https://github.com/numpy/numpy/issues/19808
         if np_dtype == bfloat16:
             return "BF16"
     return None

--- a/src/python/library/tritonclient/utils/__init__.py
+++ b/src/python/library/tritonclient/utils/__init__.py
@@ -152,13 +152,14 @@ def np_to_triton_dtype(np_dtype):
     elif np_dtype == np.object_ or np_dtype.type == np.bytes_:
         return "BYTES"
     elif (str(np_dtype) == "<class 'bfloat16'>"):
-    # Assumed bfloat16 package in use: https://pypi.org/project/bfloat16/
-    # Code is avoiding import requirement due known incompatability issue
-    # between this package and tensorflow: 
-    # https://github.com/GreenWaves-Technologies/bfloat16/issues/2
-    # 
-    # Can clean up code when numpy officially supports bfloat16
-    # https://github.com/numpy/numpy/issues/19808
+        from bfloat16 import bfloat16
+        # Assumed bfloat16 package in use: https://pypi.org/project/bfloat16/
+        # Code is avoiding import requirement due known incompatability issue
+        # between this package and tensorflow: 
+        # https://github.com/GreenWaves-Technologies/bfloat16/issues/2
+        # 
+        # Can clean up code when numpy officially supports bfloat16
+        # https://github.com/numpy/numpy/issues/19808
         if np_dtype == bfloat16:
             return "BF16"
     return None

--- a/src/python/library/tritonclient/utils/__init__.py
+++ b/src/python/library/tritonclient/utils/__init__.py
@@ -125,7 +125,6 @@ class InferenceServerException(Exception):
 
 
 def np_to_triton_dtype(np_dtype):
-    from bfloat16 import bfloat16
     if np_dtype == bool:
         return "BOOL"
     elif np_dtype == np.int8:
@@ -150,15 +149,15 @@ def np_to_triton_dtype(np_dtype):
         return "FP32"
     elif np_dtype == np.float64:
         return "FP64"
-    elif np_dtype == bfloat16:
-        return "BF16"
     elif np_dtype == np.object_ or np_dtype.type == np.bytes_:
         return "BYTES"
+    elif (str(np_dtype) == "<class 'bfloat16'>"):
+        if np_dtype == bfloat16:
+            return "BF16"
     return None
 
 
 def triton_to_np_dtype(dtype):
-    from bfloat16 import bfloat16
     if dtype == "BOOL":
         return bool
     elif dtype == "INT8":
@@ -180,6 +179,7 @@ def triton_to_np_dtype(dtype):
     elif dtype == "FP16":
         return np.float16
     elif dtype == "BF16":
+        from bfloat16 import bfloat16
         return bfloat16
     elif dtype == "FP32":
         return np.float32

--- a/src/python/library/tritonclient/utils/__init__.py
+++ b/src/python/library/tritonclient/utils/__init__.py
@@ -123,6 +123,13 @@ class InferenceServerException(Exception):
         """
         return self._debug_details
 
+def import_bfloat16():
+    try:
+        from bfloat16 import bfloat16
+    except:
+        print("ERROR: bfloat16 package is required, please install it: <pip install bfloat16>")
+        return False
+    return True
 
 def np_to_triton_dtype(np_dtype):
     if np_dtype == bool:
@@ -152,7 +159,6 @@ def np_to_triton_dtype(np_dtype):
     elif np_dtype == np.object_ or np_dtype.type == np.bytes_:
         return "BYTES"
     elif (str(np_dtype) == "<class 'bfloat16'>"):
-        from bfloat16 import bfloat16
         # Assumed bfloat16 package in use: https://pypi.org/project/bfloat16/
         # Code is avoiding import requirement due known incompatability issue
         # between this package and tensorflow: 
@@ -160,7 +166,7 @@ def np_to_triton_dtype(np_dtype):
         # 
         # Can clean up code when numpy officially supports bfloat16
         # https://github.com/numpy/numpy/issues/19808
-        if np_dtype == bfloat16:
+        if import_bfloat16() and np_dtype == bfloat16:
             return "BF16"
     return None
 
@@ -187,8 +193,10 @@ def triton_to_np_dtype(dtype):
     elif dtype == "FP16":
         return np.float16
     elif dtype == "BF16":
-        from bfloat16 import bfloat16
-        return bfloat16
+        if import_bfloat16():
+            return bfloat16
+        else:
+            return None
     elif dtype == "FP32":
         return np.float32
     elif dtype == "FP64":


### PR DESCRIPTION
Add bfloat16 library to client utils. 
Server PR to put bfloat16 pip library into SDK container: https://github.com/triton-inference-server/server/pull/4521