### PR TITLE
Test streaming in RequestRateManager

### DIFF
--- a/src/c++/perf_analyzer/client_backend/mock_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/mock_client_backend.h
@@ -103,6 +103,8 @@ class MockClientStats {
 
   std::chrono::milliseconds response_delay{0};
 
+  bool enable_stats{false};
+
   std::vector<std::chrono::time_point<std::chrono::system_clock>>
       request_timestamps;
   SeqStatus sequence_status;
@@ -234,6 +236,7 @@ class MockClientBackend : public ClientBackend {
   Error StartStream(OnCompleteFn callback, bool enable_stats)
   {
     stats_->CaptureStreamStart();
+    stats_->enable_stats = enable_stats;
     stream_callback_ = callback;
     return Error::Success;
   }

--- a/src/c++/perf_analyzer/client_backend/mock_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/mock_client_backend.h
@@ -103,7 +103,7 @@ class MockClientStats {
 
   std::chrono::milliseconds response_delay{0};
 
-  bool enable_stats{false};
+  bool start_stream_enable_stats_value{false};
 
   std::vector<std::chrono::time_point<std::chrono::system_clock>>
       request_timestamps;
@@ -236,7 +236,7 @@ class MockClientBackend : public ClientBackend {
   Error StartStream(OnCompleteFn callback, bool enable_stats)
   {
     stats_->CaptureStreamStart();
-    stats_->enable_stats = enable_stats;
+    stats_->start_stream_enable_stats_value = enable_stats;
     stream_callback_ = callback;
     return Error::Success;
   }

--- a/src/c++/perf_analyzer/mock_model_parser.h
+++ b/src/c++/perf_analyzer/mock_model_parser.h
@@ -28,15 +28,18 @@
 
 #include "model_parser.h"
 
-namespace triton { namespace perfanalyzer { 
+namespace triton { namespace perfanalyzer {
 
 class MockModelParser : public ModelParser {
  public:
-  MockModelParser(bool is_sequence_model) : ModelParser(clientbackend::BackendKind::TRITON) {
+  MockModelParser(bool is_sequence_model, bool is_decoupled_model)
+      : ModelParser(clientbackend::BackendKind::TRITON)
+  {
     if (is_sequence_model) {
       scheduler_type_ = ModelParser::SEQUENCE;
     }
+    is_decoupled_ = is_decoupled_model;
   }
 };
 
-}}
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/model_parser.h
+++ b/src/c++/perf_analyzer/model_parser.h
@@ -162,6 +162,7 @@ class ModelParser {
 
  protected:
   ModelSchedulerType scheduler_type_;
+  bool is_decoupled_;
 
  private:
   cb::Error GetEnsembleSchedulerType(
@@ -187,7 +188,6 @@ class ModelParser {
   std::string model_version_;
   std::string model_signature_name_;
   size_t max_batch_size_;
-  bool is_decoupled_;
   bool response_cache_enabled_;
 
 #ifndef DOCTEST_CONFIG_DISABLE

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -38,9 +38,9 @@ class TestConcurrencyManager : public TestLoadManagerBase,
  public:
   TestConcurrencyManager(
       PerfAnalyzerParameters params, bool is_sequence_model = false,
-      bool use_mock_infer = false)
+      bool is_decoupled_model = false, bool use_mock_infer = false)
       : use_mock_infer_(use_mock_infer),
-        TestLoadManagerBase(params, is_sequence_model),
+        TestLoadManagerBase(params, is_sequence_model, is_decoupled_model),
         ConcurrencyManager(
             params.async, params.streaming, params.batch_size,
             params.max_threads, params.max_concurrency, params.sequence_length,

--- a/src/c++/perf_analyzer/test_inference_profiler.cc
+++ b/src/c++/perf_analyzer/test_inference_profiler.cc
@@ -636,7 +636,7 @@ TEST_CASE("test the ReportPrometheusMetrics function")
       metrics.gpu_utilization_per_gpu[gpu_key] = 0.5;
       metrics.gpu_power_usage_per_gpu[gpu_key] = 75.5;
       metrics.gpu_memory_used_bytes_per_gpu[gpu_key] = 12500;
-      metrics.gpu_memory_total_bytes_per_gpu["gpu4"] = 150000;
+      metrics.gpu_memory_total_bytes_per_gpu[gpu_key] = 150000;
     }
 
     cb::Error result{ReportPrometheusMetrics(metrics)};

--- a/src/c++/perf_analyzer/test_load_manager.cc
+++ b/src/c++/perf_analyzer/test_load_manager.cc
@@ -36,8 +36,10 @@ namespace triton { namespace perfanalyzer {
 class TestLoadManager : public TestLoadManagerBase, public LoadManager {
  public:
   ~TestLoadManager() = default;
-  TestLoadManager(PerfAnalyzerParameters params, bool is_sequence_model = false)
-      : TestLoadManagerBase(params, is_sequence_model),
+  TestLoadManager(
+      PerfAnalyzerParameters params, bool is_sequence_model = false,
+      bool is_decoupled_model = false)
+      : TestLoadManagerBase(params, is_sequence_model, is_decoupled_model),
         LoadManager(
             params.async, params.streaming, params.batch_size,
             params.max_threads, params.sequence_length,

--- a/src/c++/perf_analyzer/test_load_manager_base.h
+++ b/src/c++/perf_analyzer/test_load_manager_base.h
@@ -38,7 +38,9 @@ namespace triton { namespace perfanalyzer {
 ///
 class TestLoadManagerBase {
  public:
-  TestLoadManagerBase(PerfAnalyzerParameters params, bool is_sequence_model)
+  TestLoadManagerBase(
+      PerfAnalyzerParameters params, bool is_sequence_model,
+      bool is_decoupled_model)
       : params_(params)
   {
     // Must reset this global flag every unit test.
@@ -49,7 +51,8 @@ class TestLoadManagerBase {
 
     stats_ = std::make_shared<cb::MockClientStats>();
     factory_ = std::make_shared<cb::MockClientBackendFactory>(stats_);
-    parser_ = std::make_shared<MockModelParser>(is_sequence_model);
+    parser_ = std::make_shared<MockModelParser>(
+        is_sequence_model, is_decoupled_model);
   }
 
   void CheckInferType()

--- a/src/c++/perf_analyzer/test_load_manager_base.h
+++ b/src/c++/perf_analyzer/test_load_manager_base.h
@@ -125,11 +125,12 @@ class TestLoadManagerBase {
     }
   }
 
+  std::shared_ptr<cb::MockClientStats> stats_;
+
  protected:
   PerfAnalyzerParameters params_;
   std::shared_ptr<cb::ClientBackendFactory> factory_;
   std::shared_ptr<ModelParser> parser_;
-  std::shared_ptr<cb::MockClientStats> stats_;
 
   const std::shared_ptr<ModelParser>& GetParser() { return parser_; }
   const std::shared_ptr<cb::ClientBackendFactory>& GetFactory()

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -429,7 +429,8 @@ TEST_CASE("request_rate_streaming: test that streaming-specific logic works")
 
   SUBCASE("enable_stats false")
   {
-    TestRequestRateManager trrm(params, false, true);
+    TestRequestRateManager trrm(
+        params, false /* is_decoupled */, true /* is_sequence */);
     trrm.schedule_.push_back(std::chrono::nanoseconds(1));
 
     std::future<void> infer_future{std::async(

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -430,7 +430,7 @@ TEST_CASE("request_rate_streaming: test that streaming-specific logic works")
   SUBCASE("enable_stats false")
   {
     TestRequestRateManager trrm(
-        params, false /* is_decoupled */, true /* is_sequence */);
+        params, false /* is_sequence */, true /* is_decoupled */);
     trrm.schedule_.push_back(std::chrono::nanoseconds(1));
 
     std::future<void> infer_future{std::async(


### PR DESCRIPTION
There's only two places in RequestRateManager, currently, that do custom logic when in streaming mode:

1. https://github.com/triton-inference-server/client/blob/f74b6232a5fe9a85ea24a9dd3185f30a0d51cbe9/src/c++/perf_analyzer/request_rate_manager.cc#L237-L244
    *  This is the new verification added in this PR. I check that StartStream() gets called by recording the enable_stats parameter.
2. https://github.com/triton-inference-server/client/blob/f74b6232a5fe9a85ea24a9dd3185f30a0d51cbe9/src/c++/perf_analyzer/request_rate_manager.cc#L389-L392
    * This is already verified in [CheckInferType()](https://github.com/triton-inference-server/client/blob/main/src/c%2B%2B/perf_analyzer/test_load_manager_base.h#L55)/[request_rate_infer_type](https://github.com/triton-inference-server/client/blob/main/src/c%2B%2B/perf_analyzer/test_request_rate_manager.cc#L273).