### PR TITLE
Move logic from load manager create functions into constructors

### DIFF
--- a/src/c++/perf_analyzer/client_backend/client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/client_backend.h
@@ -38,6 +38,7 @@
 
 #include "../constants.h"
 #include "../metrics.h"
+#include "../perf_analyzer_exception.h"
 #include "ipc.h"
 
 namespace pa = triton::perfanalyzer;
@@ -69,6 +70,15 @@ namespace triton { namespace perfanalyzer { namespace clientbackend {
     }                                                              \
   }                                                                \
   while (false)
+
+#define THROW_IF_ERROR(S, MSG)                                          \
+  do {                                                                  \
+    triton::perfanalyzer::clientbackend::Error status__ = (S);          \
+    if (!status__.IsOk()) {                                             \
+      std::cerr << "error: " << (MSG) << ": " << status__ << std::endl; \
+      throw PerfAnalyzerException(GENERIC_ERROR);                       \
+    }                                                                   \
+  } while (false)
 
 //==============================================================================
 /// Error status reported by backends

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -95,7 +95,9 @@ class ConcurrencyManager : public LoadManager {
       const size_t max_threads, const size_t max_concurrency,
       const size_t sequence_length, const SharedMemoryType shared_memory_type,
       const size_t output_shm_size, const uint64_t start_sequence_id,
-      const uint64_t sequence_id_range,
+      const uint64_t sequence_id_range, const size_t string_length,
+      const std::string& string_data, const bool zero_input,
+      std::vector<std::string>& user_data,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
 

--- a/src/c++/perf_analyzer/custom_load_manager.cc
+++ b/src/c++/perf_analyzer/custom_load_manager.cc
@@ -47,17 +47,7 @@ CustomLoadManager::Create(
       async, streaming, request_intervals_file, batch_size,
       measurement_window_ms, max_threads, num_of_sequences, sequence_length,
       shared_memory_type, output_shm_size, start_sequence_id, sequence_id_range,
-      parser, factory));
-
-  local_manager->threads_config_.reserve(max_threads);
-
-  RETURN_IF_ERROR(local_manager->InitManagerInputs(
-      string_length, string_data, zero_input, user_data));
-
-  if (local_manager->shared_memory_type_ !=
-      SharedMemoryType::NO_SHARED_MEMORY) {
-    RETURN_IF_ERROR(local_manager->InitSharedMemory());
-  }
+      string_length, string_data, zero_input, user_data, parser, factory));
 
   *manager = std::move(local_manager);
 
@@ -71,13 +61,16 @@ CustomLoadManager::CustomLoadManager(
     const uint32_t num_of_sequences, const size_t sequence_length,
     const SharedMemoryType shared_memory_type, const size_t output_shm_size,
     const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+    const size_t string_length, const std::string& string_data,
+    const bool zero_input, std::vector<std::string>& user_data,
     const std::shared_ptr<ModelParser>& parser,
     const std::shared_ptr<cb::ClientBackendFactory>& factory)
     : RequestRateManager(
           async, streaming, Distribution::CUSTOM, batch_size,
           measurement_window_ms, max_threads, num_of_sequences, sequence_length,
           shared_memory_type, output_shm_size, start_sequence_id,
-          sequence_id_range, parser, factory),
+          sequence_id_range, string_length, string_data, zero_input, user_data,
+          parser, factory),
       request_intervals_file_(request_intervals_file)
 {
 }

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -97,6 +97,8 @@ class CustomLoadManager : public RequestRateManager {
       const uint32_t num_of_sequences, const size_t sequence_length,
       const SharedMemoryType shared_memory_type, const size_t output_shm_size,
       const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+      const size_t string_length, const std::string& string_data,
+      const bool zero_input, std::vector<std::string>& user_data,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
 

--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -195,6 +195,8 @@ LoadManager::LoadManager(
     const size_t max_threads, const size_t sequence_length,
     const SharedMemoryType shared_memory_type, const size_t output_shm_size,
     const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+    const size_t string_length, const std::string& string_data,
+    const bool zero_input, std::vector<std::string>& user_data,
     const std::shared_ptr<ModelParser>& parser,
     const std::shared_ptr<cb::ClientBackendFactory>& factory)
     : async_(async), streaming_(streaming), batch_size_(batch_size),
@@ -209,6 +211,14 @@ LoadManager::LoadManager(
        (parser_->SchedulerType() == ModelParser::ENSEMBLE_SEQUENCE));
 
   data_loader_.reset(new DataLoader(batch_size));
+
+  auto status =
+      InitManagerInputs(string_length, string_data, zero_input, user_data);
+  THROW_IF_ERROR(status, "Failed to init manager inputs");
+
+  if (shared_memory_type_ != SharedMemoryType::NO_SHARED_MEMORY) {
+    THROW_IF_ERROR(InitSharedMemory(), "Unable to init shared memory");
+  }
 }
 
 cb::Error

--- a/src/c++/perf_analyzer/load_manager.h
+++ b/src/c++/perf_analyzer/load_manager.h
@@ -128,6 +128,8 @@ class LoadManager {
       const size_t max_threads, const size_t sequence_length,
       const SharedMemoryType shared_memory_type, const size_t output_shm_size,
       const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+      const size_t string_length, const std::string& string_data,
+      const bool zero_input, std::vector<std::string>& user_data,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
 

--- a/src/c++/perf_analyzer/request_rate_manager.h
+++ b/src/c++/perf_analyzer/request_rate_manager.h
@@ -128,7 +128,9 @@ class RequestRateManager : public LoadManager {
       const size_t max_threads, const uint32_t num_of_sequences,
       const size_t sequence_length, const SharedMemoryType shared_memory_type,
       const size_t output_shm_size, const uint64_t start_sequence_id,
-      const uint64_t sequence_id_range,
+      const uint64_t sequence_id_range, const size_t string_length,
+      const std::string& string_data, const bool zero_input,
+      std::vector<std::string>& user_data,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
 


### PR DESCRIPTION
Move all logic out of Create functions into constructors
Move common code of InitManagerInputs() and InitSharedMemory() into base class
threads_config_.reserve(max_threads) has to stay in child classes because they don't share thread_config type

