### PR TITLE
Improve server side and client side metrics collection

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -984,9 +984,10 @@ InferenceProfiler::Measure(
   uint64_t window_start_ns = previous_window_end_ns_;
   start_stat = prev_client_side_stats_;
   start_status = prev_server_side_stats_;
-
+  
   // Set current window start time to end of previous window. For first
-  // measurement window, capture start time.
+  // measurement window, capture start time, server side stats, and client side
+  // stats.
   if (window_start_ns == 0) {
     window_start_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
                           std::chrono::system_clock::now().time_since_epoch())

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1017,15 +1017,15 @@ InferenceProfiler::Measure(
           .count();
   previous_window_end_ns_ = window_end_ns;
 
-  RETURN_IF_ERROR(manager_->GetAccumulatedClientStat(&end_stat));
-  prev_client_side_stats_ = end_stat;
-
   // Get server status and then print report on difference between
   // before and after status.
   if (include_server_stats_) {
     RETURN_IF_ERROR(GetServerSideStatus(&end_status));
     prev_server_side_stats_ = end_status;
   }
+
+  RETURN_IF_ERROR(manager_->GetAccumulatedClientStat(&end_stat));
+  prev_client_side_stats_ = end_stat;
 
   TimestampVector current_timestamps;
   RETURN_IF_ERROR(manager_->SwapTimestamps(current_timestamps));

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -981,13 +981,12 @@ InferenceProfiler::Measure(
   cb::InferStat start_stat;
   cb::InferStat end_stat;
 
-  uint64_t window_start_ns = previous_window_end_ns_;
-  start_stat = prev_client_side_stats_;
-  start_status = prev_server_side_stats_;
-  
   // Set current window start time to end of previous window. For first
   // measurement window, capture start time, server side stats, and client side
   // stats.
+  uint64_t window_start_ns = previous_window_end_ns_;
+  start_stat = prev_client_side_stats_;
+  start_status = prev_server_side_stats_;
   if (window_start_ns == 0) {
     window_start_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
                           std::chrono::system_clock::now().time_since_epoch())

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -534,6 +534,12 @@ class InferenceProfiler {
   /// The end time of the previous measurement window
   uint64_t previous_window_end_ns_;
 
+  /// Previous server side statistics
+  std::map<cb::ModelIdentifier, cb::ModelStatistics> prev_server_side_stats_;
+
+  /// Previous client side statistics
+  cb::InferStat prev_client_side_stats_;
+
 #ifndef DOCTEST_CONFIG_DISABLE
   friend TestInferenceProfiler;
 

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -534,10 +534,10 @@ class InferenceProfiler {
   /// The end time of the previous measurement window
   uint64_t previous_window_end_ns_;
 
-  /// Previous server side statistics
+  /// Server side statistics from the previous measurement window
   std::map<cb::ModelIdentifier, cb::ModelStatistics> prev_server_side_stats_;
 
-  /// Previous client side statistics
+  /// Client side statistics from the previous measurement window
   cb::InferStat prev_client_side_stats_;
 
 #ifndef DOCTEST_CONFIG_DISABLE


### PR DESCRIPTION
After:

```
 /opt/tritonserver/bin/perf_analyzer -m identity_fp32 --shape INPUT0:1 -t 32 -f my_file.csv
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 32
  Client:
    Request count: 30
    Throughput: 1.66619 infer/sec
    Avg latency: 17695686 usec (standard deviation 0 usec)
    p50 latency: 19260511 usec
    p90 latency: 19261207 usec
    p95 latency: 19261332 usec
    p99 latency: 19261533 usec
    Avg HTTP time: 17695644 usec (send/recv 2037 usec + response wait 17693607 usec)
  Server:
    Inference count: 30
    Execution count: 30
    Successful request count: 30
    Avg request latency: 17691933 usec (overhead 99 usec + queue 17090118 usec + compute input 134 usec + compute infer 601361 usec + compute output 220 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 32, throughput: 1.66619 infer/sec, latency 17695686 usec
```

Before:

```
/opt/tritonserver/bin/perf_analyzer -m identity_fp32 --shape INPUT0:1 -t 32 -f my_file.csv
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 32
  Client:
    Request count: 30
    Throughput: 1.66587 infer/sec
    Avg latency: 17696562 usec (standard deviation 0 usec)
    p50 latency: 19260674 usec
    p90 latency: 19261328 usec
    p95 latency: 19261484 usec
    p99 latency: 19262457 usec
    Avg HTTP time: 17696519 usec (send/recv 2781 usec + response wait 17693738 usec)
  Server:
    Inference count: 30
    Execution count: 30
    Successful request count: 30
    Avg request latency: 17691667 usec (overhead 106 usec + queue 17089849 usec + compute input 136 usec + compute infer 601355 usec + compute output 220 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 32, throughput: 1.66587 infer/sec, latency 17696562 usec
```

The report doesn't look very different and I was not able to find a case where this leads to the warning being printed. Looks like all the warning I observed in the CI were related to the C-API. There is a known issue with the C-API that the queueing time is incorrect.

Having said that, the standard deviation of zero looks strange. I have filed a follow up ticket for it.