### PR TITLE
Gpu metrics support (#164)

### DIFF
--- a/src/c++/perf_analyzer/CMakeLists.txt
+++ b/src/c++/perf_analyzer/CMakeLists.txt
@@ -47,6 +47,7 @@ set(
   inference_profiler.cc
   report_writer.cc
   mpi_utils.cc
+  metrics_manager.cc
 )
 
 set(
@@ -65,6 +66,8 @@ set(
   mpi_utils.h
   doctest.h
   constants.h
+  metrics.h
+  metrics_manager.h
 )
 
 add_executable(
@@ -142,6 +145,9 @@ add_executable(
   test_inference_profiler.cc
   test_command_line_parser.cc
   test_model_parser.cc
+  test_metrics_manager.cc
+  test_report_writer.cc
+  client_backend/triton/test_triton_client_backend.cc
   $<TARGET_OBJECTS:json-utils-library>
 )
 

--- a/src/c++/perf_analyzer/client_backend/triton/CMakeLists.txt
+++ b/src/c++/perf_analyzer/client_backend/triton/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 NVIDIA CORPORATION. All rights reserved.
+# Copyright 2020-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,6 +46,12 @@ target_link_libraries(
   triton-client-backend-library
   PUBLIC grpcclient_static
   PUBLIC httpclient_static
+  PRIVATE CURL::libcurl
+)
+
+target_include_directories(
+  triton-client-backend-library
+  PRIVATE CURL::libcurl
 )
 
 if(${TRITON_ENABLE_GPU})

--- a/src/c++/perf_analyzer/client_backend/triton/test_triton_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/triton/test_triton_client_backend.cc
@@ -1,0 +1,141 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include "../../doctest.h"
+#include "triton_client_backend.h"
+
+namespace triton { namespace perfanalyzer { namespace clientbackend {
+namespace tritonremote {
+
+class TestTritonClientBackend : public TritonClientBackend {
+ public:
+  template <typename T>
+  void ParseAndStoreMetric(
+      const std::string& metrics_endpoint_text, const std::string metric_id,
+      std::map<std::string, T>& metric_per_gpu)
+  {
+    TritonClientBackend::ParseAndStoreMetric<T>(
+        metrics_endpoint_text, metric_id, metric_per_gpu);
+  }
+};
+
+TEST_CASE("testing the ParseAndStoreMetric function")
+{
+  TestTritonClientBackend ttcb{};
+
+  SUBCASE("nv_gpu_utilization metric")
+  {
+    const std::string metrics_endpoint_text{R"(
+# HELP nv_gpu_utilization GPU utilization rate [0.0 - 1.0)
+# TYPE nv_gpu_utilization gauge
+nv_gpu_utilization{gpu_uuid="GPU-00000000-0000-0000-0000-000000000000"} 0.41
+nv_gpu_utilization{gpu_uuid="GPU-00000000-0000-0000-0000-000000000001"} 0.77
+    )"};
+    const std::string metric_id{"nv_gpu_utilization"};
+    std::map<std::string, double> gpu_utilization_per_gpu{};
+
+    ttcb.ParseAndStoreMetric<double>(
+        metrics_endpoint_text, metric_id, gpu_utilization_per_gpu);
+    CHECK(gpu_utilization_per_gpu.size() == 2);
+    CHECK(
+        gpu_utilization_per_gpu["GPU-00000000-0000-0000-0000-000000000000"] ==
+        doctest::Approx(0.41));
+    CHECK(
+        gpu_utilization_per_gpu["GPU-00000000-0000-0000-0000-000000000001"] ==
+        doctest::Approx(0.77));
+  }
+
+  SUBCASE("nv_gpu_power_usage metric")
+  {
+    const std::string metrics_endpoint_text{R"(
+# HELP nv_gpu_power_usage GPU power usage in watts
+# TYPE nv_gpu_power_usage gauge
+nv_gpu_power_usage{gpu_uuid="GPU-00000000-0000-0000-0000-000000000000"} 81.619
+nv_gpu_power_usage{gpu_uuid="GPU-00000000-0000-0000-0000-000000000001"} 99.217
+    )"};
+    const std::string metric_id{"nv_gpu_power_usage"};
+    std::map<std::string, double> gpu_power_usage_per_gpu{};
+
+    ttcb.ParseAndStoreMetric<double>(
+        metrics_endpoint_text, metric_id, gpu_power_usage_per_gpu);
+    CHECK(gpu_power_usage_per_gpu.size() == 2);
+    CHECK(
+        gpu_power_usage_per_gpu["GPU-00000000-0000-0000-0000-000000000000"] ==
+        doctest::Approx(81.619));
+    CHECK(
+        gpu_power_usage_per_gpu["GPU-00000000-0000-0000-0000-000000000001"] ==
+        doctest::Approx(99.217));
+  }
+
+  SUBCASE("nv_gpu_memory_used_bytes metric")
+  {
+    const std::string metrics_endpoint_text{R"(
+# HELP nv_gpu_memory_used_bytes GPU used memory, in bytes
+# TYPE nv_gpu_memory_used_bytes gauge
+nv_gpu_memory_used_bytes{gpu_uuid="GPU-00000000-0000-0000-0000-000000000000"} 50000000
+nv_gpu_memory_used_bytes{gpu_uuid="GPU-00000000-0000-0000-0000-000000000001"} 75000000
+    )"};
+    const std::string metric_id{"nv_gpu_memory_used_bytes"};
+    std::map<std::string, uint64_t> gpu_memory_used_bytes_per_gpu{};
+
+    ttcb.ParseAndStoreMetric<uint64_t>(
+        metrics_endpoint_text, metric_id, gpu_memory_used_bytes_per_gpu);
+    CHECK(gpu_memory_used_bytes_per_gpu.size() == 2);
+    CHECK(
+        gpu_memory_used_bytes_per_gpu
+            ["GPU-00000000-0000-0000-0000-000000000000"] == 50000000);
+    CHECK(
+        gpu_memory_used_bytes_per_gpu
+            ["GPU-00000000-0000-0000-0000-000000000001"] == 75000000);
+  }
+
+  SUBCASE("nv_gpu_memory_total_bytes metric")
+  {
+    const std::string metrics_endpoint_text{R"(
+# HELP nv_gpu_memory_total_bytes GPU total memory, in bytes
+# TYPE nv_gpu_memory_total_bytes gauge
+nv_gpu_memory_total_bytes{gpu_uuid="GPU-00000000-0000-0000-0000-000000000000"} 1000000000
+nv_gpu_memory_total_bytes{gpu_uuid="GPU-00000000-0000-0000-0000-000000000001"} 2000000000
+    )"};
+    const std::string metric_id{"nv_gpu_memory_total_bytes"};
+    std::map<std::string, uint64_t> gpu_memory_total_bytes_per_gpu{};
+
+    ttcb.ParseAndStoreMetric<uint64_t>(
+        metrics_endpoint_text, metric_id, gpu_memory_total_bytes_per_gpu);
+    CHECK(gpu_memory_total_bytes_per_gpu.size() == 2);
+    CHECK(
+        gpu_memory_total_bytes_per_gpu
+            ["GPU-00000000-0000-0000-0000-000000000000"] == 1000000000);
+    CHECK(
+        gpu_memory_total_bytes_per_gpu
+            ["GPU-00000000-0000-0000-0000-000000000001"] == 2000000000);
+  }
+}
+
+}}}}  // namespace triton::perfanalyzer::clientbackend::tritonremote

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -25,8 +25,13 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <cstdint>
+#include <map>
+#include <regex>
 #include <string>
+#include <type_traits>
 #include "../../constants.h"
+#include "../../metrics.h"
 #include "../../perf_utils.h"
 #include "../client_backend.h"
 #include "grpc_client.h"
@@ -55,6 +60,10 @@ namespace tc = triton::client;
 namespace triton { namespace perfanalyzer { namespace clientbackend {
 namespace tritonremote {
 
+#ifndef DOCTEST_CONFIG_DISABLE
+class TestTritonClientBackend;
+#endif
+
 //==============================================================================
 /// TritonClientBackend uses triton client C++ library to communicate with
 /// triton inference service.
@@ -69,8 +78,8 @@ class TritonClientBackend : public ClientBackend {
   /// \param http_headers Map of HTTP headers. The map key/value indicates
   /// the header name/value.
   /// \param verbose Enables the verbose mode.
-  /// \param client_backend Returns a new TritonClientBackend
-  /// object.
+  /// \param metrics_url The inference server metrics url and port.
+  /// \param client_backend Returns a new TritonClientBackend object.
   /// \return Error object indicating success or failure.
   static Error Create(
       const std::string& url, const ProtocolType protocol,
@@ -78,6 +87,7 @@ class TritonClientBackend : public ClientBackend {
       const std::map<std::string, std::vector<std::string>> trace_options,
       const grpc_compression_algorithm compression_algorithm,
       std::shared_ptr<tc::Headers> http_headers, const bool verbose,
+      const std::string& metrics_url,
       std::unique_ptr<ClientBackend>* client_backend);
 
   /// See ClientBackend::ServerExtensions()
@@ -122,6 +132,9 @@ class TritonClientBackend : public ClientBackend {
       const std::string& model_name = "",
       const std::string& model_version = "") override;
 
+  /// See ClientBackend::Metrics()
+  Error Metrics(triton::perfanalyzer::Metrics& metrics) override;
+
   /// See ClientBackend::UnregisterAllSharedMemory()
   Error UnregisterAllSharedMemory() override;
 
@@ -156,10 +169,10 @@ class TritonClientBackend : public ClientBackend {
   TritonClientBackend(
       const ProtocolType protocol,
       const grpc_compression_algorithm compression_algorithm,
-      std::shared_ptr<tc::Headers> http_headers)
+      std::shared_ptr<tc::Headers> http_headers, const std::string& metrics_url)
       : ClientBackend(BackendKind::TRITON), protocol_(protocol),
         compression_algorithm_(compression_algorithm),
-        http_headers_(http_headers)
+        http_headers_(http_headers), metrics_url_(metrics_url)
   {
   }
 
@@ -179,6 +192,35 @@ class TritonClientBackend : public ClientBackend {
       std::map<ModelIdentifier, ModelStatistics>* model_stats);
   void ParseInferStat(
       const tc::InferStat& triton_infer_stat, InferStat* infer_stat);
+  void AccessMetricsEndpoint(std::string& metrics_endpoint_text);
+  void ParseAndStoreMetrics(
+      const std::string& metrics_endpoint_text,
+      triton::perfanalyzer::Metrics& metrics);
+
+  template <typename T>
+  void ParseAndStoreMetric(
+      const std::string& metrics_endpoint_text, const std::string metric_id,
+      std::map<std::string, T>& metric_per_gpu)
+  {
+    std::regex metric_regex(
+        R"(\n)" + metric_id + R"(\{gpu_uuid\=\"([^"]+)\"\} (\d+\.?\d*))");
+    std::sregex_iterator metric_regex_match_begin{std::sregex_iterator(
+        metrics_endpoint_text.begin(), metrics_endpoint_text.end(),
+        metric_regex)};
+
+    for (std::sregex_iterator i{metric_regex_match_begin};
+         i != std::sregex_iterator(); i++) {
+      const std::smatch& match{*i};
+      const std::string& gpu_uuid{match[1].str()};
+      T metric{};
+      if (std::is_same<T, double>::value) {
+        metric = std::stod(match[2].str());
+      } else if (std::is_same<T, uint64_t>::value) {
+        metric = static_cast<uint64_t>(std::stod(match[2].str()));
+      }
+      metric_per_gpu[gpu_uuid] = metric;
+    }
+  }
 
   /// Union to represent the underlying triton client belonging to one of
   /// the protocols
@@ -193,9 +235,17 @@ class TritonClientBackend : public ClientBackend {
     std::unique_ptr<tc::InferenceServerGrpcClient> grpc_client_;
   } client_;
 
-  const ProtocolType protocol_;
-  const grpc_compression_algorithm compression_algorithm_;
+  const ProtocolType protocol_{UNKNOWN};
+  const grpc_compression_algorithm compression_algorithm_{GRPC_COMPRESS_NONE};
   std::shared_ptr<tc::Headers> http_headers_;
+  const std::string metrics_url_{""};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+  friend TestTritonClientBackend;
+
+ protected:
+  TritonClientBackend() = default;
+#endif
 };
 
 //==============================================================

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -107,6 +107,18 @@ struct PerfAnalyzerParameters {
   std::shared_ptr<MPIDriver> mpi_driver;
   std::string memory_type{"system"};  // currently not used, to be removed
 
+  // Enable collection of server-side metrics from inference server.
+  bool should_collect_metrics{false};
+
+  // The URL to query for server-side inference server metrics.
+  std::string metrics_url{"localhost:8002/metrics"};
+  bool metrics_url_specified{false};
+
+  // How often, within each measurement window, to query for server-side
+  // inference server metrics.
+  uint64_t metrics_interval_ms{1000};
+  bool metrics_interval_ms_specified{false};
+
   // Return true if targeting concurrency
   //
   bool targeting_concurrency() const

--- a/src/c++/perf_analyzer/metrics.h
+++ b/src/c++/perf_analyzer/metrics.h
@@ -23,37 +23,22 @@
 // OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 #pragma once
 
-#include <exception>
+#include <cstdint>
+#include <map>
 #include <string>
 
 namespace triton { namespace perfanalyzer {
 
-// Perf Exception error class
-//
-class PerfAnalyzerException : public std::exception {
- public:
-  PerfAnalyzerException(uint32_t error) : error_(error) {}
-
-  PerfAnalyzerException(const std::string& message, uint32_t error)
-      : message_(message), error_(error)
-  {
-  }
-
-  virtual const char* what() const throw()
-  {
-    std::string msg =
-        "Perf Error " + std::to_string(error_) + " thrown:\n" + message_;
-    return msg.c_str();
-  }
-
-  inline int GetError() const { return error_; }
-
- private:
-  const std::string message_{""};
-  uint32_t error_;
+/// Struct that holds server-side metrics for the inference server.
+/// The keys for each map are GPU UUIDs and the values are described in the
+/// variable names.
+struct Metrics {
+  std::map<std::string, double> gpu_utilization_per_gpu{};
+  std::map<std::string, double> gpu_power_usage_per_gpu{};
+  std::map<std::string, uint64_t> gpu_memory_used_bytes_per_gpu{};
+  std::map<std::string, uint64_t> gpu_memory_total_bytes_per_gpu{};
 };
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/metrics_manager.cc
+++ b/src/c++/perf_analyzer/metrics_manager.cc
@@ -1,0 +1,172 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "metrics_manager.h"
+#include <iostream>
+#include <stdexcept>
+#include <utility>
+#include "constants.h"
+#include "perf_analyzer_exception.h"
+
+namespace triton { namespace perfanalyzer {
+
+MetricsManager::MetricsManager(
+    std::shared_ptr<clientbackend::ClientBackend> client_backend,
+    uint64_t metrics_interval_ms)
+    : client_backend_(client_backend), metrics_interval_ms_(metrics_interval_ms)
+{
+}
+
+MetricsManager::~MetricsManager()
+{
+  if (query_loop_future_.valid()) {
+    StopQueryingMetrics();
+  }
+}
+
+void
+MetricsManager::StartQueryingMetrics()
+{
+  should_keep_querying_ = true;
+  query_loop_future_ =
+      std::async(&MetricsManager::QueryMetricsEveryNMilliseconds, this);
+}
+
+void
+MetricsManager::QueryMetricsEveryNMilliseconds()
+{
+  while (should_keep_querying_) {
+    const auto& start{std::chrono::system_clock::now()};
+
+    Metrics metrics{};
+    clientbackend::Error err{client_backend_->Metrics(metrics)};
+    if (err.IsOk() == false) {
+      throw PerfAnalyzerException(err.Message(), err.Err());
+    }
+
+    CheckForMissingMetrics(metrics);
+
+    {
+      std::lock_guard<std::mutex> metrics_lock{metrics_mutex_};
+      metrics_.push_back(std::move(metrics));
+    }
+
+    const auto& end{std::chrono::system_clock::now()};
+    const auto& duration{end - start};
+    const auto& remainder{std::chrono::milliseconds(metrics_interval_ms_) -
+                          duration};
+
+    CheckForMetricIntervalTooShort(remainder, duration);
+
+    {
+      std::unique_lock<std::mutex> query_loop_lock{query_loop_mutex_};
+      query_loop_cv_.wait_for(query_loop_lock, remainder);
+    }
+  }
+}
+
+void
+MetricsManager::CheckForMissingMetrics(const Metrics& metrics)
+{
+  if (has_given_missing_metrics_warning_) {
+    return;
+  }
+  if (metrics.gpu_utilization_per_gpu.empty()) {
+    std::cerr << "WARNING: Unable to parse 'nv_gpu_utilization' metric."
+              << std::endl;
+    has_given_missing_metrics_warning_ = true;
+  }
+  if (metrics.gpu_power_usage_per_gpu.empty()) {
+    std::cerr << "WARNING: Unable to parse 'nv_gpu_power_usage' metric."
+              << std::endl;
+    has_given_missing_metrics_warning_ = true;
+  }
+  if (metrics.gpu_memory_used_bytes_per_gpu.empty()) {
+    std::cerr << "WARNING: Unable to parse 'nv_gpu_memory_used_bytes' metric."
+              << std::endl;
+    has_given_missing_metrics_warning_ = true;
+  }
+  if (metrics.gpu_memory_total_bytes_per_gpu.empty()) {
+    std::cerr << "WARNING: Unable to parse 'nv_gpu_memory_total_bytes' metric."
+              << std::endl;
+    has_given_missing_metrics_warning_ = true;
+  }
+}
+
+void
+MetricsManager::CheckForMetricIntervalTooShort(
+    const std::chrono::nanoseconds& remainder,
+    const std::chrono::nanoseconds& duration)
+{
+  if (has_given_metric_interval_warning_) {
+    return;
+  }
+  if (remainder < std::chrono::nanoseconds::zero()) {
+    std::cerr << "WARNING: Triton metrics endpoint latency ("
+              << std::chrono::duration_cast<std::chrono::milliseconds>(duration)
+                     .count()
+              << "ms) is larger than the querying interval ("
+              << metrics_interval_ms_
+              << "ms). Please try a larger querying interval "
+                 "via `--triton-metrics-interval`."
+              << std::endl;
+    has_given_metric_interval_warning_ = true;
+  }
+}
+
+void
+MetricsManager::CheckQueryingStatus()
+{
+  if (query_loop_future_.valid() &&
+      query_loop_future_.wait_for(std::chrono::seconds(0)) ==
+          std::future_status::ready) {
+    query_loop_future_.get();
+  }
+}
+
+void
+MetricsManager::GetLatestMetrics(std::vector<Metrics>& metrics)
+{
+  if (metrics.empty() == false) {
+    throw PerfAnalyzerException(
+        "MetricsManager::GetLatestMetrics() must be passed an empty vector.",
+        GENERIC_ERROR);
+  }
+  std::lock_guard<std::mutex> metrics_lock{metrics_mutex_};
+  metrics_.swap(metrics);
+}
+
+void
+MetricsManager::StopQueryingMetrics()
+{
+  should_keep_querying_ = false;
+  query_loop_cv_.notify_one();
+  if (query_loop_future_.valid()) {
+    query_loop_future_.get();
+  }
+}
+
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/metrics_manager.h
+++ b/src/c++/perf_analyzer/metrics_manager.h
@@ -1,0 +1,93 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <vector>
+#include "client_backend/client_backend.h"
+#include "metrics.h"
+
+namespace triton { namespace perfanalyzer {
+
+#ifndef DOCTEST_CONFIG_DISABLE
+class TestMetricsManager;
+#endif
+
+class MetricsManager {
+ public:
+  MetricsManager(
+      std::shared_ptr<clientbackend::ClientBackend> client_backend,
+      uint64_t metrics_interval_ms);
+
+  /// Ends the background thread, redundant in case StopQueryingMetrics() isn't
+  /// called
+  ~MetricsManager();
+
+  /// Starts background thread that queries metrics on an interval
+  void StartQueryingMetrics();
+
+  /// Checks if background thread threw exception and propogates it if so
+  void CheckQueryingStatus();
+
+  /// Puts the latest-collected metrics from background thread into vector
+  /// output parameter to be used by main thread
+  void GetLatestMetrics(std::vector<Metrics>& metrics_per_timestamp);
+
+  /// Ends the background thread
+  void StopQueryingMetrics();
+
+ private:
+  void QueryMetricsEveryNMilliseconds();
+  void CheckForMissingMetrics(const Metrics& metrics);
+  void CheckForMetricIntervalTooShort(
+      const std::chrono::nanoseconds& remainder,
+      const std::chrono::nanoseconds& duration);
+
+  std::shared_ptr<clientbackend::ClientBackend> client_backend_{nullptr};
+  uint64_t metrics_interval_ms_{0};
+  std::mutex metrics_mutex_{};
+  std::vector<Metrics> metrics_{};
+  bool should_keep_querying_{false};
+  std::future<void> query_loop_future_{};
+  std::mutex query_loop_mutex_{};
+  std::condition_variable query_loop_cv_{};
+  bool has_given_missing_metrics_warning_{false};
+  bool has_given_metric_interval_warning_{false};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+  friend TestMetricsManager;
+
+ protected:
+  MetricsManager() = default;
+#endif
+};
+
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -79,7 +79,7 @@ PerfAnalyzer::CreateAnalyzerObjects()
           params_->trace_options, params_->compression_algorithm,
           params_->http_headers, params_->triton_server_path,
           params_->model_repository_path, params_->memory_type,
-          params_->extra_verbose, &factory),
+          params_->extra_verbose, params_->metrics_url, &factory),
       "failed to create client factory");
 
   FAIL_IF_ERR(
@@ -259,7 +259,8 @@ PerfAnalyzer::CreateAnalyzerObjects()
           params_->percentile, params_->latency_threshold_ms, params_->protocol,
           parser_, std::move(backend_), std::move(manager), &profiler_,
           params_->measurement_request_count, params_->measurement_mode,
-          params_->mpi_driver),
+          params_->mpi_driver, params_->metrics_interval_ms,
+          params_->should_collect_metrics),
       "failed to create profiler");
 }
 
@@ -400,7 +401,8 @@ PerfAnalyzer::WriteReport()
       pa::ReportWriter::Create(
           params_->filename, params_->targeting_concurrency(), summary_,
           params_->verbose_csv, profiler_->IncludeServerStats(),
-          params_->percentile, parser_, &writer),
+          params_->percentile, parser_, &writer,
+          params_->should_collect_metrics),
       "failed to create report writer");
 
   writer->GenerateReport();

--- a/src/c++/perf_analyzer/report_writer.h
+++ b/src/c++/perf_analyzer/report_writer.h
@@ -25,12 +25,18 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <ostream>
 #include "client_backend/client_backend.h"
 #include "inference_profiler.h"
+#include "metrics.h"
 #include "model_parser.h"
 #include "perf_utils.h"
 
 namespace triton { namespace perfanalyzer {
+
+#ifndef DOCTEST_CONFIG_DISABLE
+class TestReportWriter;
+#endif
 
 //==============================================================================
 /// ReportWriter is a helper class to generate csv files from the profiled data.
@@ -54,32 +60,48 @@ class ReportWriter {
   /// \param parser The ModelParse object which holds all the details about the
   /// model.
   /// \param writer Returns a new ReportWriter object.
-  /// \return cb::Error object indicating success or
-  /// failure.
+  /// \param should_output_metrics Whether server-side inference server metrics
+  /// should be output.
+  /// \return cb::Error object indicating success or failure.
   static cb::Error Create(
       const std::string& filename, const bool target_concurrency,
       const std::vector<pa::PerfStatus>& summary, const bool verbose_csv,
       const bool include_server_stats, const int32_t percentile,
       const std::shared_ptr<ModelParser>& parser,
-      std::unique_ptr<ReportWriter>* writer);
+      std::unique_ptr<ReportWriter>* writer, const bool should_output_metrics);
 
   void GenerateReport();
+
+  /// Output gpu metrics to a stream
+  /// \param ofs A stream to output the csv data
+  /// \param metric The metric container for a particular concurrency or request
+  /// rate
+  void WriteGpuMetrics(std::ostream& ofs, const Metrics& metric);
 
  private:
   ReportWriter(
       const std::string& filename, const bool target_concurrency,
       const std::vector<pa::PerfStatus>& summary, const bool verbose_csv,
       const bool include_server_stats, const int32_t percentile,
-      const std::shared_ptr<ModelParser>& parser);
+      const std::shared_ptr<ModelParser>& parser,
+      const bool should_output_metrics);
 
 
-  const std::string& filename_;
-  const bool target_concurrency_;
-  const bool include_server_stats_;
-  const bool verbose_csv_;
-  const int32_t percentile_;
-  std::vector<pa::PerfStatus> summary_;
-  const std::shared_ptr<ModelParser>& parser_;
+  const std::string& filename_{""};
+  const bool target_concurrency_{true};
+  const bool include_server_stats_{true};
+  const bool verbose_csv_{true};
+  const int32_t percentile_{90};
+  std::vector<pa::PerfStatus> summary_{};
+  const std::shared_ptr<ModelParser>& parser_{nullptr};
+  const bool should_output_metrics_{false};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+  friend TestReportWriter;
+
+ protected:
+  ReportWriter() = default;
+#endif
 };
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_metrics_manager.cc
+++ b/src/c++/perf_analyzer/test_metrics_manager.cc
@@ -1,0 +1,136 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include "doctest.h"
+#include "metrics_manager.h"
+
+namespace triton { namespace perfanalyzer {
+
+class TestMetricsManager : public MetricsManager {
+ public:
+  void CheckForMissingMetrics(const Metrics& metrics)
+  {
+    MetricsManager::CheckForMissingMetrics(metrics);
+  }
+
+  void CheckForMetricIntervalTooShort(
+      const std::chrono::nanoseconds& remainder,
+      const std::chrono::nanoseconds& duration)
+  {
+    MetricsManager::CheckForMetricIntervalTooShort(remainder, duration);
+  }
+
+  uint64_t& metrics_interval_ms_{MetricsManager::metrics_interval_ms_};
+};
+
+TEST_CASE("testing the CheckForMissingMetrics function")
+{
+  TestMetricsManager tmm{};
+  Metrics metrics{};
+  std::stringstream captured_cerr;
+  std::streambuf* old_cerr{std::cerr.rdbuf(captured_cerr.rdbuf())};
+
+  // check that no warning gets printed when all metrics are present
+  metrics.gpu_utilization_per_gpu["gpu0"] = 0.5;
+  metrics.gpu_power_usage_per_gpu["gpu0"] = 50.0;
+  metrics.gpu_memory_used_bytes_per_gpu["gpu0"] = 1000;
+  metrics.gpu_memory_total_bytes_per_gpu["gpu0"] = 10000;
+  tmm.CheckForMissingMetrics(metrics);
+  CHECK(captured_cerr.str() == "");
+
+  // check that still no warning gets printed on a subsequent call
+  tmm.CheckForMissingMetrics(metrics);
+  CHECK(captured_cerr.str() == "");
+
+  // check that warning gets printed when missing metrics
+  metrics.gpu_utilization_per_gpu.clear();
+  metrics.gpu_power_usage_per_gpu.clear();
+  metrics.gpu_memory_used_bytes_per_gpu.clear();
+  metrics.gpu_memory_total_bytes_per_gpu.clear();
+  tmm.CheckForMissingMetrics(metrics);
+  CHECK(
+      captured_cerr.str() ==
+      "WARNING: Unable to parse 'nv_gpu_utilization' metric.\n"
+      "WARNING: Unable to parse 'nv_gpu_power_usage' metric.\n"
+      "WARNING: Unable to parse 'nv_gpu_memory_used_bytes' metric.\n"
+      "WARNING: Unable to parse 'nv_gpu_memory_total_bytes' metric.\n");
+
+  // check that no additional warning gets printed on a subsequent call
+  tmm.CheckForMissingMetrics(metrics);
+  CHECK(
+      captured_cerr.str() ==
+      "WARNING: Unable to parse 'nv_gpu_utilization' metric.\n"
+      "WARNING: Unable to parse 'nv_gpu_power_usage' metric.\n"
+      "WARNING: Unable to parse 'nv_gpu_memory_used_bytes' metric.\n"
+      "WARNING: Unable to parse 'nv_gpu_memory_total_bytes' metric.\n");
+
+  std::cerr.rdbuf(old_cerr);
+}
+
+TEST_CASE("testing the CheckForMetricIntervalTooShort function")
+{
+  TestMetricsManager tmm{};
+  tmm.metrics_interval_ms_ = 5;
+  std::chrono::nanoseconds remainder{};
+  std::chrono::nanoseconds duration{};
+  std::stringstream captured_cerr;
+  std::streambuf* old_cerr{std::cerr.rdbuf(captured_cerr.rdbuf())};
+
+  // check that no warning gets printed when interval is long enough
+  remainder = std::chrono::nanoseconds(2000000);
+  duration = std::chrono::nanoseconds(3000000);
+  tmm.CheckForMetricIntervalTooShort(remainder, duration);
+  CHECK(captured_cerr.str() == "");
+
+  // check that still no warning gets printed on a subsequent call
+  tmm.CheckForMetricIntervalTooShort(remainder, duration);
+  CHECK(captured_cerr.str() == "");
+
+  // check that warning gets printed when interval is too short
+  remainder = std::chrono::nanoseconds(-2000000);
+  duration = std::chrono::nanoseconds(7000000);
+  tmm.CheckForMetricIntervalTooShort(remainder, duration);
+  CHECK(
+      captured_cerr.str() ==
+      "WARNING: Triton metrics endpoint latency (7ms) is larger than the "
+      "querying interval (5ms). Please try a larger querying interval via "
+      "`--triton-metrics-interval`.\n");
+
+  // check that no additional warning gets printed on a subsequent call
+  tmm.CheckForMetricIntervalTooShort(remainder, duration);
+  CHECK(
+      captured_cerr.str() ==
+      "WARNING: Triton metrics endpoint latency (7ms) is larger than the "
+      "querying interval (5ms). Please try a larger querying interval via "
+      "`--triton-metrics-interval`.\n");
+
+  std::cerr.rdbuf(old_cerr);
+}
+
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_report_writer.cc
+++ b/src/c++/perf_analyzer/test_report_writer.cc
@@ -1,0 +1,92 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS"" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <string>
+#include "doctest.h"
+#include "report_writer.h"
+
+namespace triton { namespace perfanalyzer {
+
+class TestReportWriter : ReportWriter {
+ public:
+  void WriteGpuMetrics(std::ostream& ofs, const Metrics& metrics)
+  {
+    ReportWriter::WriteGpuMetrics(ofs, metrics);
+  }
+};
+
+TEST_CASE("testing WriteGpuMetrics")
+{
+  TestReportWriter trw{};
+  Metrics m{};
+  m.gpu_utilization_per_gpu["a"] = 1.0;
+  m.gpu_power_usage_per_gpu["a"] = 2.2;
+  m.gpu_memory_used_bytes_per_gpu["a"] = 3;
+  m.gpu_memory_total_bytes_per_gpu["a"] = 4;
+  std::ostringstream actual_output{};
+
+  SUBCASE("single gpu complete output")
+  {
+    trw.WriteGpuMetrics(actual_output, m);
+    const std::string expected_output{"a:1;,a:2.2;,a:3;,a:4;,"};
+    CHECK(actual_output.str() == expected_output);
+  }
+
+  SUBCASE("single gpu missing data")
+  {
+    m.gpu_power_usage_per_gpu.erase("a");
+    trw.WriteGpuMetrics(actual_output, m);
+    const std::string expected_output{"a:1;,,a:3;,a:4;,"};
+    CHECK(actual_output.str() == expected_output);
+  }
+
+  SUBCASE("multi-gpu")
+  {
+    m.gpu_utilization_per_gpu["z"] = 100.0;
+    m.gpu_power_usage_per_gpu["z"] = 222.2;
+    m.gpu_memory_used_bytes_per_gpu["z"] = 45;
+    m.gpu_memory_total_bytes_per_gpu["z"] = 89;
+
+    SUBCASE("multi gpu complete output")
+    {
+      trw.WriteGpuMetrics(actual_output, m);
+      const std::string expected_output{
+          "a:1;z:100;,a:2.2;z:222.2;,a:3;z:45;,a:4;z:89;,"};
+      CHECK(actual_output.str() == expected_output);
+    }
+
+    SUBCASE("multi gpu missing data")
+    {
+      m.gpu_utilization_per_gpu.erase("z");
+      m.gpu_power_usage_per_gpu.erase("a");
+      trw.WriteGpuMetrics(actual_output, m);
+      const std::string expected_output{"a:1;,z:222.2;,a:3;z:45;,a:4;z:89;,"};
+      CHECK(actual_output.str() == expected_output);
+    }
+  }
+}
+
+}}  // namespace triton::perfanalyzer


### PR DESCRIPTION
* Implement triton metric collection (#154)

* Implement triton metric collection

* Addressed comments

* Addressed comments

* Fix bugs

* Addressed comments

* Addressed comments

* Addressed comments

* Implement GPU metrics aggregation (#158)

* Implement GPU metrics aggregation

* Addressed comments

* Implement various CLI options (#160)

* Implement various CLI options

* Addressed comments

* Implement gpu total memory metric collection and aggregation (#161)

* Implement gpu total memory metric collection and aggregation

* Remove unnecessary logic

* Fix warning bug

* Add gpu metrics csv output (#162)

* Update options to use defines

* Update metric option to collect-gpu-metrics and plumb option to report writer

* Add new headers for gpu metrics

* Add assert to ensure vector is size 1

* Guard metrics output to csv file

* Add testing for Write gpu metrics

* Change collect-gpu-metrics to collect-metrics

* Add total memory stats

* Remove plural on gpu csv headers

* Addressed comments

Co-authored-by: Matthew Kotila <matthew.r.kotila@gmail.com>

* Switch to PerfAnalyzerException

* Addressed comments

Co-authored-by: Elias Bermudez <6505145+debermudez@users.noreply.github.com>