### PR TITLE
Add timeout to avoid busyloop in async http client

### DIFF
--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -201,7 +201,7 @@ struct InferOptions {
   /// will handle the request using default setting for the model.
   uint64_t priority_;
   /// The timeout value for the request, in microseconds. If the request
-  /// cannot be completed within the time by the server can take a
+  /// cannot be completed within the time by the server. The server can take a
   /// model-specific action such as terminating the request. If not
   /// provided, the server will handle the request using default setting
   /// for the model.

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -1800,6 +1800,7 @@ InferenceServerHttpClient::PreRunProcessing(
   curl_easy_setopt(curl, CURLOPT_USERAGENT, "libcurl-agent/1.0");
   curl_easy_setopt(curl, CURLOPT_POST, 1L);
   curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 1L);
+
   if (options.client_timeout_ != 0) {
     uint64_t timeout_ms = (options.client_timeout_ / 1000);
     curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout_ms);
@@ -1898,47 +1899,58 @@ InferenceServerHttpClient::AsyncTransfer()
       return !this->ongoing_async_requests_.empty();
     });
 
-    curl_multi_perform(multi_handle_, &place_holder);
-    while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
-      uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);
-      auto itr = ongoing_async_requests_.find(identifier);
-      // This shouldn't happen
-      if (itr == ongoing_async_requests_.end()) {
-        std::cerr << "Unexpected error: received completed request that is not "
-                     "in the list of asynchronous requests"
-                  << std::endl;
+    CURLMcode mc = curl_multi_perform(multi_handle_, &place_holder);
+    int numfds;
+    if (mc == CURLM_OK) {
+      // Wait for activity. Timeout should be capped by server_timeout_
+      // of InferOptions
+      mc = curl_multi_poll(multi_handle_, NULL, 0, INT_MAX, &numfds);
+      while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
+        uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);
+        auto itr = ongoing_async_requests_.find(identifier);
+        // This shouldn't happen
+        if (itr == ongoing_async_requests_.end()) {
+          std::cerr
+              << "Unexpected error: received completed request that is not "
+                 "in the list of asynchronous requests"
+              << std::endl;
+          curl_multi_remove_handle(multi_handle_, msg->easy_handle);
+          curl_easy_cleanup(msg->easy_handle);
+          continue;
+        }
+
+        long http_code = 400;
+        if (msg->data.result == CURLE_OK) {
+          curl_easy_getinfo(
+              msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_code);
+        } else if (msg->data.result == CURLE_OPERATION_TIMEDOUT) {
+          http_code = 499;
+        }
+
+        request_list.emplace_back(itr->second);
+        ongoing_async_requests_.erase(itr);
         curl_multi_remove_handle(multi_handle_, msg->easy_handle);
         curl_easy_cleanup(msg->easy_handle);
-        continue;
-      }
 
-      long http_code = 400;
-      if (msg->data.result == CURLE_OK) {
-        curl_easy_getinfo(msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_code);
-      } else if (msg->data.result == CURLE_OPERATION_TIMEDOUT) {
-        http_code = 499;
-      }
+        std::shared_ptr<HttpInferRequest> async_request = request_list.back();
+        async_request->http_code_ = http_code;
 
-      request_list.emplace_back(itr->second);
-      ongoing_async_requests_.erase(itr);
-      curl_multi_remove_handle(multi_handle_, msg->easy_handle);
-      curl_easy_cleanup(msg->easy_handle);
-
-      std::shared_ptr<HttpInferRequest> async_request = request_list.back();
-      async_request->http_code_ = http_code;
-
-      if (msg->msg != CURLMSG_DONE) {
-        // Something wrong happened.
-        std::cerr << "Unexpected error: received CURLMsg=" << msg->msg
-                  << std::endl;
-      } else {
-        async_request->Timer().CaptureTimestamp(
-            RequestTimers::Kind::REQUEST_END);
-        Error err = UpdateInferStat(async_request->Timer());
-        if (!err.IsOk()) {
-          std::cerr << "Failed to update context stat: " << err << std::endl;
+        if (msg->msg != CURLMSG_DONE) {
+          // Something wrong happened.
+          std::cerr << "Unexpected error: received CURLMsg=" << msg->msg
+                    << std::endl;
+        } else {
+          async_request->Timer().CaptureTimestamp(
+              RequestTimers::Kind::REQUEST_END);
+          Error err = UpdateInferStat(async_request->Timer());
+          if (!err.IsOk()) {
+            std::cerr << "Failed to update context stat: " << err << std::endl;
+          }
         }
       }
+    } else {
+      std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
+                << std::endl;
     }
     lock.unlock();
 

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -30,6 +30,7 @@
 
 #include <curl/curl.h>
 #include <zlib.h>
