### PR TITLE
Fix grpc timing calculations

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -997,6 +997,9 @@ InferenceProfiler::Measure(
     if (include_server_stats_) {
       RETURN_IF_ERROR(GetServerSideStatus(&start_status));
     }
+    // Need to zero out start stats when window start is 0
+    start_status = std::map<cb::ModelIdentifier, cb::ModelStatistics>();
+    start_stat = cb::InferStat();
     RETURN_IF_ERROR(manager_->GetAccumulatedClientStat(&start_stat));
   }
 


### PR DESCRIPTION
Updating grpc timing calculations.  
Time accumulation was being done twice on new configurations. Resetting the calculation when window_start_ns == 0 removes the duplication.