### PR TITLE
Fix perf analyzer CAPI request lifecycle

### DIFF
--- a/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.cc
+++ b/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.cc
@@ -42,7 +42,7 @@
 namespace triton { namespace perfanalyzer { namespace clientbackend {
 namespace tritoncapi {
 namespace {
-bool enforce_memory_type = false;
+
 TRITONSERVER_MemoryType requested_memory_type;
 bool helper_verbose = false;
 /// Helper function for allocating memory
@@ -70,20 +70,8 @@ ResponseAlloc(
     }
   } else {
     void* allocated_ptr = nullptr;
-    if (enforce_memory_type) {
-      *actual_memory_type = requested_memory_type;
-    }
-
-    switch (*actual_memory_type) {
-      // Use CPU memory if the requested memory type is unknown
-      // (default case).
-      case TRITONSERVER_MEMORY_CPU:
-      default: {
-        *actual_memory_type = TRITONSERVER_MEMORY_CPU;
-        allocated_ptr = malloc(byte_size);
-        break;
-      }
-    }
+    *actual_memory_type = TRITONSERVER_MEMORY_CPU;
+    allocated_ptr = malloc(byte_size);
 
     // Pass the tensor name with buffer_userp so we can show it when
     // releasing the buffer.
@@ -138,8 +126,7 @@ void
 InferRequestComplete(
     TRITONSERVER_InferenceRequest* request, const uint32_t flags, void* userp)
 {
-  // request is deleted at the end of the Infer call so don't need to do
-  // anything here
+  TritonLoader::DeleteInferRequest(request);
 }
 
 
@@ -955,9 +942,6 @@ TritonLoader::Infer(
   RETURN_IF_TRITONSERVER_ERROR(
       GetSingleton()->inference_response_delete_fn_(completed_response),
       "deleting inference response");
-  RETURN_IF_TRITONSERVER_ERROR(
-      GetSingleton()->request_delete_fn_(irequest),
-      "deleting inference request");
   RETURN_IF_TRITONSERVER_ERROR(
       GetSingleton()->response_allocator_delete_fn_(allocator),
       "deleting response allocator");

--- a/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.h
+++ b/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.h
@@ -119,6 +119,11 @@ class TritonLoader : public tc::InferenceServerClient {
 
   static bool ModelIsLoaded() { return GetSingleton()->model_is_loaded_; }
   static bool ServerIsReady() { return GetSingleton()->server_is_ready_; }
+  static TRITONSERVER_Error* DeleteInferRequest(
+      TRITONSERVER_InferenceRequest* irequest)
+  {
+    return GetSingleton()->request_delete_fn_(irequest);
+  }
 
   // TRITONSERVER_ApiVersion
   typedef TRITONSERVER_Error* (*TritonServerApiVersionFn_t)(


### PR DESCRIPTION
The request object was released as soon as a response is received. This lead to a segfault if the backend wants to still use the inference request object for metrics reporting. This seems to have resolved crazy queue time values that was observed in the C-API too.

Before:

```
 USING C API: only default functionalities supported
OpenLibraryHandle: /opt/tritonserver/lib/libtritonserver.so
server is alive!
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using p95 latency

Request concurrency: 1
Segmentation fault (core dumped)
0704 20:04:16.679908 6192 pb_stub.cc:1006] Non-graceful termination detected.
```

After:

```
/opt/tritonserver/bin/perf_analyzer -v -p5000 -s5.0 --percentile=95 --shared-memory '"none"' -m python_zero_1_float32 -b1 -t1 --shape INPUT0:1 --service-kind triton_c_api --triton-server-directory /opt/tritonserver --model-repository /opt/tritonserver/qa/L0_perf_nomodel/models -f 22.07dev/min_latency_triton_c_api/python_sbatch1_dbatch1_instance1.csv
 USING C API: only default functionalities supported
OpenLibraryHandle: /opt/tritonserver/lib/libtritonserver.so
server is alive!
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using p95 latency

Request concurrency: 1
  Pass [1] throughput: 1263.82 infer/sec. p95 latency: 846 usec
  Pass [2] throughput: 1266.1 infer/sec. p95 latency: 845 usec
  Pass [3] throughput: 1262.93 infer/sec. p95 latency: 848 usec
  Client:
    Request count: 22785
    Throughput: 1264.28 infer/sec
    p50 latency: 791 usec
    p90 latency: 833 usec
    p95 latency: 846 usec
    p99 latency: 933 usec

  Server:
    Inference count: 22760
    Execution count: 22760
    Successful request count: 22761
    Avg request latency: 759 usec (overhead 110 usec + queue 135 usec + compute input 94 usec + compute infer 349 usec + compute output 70 usec)

Inferences/Second vs. Client p95 Batch Latency
Concurrency: 1, throughput: 1264.28 infer/sec, latency 846 usec
```