+#include <climits>
 #include <atomic>
 #include <cstdint>
 #include <deque>
@@ -1902,9 +1903,10 @@ InferenceServerHttpClient::AsyncTransfer()
     CURLMcode mc = curl_multi_perform(multi_handle_, &place_holder);
     int numfds;
     if (mc == CURLM_OK) {
-      // Wait for activity up to CLIENT_WAIT_TIME_MS
+      // Wait for activity. If there are no descripters in the multi_handle_
+      // then curl_multi_wait will return immediately
       mc =
-          curl_multi_wait(multi_handle_, NULL, 0, CLIENT_WAIT_TIME_MS, &numfds);
+          curl_multi_wait(multi_handle_, NULL, 0, INT_MAX, &numfds);
       if (mc == CURLM_OK) {
         while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
           uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -1902,8 +1902,7 @@ InferenceServerHttpClient::AsyncTransfer()
     CURLMcode mc = curl_multi_perform(multi_handle_, &place_holder);
     int numfds;
     if (mc == CURLM_OK) {
-      // Wait for activity. Timeout should be capped by server_timeout_
-      // of InferOptions
+      // Wait for activity up to CLIENT_WAIT_TIME_MS
       mc =
           curl_multi_wait(multi_handle_, NULL, 0, CLIENT_WAIT_TIME_MS, &numfds);
       if (mc == CURLM_OK) {

--- a/src/c++/library/http_client.h
+++ b/src/c++/library/http_client.h
@@ -647,8 +647,6 @@ class InferenceServerHttpClient : public InferenceServerClient {
   // map to record ongoing asynchronous requests with pointer to easy handle
   // or tag id as key
   AsyncReqMap ongoing_async_requests_;
-  // Wait time before the client processes data
-  static constexpr int CLIENT_WAIT_TIME_MS = 1000;
 };
 
 }}  // namespace triton::client

--- a/src/c++/library/http_client.h
+++ b/src/c++/library/http_client.h
@@ -29,7 +29,6 @@
 
 #include <map>
 #include <memory>
-#include <climits>
 #include "common.h"
 #include "ipc.h"
 
@@ -648,8 +647,8 @@ class InferenceServerHttpClient : public InferenceServerClient {
   // map to record ongoing asynchronous requests with pointer to easy handle
   // or tag id as key
   AsyncReqMap ongoing_async_requests_;
-  // shortest client timeout ms
-  int shortest_timeout_ms_ = INT_MAX;
+
+  static constexpr int CLIENT_WAIT_TIME_MS = 1000;
 };
 
 }}  // namespace triton::client

--- a/src/c++/library/http_client.h
+++ b/src/c++/library/http_client.h
@@ -647,7 +647,7 @@ class InferenceServerHttpClient : public InferenceServerClient {
   // map to record ongoing asynchronous requests with pointer to easy handle
   // or tag id as key
   AsyncReqMap ongoing_async_requests_;
-
+  // Wait time before the client processes data
   static constexpr int CLIENT_WAIT_TIME_MS = 1000;
 };
 

--- a/src/c++/library/http_client.h
+++ b/src/c++/library/http_client.h
@@ -29,6 +29,7 @@
 
 #include <map>
 #include <memory>
+#include <climits>
 #include "common.h"
 #include "ipc.h"
 
@@ -647,6 +648,8 @@ class InferenceServerHttpClient : public InferenceServerClient {
   // map to record ongoing asynchronous requests with pointer to easy handle
   // or tag id as key
   AsyncReqMap ongoing_async_requests_;
+  // shortest client timeout ms
+  int shortest_timeout_ms_ = INT_MAX;
 };
 
 }}  // namespace triton::client


### PR DESCRIPTION
Using `curl_multi_wait` instead of busyloop to wait for server responses. This decreases client CPU usage.