### PR TITLE
remove std::move call

### DIFF
--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -1251,8 +1251,7 @@ InferenceServerHttpClient::UpdateTraceSettings(
   {
     for (const auto& pr : settings) {
       if (pr.second.empty()) {
-        request_json.Add(
-            pr.first.c_str(), std::move(triton::common::TritonJson::Value()));
+        request_json.Add(pr.first.c_str(), triton::common::TritonJson::Value());
       } else {
         if (pr.first == "trace_level") {
           triton::common::TritonJson::Value level_json(


### PR DESCRIPTION
This PR removes std:move call to fix the -Werror,-Wpessimizing-move issue. Thanks for the review.

```
In file included from /../cmake-build/external/triton/client/src/c++/library/CMakeFiles/http-client-library.dir/Unity/unity_0_cxx.cxx:3:
/../external/triton/client/src/c++/library/http_client.cc:1257:31: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
            pr.first.c_str(), std::move(triton::common::TritonJson::Value()));
                              ^
/../external/triton/client/src/c++/library/http_client.cc:1257:31: note: remove std::move call here
            pr.first.c_str(), std::move(triton::common::TritonJson::Value()));
```

cmake version 3.22.2
GNU Make 4.1
Built for x86_64-pc-linux-gnu