### PR TITLE
 c api segfault fixes

### DIFF
--- a/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.cc
+++ b/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.cc
@@ -929,10 +929,6 @@ TritonLoader::Infer(
     return Error("request failure in triton server", 1);
   }
 
-  // RETURN_IF_TRITONSERVER_ERROR(
-  //     GetSingleton()->inference_response_error_fn_(completed_response),
-  //     "response status");
-
   timer.CaptureTimestamp(tc::RequestTimers::Kind::RECV_START);
   timer.CaptureTimestamp(tc::RequestTimers::Kind::RECV_END);
   timer.CaptureTimestamp(tc::RequestTimers::Kind::REQUEST_END);
@@ -947,13 +943,13 @@ TritonLoader::Infer(
       "Failed to get request id");
   std::string id(cid);
   InferResult::Create(result, err, id);
-  // // clean up
-  // RETURN_IF_TRITONSERVER_ERROR(
-  //     GetSingleton()->inference_response_delete_fn_(completed_response),
-  //     "deleting inference response");
-  // RETURN_IF_TRITONSERVER_ERROR(
-  //     GetSingleton()->response_allocator_delete_fn_(allocator),
-  //     "deleting response allocator");
+  // clean up
+  RETURN_IF_TRITONSERVER_ERROR(
+      GetSingleton()->inference_response_delete_fn_(completed_response),
+      "deleting inference response");
+  RETURN_IF_TRITONSERVER_ERROR(
+      GetSingleton()->response_allocator_delete_fn_(allocator),
+      "deleting response allocator");
   return Error::Success;
 }
 

--- a/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.cc
+++ b/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.cc
@@ -565,6 +565,7 @@ TritonLoader::LoadServerLibrary()
 
   TritonServerErrorDeleteFn_t edfn;
   TritonServerErrorCodeToStringFn_t ectsfn;
+  TritonServerErrorMessageFn_t emfn;
   TritonServerModelConfigFn_t mcfn;
   TritonServerInferenceRequestSetCorrelationIdFn_t scidfn;
   TritonServerInferenceRequestSetStringCorrelationIdFn_t sscidfn;
@@ -700,6 +701,9 @@ TritonLoader::LoadServerLibrary()
       dlhandle_, "TRITONSERVER_ErrorCodeString", false /* optional */,
       reinterpret_cast<void**>(&ectsfn)));
   RETURN_IF_ERROR(GetEntrypoint(
+      dlhandle_, "TRITONSERVER_ErrorMessage", false /* optional */,
+      reinterpret_cast<void**>(&emfn)));
+  RETURN_IF_ERROR(GetEntrypoint(
       dlhandle_, "TRITONSERVER_ServerModelConfig", false /* optional */,
       reinterpret_cast<void**>(&mcfn)));
   RETURN_IF_ERROR(GetEntrypoint(
@@ -788,6 +792,7 @@ TritonLoader::LoadServerLibrary()
 
   error_delete_fn_ = edfn;
   error_code_to_string_fn_ = ectsfn;
+  error_message_fn_ = emfn;
   model_config_fn_ = mcfn;
   set_correlation_id_fn_ = scidfn;
   set_string_correlation_id_fn_ = sscidfn;
@@ -924,9 +929,15 @@ TritonLoader::Infer(
 
   // check if there completed response is an error and needs to shut down
   // gracefully
-  if (completed_response != nullptr) {
-    CleanUp(completed_response, allocator);
-    return Error("request failure in triton server", 1);
+  TRITONSERVER_Error* completed_response_err =
+      GetSingleton()->inference_response_error_fn_(completed_response);
+  if (completed_response_err != nullptr) {
+    // intentionally not using the return value from Clean up here
+    // it is captured to avoid warnings but at this point, the error from the
+    // tritonserver (completed_response_err) is more important to bubble up
+    Error val = CleanUp(completed_response, allocator);
+    RETURN_IF_TRITONSERVER_ERROR(
+        completed_response_err, "request failure in triton server");
   }
 
   timer.CaptureTimestamp(tc::RequestTimers::Kind::RECV_START);
@@ -943,24 +954,21 @@ TritonLoader::Infer(
       "Failed to get request id");
   std::string id(cid);
   InferResult::Create(result, err, id);
-  // clean up
-  RETURN_IF_TRITONSERVER_ERROR(
-      GetSingleton()->inference_response_delete_fn_(completed_response),
-      "deleting inference response");
-  RETURN_IF_TRITONSERVER_ERROR(
-      GetSingleton()->response_allocator_delete_fn_(allocator),
-      "deleting response allocator");
-  return Error::Success;
+  return CleanUp(completed_response, allocator);
 }
 
-void
+Error
 TritonLoader::CleanUp(
     TRITONSERVER_InferenceResponse* completed_response,
     TRITONSERVER_ResponseAllocator* allocator)
 {
-  // clean up
-  GetSingleton()->inference_response_delete_fn_(completed_response);
-  GetSingleton()->response_allocator_delete_fn_(allocator);
+  TRITONSERVER_Error* response_err =
+      GetSingleton()->inference_response_delete_fn_(completed_response);
+  TRITONSERVER_Error* allocator_err =
+      GetSingleton()->response_allocator_delete_fn_(allocator);
+  RETURN_IF_TRITONSERVER_ERROR(response_err, "deleting inference response");
+  RETURN_IF_TRITONSERVER_ERROR(allocator_err, "deleting response allocator");
+  return Error::Success;
 }
 
 Error

--- a/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.h
+++ b/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.h
@@ -107,6 +107,10 @@ class TritonLoader : public tc::InferenceServerClient {
       const std::vector<const tc::InferRequestedOutput*>& outputs,
       InferResult** result);
 
+  static void CleanUp(
+      TRITONSERVER_InferenceResponse* completed_response,
+      TRITONSERVER_ResponseAllocator* allocator);
+
   static Error ModelInferenceStatistics(
       const std::string& model_name, const std::string& model_version,
       rapidjson::Document* infer_stat);

--- a/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.h
+++ b/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.h
@@ -107,7 +107,7 @@ class TritonLoader : public tc::InferenceServerClient {
       const std::vector<const tc::InferRequestedOutput*>& outputs,
       InferResult** result);
 
-  static void CleanUp(
+  static Error CleanUp(
       TRITONSERVER_InferenceResponse* completed_response,
       TRITONSERVER_ResponseAllocator* allocator);
 


### PR DESCRIPTION
Clean up and refactor some clean up code when the c_api experiences errors.
Attach the error_message_fn pointer to avoid segfaults