### PR TITLE
only fetch googletest when needed

### DIFF
--- a/src/c++/CMakeLists.txt
+++ b/src/c++/CMakeLists.txt
@@ -83,7 +83,9 @@ if(NOT TRITON_ENABLE_PERF_ANALYZER AND NOT TRITON_ENABLE_CC_HTTP AND NOT TRITON_
   set(TRITON_COMMON_ENABLE_JSON OFF)
 endif()
 
-FetchContent_MakeAvailable(googletest)
+if(TRITON_ENABLE_TESTS OR TRITON_ENABLE_PERF_ANALYZER)
+  FetchContent_MakeAvailable(googletest)
+endif()
 FetchContent_MakeAvailable(repo-common)
 
 #


### PR DESCRIPTION
Currently, googletest is always fetched when building the client, leading to gtest and gmock includes and libraries being installed. However, this dependency is only needed for the examples and the perf client, so it should only be fetched when those are enabled.