### PR TITLE
Update grpcio to 1.41.1

### DIFF
--- a/src/python/library/requirements/requirements_grpc.txt
+++ b/src/python/library/requirements/requirements_grpc.txt
@@ -31,6 +31,6 @@ protobuf>=3.5.0,<3.20
 # There is memory leak in later Python GRPC (1.43.0 to be specific),
 # use known working version until the memory leak is resolved in the future
 # (see https://github.com/grpc/grpc/issues/28513)
-grpcio==1.41.0
+grpcio==1.41.1
 numpy>=1.19.1
 python-rapidjson>=0.9.1


### PR DESCRIPTION
Moving to `grpcio=1.41.1` would be a tremendous help, as `grpcio-tools=1.41.0` is unavailable on Conda-Forge.