### PR TITLE
Implement various CLI options

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -212,7 +212,8 @@ class InferenceProfiler {
   /// \param measurement_mode The measurement mode to use for windows.
   /// \param mpi_driver The driver class for MPI operations.
   /// \param metrics_interval_ms The interval at which the server-side metrics
-  /// are queried.
+  /// \param should_collect_metrics Whether server-side inference server metrics
+  /// should be collected.
   /// \return cb::Error object indicating success or failure.
   static cb::Error Create(
       const bool verbose, const double stability_threshold,
@@ -223,8 +224,8 @@ class InferenceProfiler {
       std::unique_ptr<LoadManager> manager,
       std::unique_ptr<InferenceProfiler>* profiler,
       uint64_t measurement_request_count, MeasurementMode measurement_mode,
-      std::shared_ptr<MPIDriver> mpi_driver,
-      const uint64_t metrics_interval_ms);
+      std::shared_ptr<MPIDriver> mpi_driver, const uint64_t metrics_interval_ms,
+      const bool should_collect_metrics);
 
   /// Performs the profiling on the given range with the given search algorithm.
   /// For profiling using request rate invoke template with double, otherwise
@@ -305,7 +306,7 @@ class InferenceProfiler {
       std::shared_ptr<cb::ClientBackend> profile_backend,
       std::unique_ptr<LoadManager> manager, uint64_t measurement_request_count,
       MeasurementMode measurement_mode, std::shared_ptr<MPIDriver> mpi_driver,
-      const uint64_t metrics_interval_ms);
+      const uint64_t metrics_interval_ms, const bool should_collect_metrics);
 
   /// Actively measure throughput in every 'measurement_window' msec until the
   /// throughput is stable. Once the throughput is stable, it adds the
@@ -629,6 +630,9 @@ class InferenceProfiler {
 
   /// Metrics manager that collects server-side metrics periodically
   std::shared_ptr<MetricsManager> metrics_manager_{nullptr};
+
+  /// Whether server-side inference server metrics should be collected.
+  bool should_collect_metrics_{false};
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend TestInferenceProfiler;

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -808,13 +808,13 @@ Usage(char** argv, const std::string& msg = std::string())
             << std::endl;
   std::cerr << FormatMessage(
                    " --metrics-url: The URL to query for server-side inference "
-                   "server metrics.",
+                   "server metrics. Default is 'localhost:8002/metrics'.",
                    18)
             << std::endl;
   std::cerr << FormatMessage(
                    " --metrics-interval: How often in milliseconds, within "
                    "each measurement window, to query for server-side "
-                   "inference server metrics.",
+                   "inference server metrics. Default is 1000.",
                    18)
             << std::endl;
 


### PR DESCRIPTION
I have manually tested the following things:
* Test that GPU code does/doesn't get called when `--collect-metrics` option is true/false
* Test that user-set value for `--metrics-url` option gets used for triton metrics curl
* Test that default value for `--metrics-url` is used when option is unspecified
* Test that error is thrown when using `--metrics-url` without `--collect-metrics`
* Test that value for `--metrics-interval` option gets passed to thread sleep/callback logic for curling triton metrics
* Test that default value for `--metrics-interval` option is used when option is unspecified
* Test that error is thrown when using `--metrics-interval` without `--collect-metrics`
* Test that error is thrown when 0 is specified for `--metrics-interval`

I will add testing in a future PR for the CLI option verification when #152 gets merged