### PR TITLE
Restrict the geventhttpclient version to 2.0.2

### DIFF
--- a/src/python/library/requirements/requirements_http.txt
+++ b/src/python/library/requirements/requirements_http.txt
@@ -24,7 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-geventhttpclient>=1.4.4
+geventhttpclient>=1.4.4,<=2.0.2
 aiohttp>=3.8.1
 numpy>=1.19.1
 python-rapidjson>=0.9.1


### PR DESCRIPTION
Looks like geventhttpclient has changed handling of ssl_context_factory in 2.0.8 release that is making our L0_https fail.

Need to take a deeper look into what needs to change to move to 2.0.8 versions and later.