### PR TITLE
Add missing `import sys`

### DIFF
--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -31,6 +31,7 @@ import pathlib
 import re
 import shutil
 import subprocess
+import sys
 from distutils.dir_util import copy_tree
 from tempfile import mkstemp
 


### PR DESCRIPTION
The `sys` module is used in `fail_if` (please see below). However it was not imported. So this adds that `import` to fix the missing import issue.

https://github.com/triton-inference-server/client/blob/f560cb3b928f86f167cf6d0b764c46c50226f8b8/src/python/library/build_wheel.py#L39-L42