### PR TITLE
Standardize handling of sequences by LoadManagers

### DIFF
--- a/src/c++/perf_analyzer/client_backend/mock_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/mock_client_backend.h
@@ -94,6 +94,10 @@ class MockClientStats {
     void HandleSeqRequest(uint64_t seq_id) { live_seq_ids_to_length[seq_id]++; }
     void Reset()
     {
+      // Note that live_seq_ids_to_length is explicitly not reset here.
+      // This is because we always want to maintain the true status of
+      // live sequences
+
       used_seq_ids.clear();
       max_live_seq_count = 0;
       seq_lengths.clear();

--- a/src/c++/perf_analyzer/client_backend/mock_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/mock_client_backend.h
@@ -262,13 +262,8 @@ class MockClientBackend : public ClientBackend {
   }
 
  private:
-  void LaunchAsyncMockRequest(
-      const InferOptions& options_in, OnCompleteFn callback)
+  void LaunchAsyncMockRequest(const InferOptions options, OnCompleteFn callback)
   {
-    // Make a local copy of the options, in case they are changed while we wait
-    //
-    InferOptions options = options_in;
-
     std::thread([this, options, callback]() {
       std::this_thread::sleep_for(stats_->response_delay);
 

--- a/src/c++/perf_analyzer/client_backend/mock_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/mock_client_backend.h
@@ -255,9 +255,9 @@ class MockClientBackend : public ClientBackend {
     return Error::Success;
   }
 
-  Error ClientInferStat(InferStat* a) override
+  Error ClientInferStat(InferStat* infer_stat) override
   {
-    a->completed_request_count = local_req_count_;
+    infer_stat->completed_request_count = local_req_count_;
     return Error::Success;
   }
 

--- a/src/c++/perf_analyzer/client_backend/mock_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/mock_client_backend.h
@@ -92,6 +92,12 @@ class MockClientStats {
     }
 
     void HandleSeqRequest(uint64_t seq_id) { live_seq_ids_to_length[seq_id]++; }
+    void Reset()
+    {
+      used_seq_ids.clear();
+      max_live_seq_count = 0;
+      seq_lengths.clear();
+    }
   };
 
   std::atomic<size_t> num_infer_calls{0};
@@ -137,6 +143,7 @@ class MockClientStats {
     num_async_stream_infer_calls = 0;
     num_start_stream_calls = 0;
     request_timestamps.clear();
+    sequence_status.Reset();
   }
 
  private:

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -91,16 +91,16 @@ cb::Error
 ConcurrencyManager::ChangeConcurrencyLevel(
     const size_t concurrent_request_count)
 {
-  PauseWorkers();
-  BalanceThreads(concurrent_request_count);
-  ResumeWorkers();
+  PauseSequenceWorkers();
+  ReconfigThreads(concurrent_request_count);
+  ResumeSequenceWorkers();
 
   std::cout << "Request concurrency: " << concurrent_request_count << std::endl;
   return cb::Error::Success;
 }
 
 void
-ConcurrencyManager::PauseWorkers()
+ConcurrencyManager::PauseSequenceWorkers()
 {
   if (on_sequence_model_) {
     execute_ = false;
@@ -114,7 +114,7 @@ ConcurrencyManager::PauseWorkers()
 }
 
 void
-ConcurrencyManager::BalanceThreads(const size_t concurrent_request_count)
+ConcurrencyManager::ReconfigThreads(const size_t concurrent_request_count)
 {
   // Always prefer to create new threads if the maximum limit has not been met
   while ((concurrent_request_count > threads_.size()) &&
@@ -153,7 +153,7 @@ ConcurrencyManager::BalanceThreads(const size_t concurrent_request_count)
 }
 
 void
-ConcurrencyManager::ResumeWorkers()
+ConcurrencyManager::ResumeSequenceWorkers()
 {
   if (on_sequence_model_) {
     execute_ = true;

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -91,7 +91,18 @@ cb::Error
 ConcurrencyManager::ChangeConcurrencyLevel(
     const size_t concurrent_request_count)
 {
-  if (on_sequence_model_ && async_) {
+  PauseWorkers();
+  BalanceThreads(concurrent_request_count);
+  ResumeWorkers();
+
+  std::cout << "Request concurrency: " << concurrent_request_count << std::endl;
+  return cb::Error::Success;
+}
+
+void
+ConcurrencyManager::PauseWorkers()
+{
+  if (on_sequence_model_) {
     execute_ = false;
     // Wait to see all threads are paused.
     for (auto& thread_config : threads_config_) {
@@ -100,6 +111,11 @@ ConcurrencyManager::ChangeConcurrencyLevel(
       }
     }
   }
+}
+
+void
+ConcurrencyManager::BalanceThreads(const size_t concurrent_request_count)
+{
   // Always prefer to create new threads if the maximum limit has not been met
   while ((concurrent_request_count > threads_.size()) &&
          (threads_.size() < max_threads_)) {
@@ -134,17 +150,19 @@ ConcurrencyManager::ChangeConcurrencyLevel(
       active_threads_++;
     }
   }
+}
 
-  if (on_sequence_model_ && async_) {
+void
+ConcurrencyManager::ResumeWorkers()
+{
+  if (on_sequence_model_) {
     execute_ = true;
   }
 
   // Make sure all threads will check their updated concurrency level
   wake_signal_.notify_all();
-
-  std::cout << "Request concurrency: " << concurrent_request_count << std::endl;
-  return cb::Error::Success;
 }
+
 
 // Function for worker threads.
 // If the model is non-sequence model, each worker uses only one context
@@ -223,7 +241,7 @@ ConcurrencyManager::Infer(
   // Note that 'free_ctx_ids' must be reconstruct after the call because
   // this function doesn't utilize 'free_ctx_ids' in the same way as in main
   // loop
-  const auto complete_onging_sequence_func = [&]() {
+  const auto complete_ongoing_sequence_func = [&]() {
     if (!on_sequence_model_) {
       return cb::Error::Success;
     }
@@ -238,6 +256,7 @@ ConcurrencyManager::Infer(
       std::lock_guard<std::mutex> guard(sequence_stat_[seq_stat_index]->mtx_);
       // Complete the sequence if there are remaining queries
       while (sequence_stat_[seq_stat_index]->remaining_queries_ != 0) {
+        sequence_stat_[seq_stat_index]->remaining_queries_ = 1;
         SetInferSequenceOptions(seq_stat_index, ctxs[ctx_id]->options_);
 
         // Update the inputs if required
@@ -285,17 +304,17 @@ ConcurrencyManager::Infer(
 
   // run inferencing until receiving exit signal to maintain server load.
   do {
-    if (on_sequence_model_ && async_) {
+    if (on_sequence_model_) {
       if (!execute_) {
         // Ensures the clean exit of the sequences
-        auto status = complete_onging_sequence_func();
+        auto status = complete_ongoing_sequence_func();
         if (thread_stat->status_.IsOk()) {
           thread_stat->status_ = status;
         }
         while (total_ongoing_requests != 0) {
           std::this_thread::sleep_for(std::chrono::milliseconds(500));
         }
-        // Reconstruct 'free_ctx_ids' because complete_onging_sequence_func()
+        // Reconstruct 'free_ctx_ids' because complete_ongoing_sequence_func()
         // has destructive side affects
         free_ctx_ids = std::queue<int>();
         for (size_t i = 0; i < ctxs.size(); ++i) {
@@ -507,16 +526,14 @@ ConcurrencyManager::Infer(
     }
 
     if (early_exit || (!thread_stat->cb_status_.IsOk())) {
-      if (async_) {
-        // Wait for all callbacks to complete.
-        // Loop to ensure all the inflight requests have been completed.
-        auto status = complete_onging_sequence_func();
-        if (thread_stat->status_.IsOk()) {
-          thread_stat->status_ = status;
-        }
-        while (total_ongoing_requests != 0) {
-          std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        }
+      // Wait for all callbacks to complete.
+      // Loop to ensure all the inflight requests have been completed.
+      auto status = complete_ongoing_sequence_func();
+      if (thread_stat->status_.IsOk()) {
+        thread_stat->status_ = status;
+      }
+      while (total_ongoing_requests != 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
       }
       // end loop
       break;

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -122,6 +122,10 @@ class ConcurrencyManager : public LoadManager {
     bool is_paused_;
   };
 
+  void PauseWorkers();
+  void BalanceThreads(size_t concurrent_request_count);
+  void ResumeWorkers();
+
   /// Function for worker that sends inference requests.
   /// \param thread_stat Worker thread status specific data.
   /// \param thread_config Worker thread configuration specific data.

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -122,9 +122,18 @@ class ConcurrencyManager : public LoadManager {
     bool is_paused_;
   };
 
-  void PauseWorkers();
-  void BalanceThreads(size_t concurrent_request_count);
-  void ResumeWorkers();
+  // Pause all worker threads that are working on sequences
+  //
+  void PauseSequenceWorkers();
+
+  // Create new threads (if necessary), and then reconfigure all worker threads
+  // to handle the new concurrent request count
+  //
+  void ReconfigThreads(size_t concurrent_request_count);
+
+  // Restart all worker threads that were working on sequences
+  //
+  void ResumeSequenceWorkers();
 
   /// Function for worker that sends inference requests.
   /// \param thread_stat Worker thread status specific data.

--- a/src/c++/perf_analyzer/load_manager.h
+++ b/src/c++/perf_analyzer/load_manager.h
@@ -307,6 +307,9 @@ class LoadManager {
         : seq_id_(seq_id), data_stream_id_(0), remaining_queries_(0)
     {
     }
+    // If paused, no more requests should be sent other than a single request to
+    // finish the active sequence
+    bool paused_ = false;
     // The unique correlation id allocated to the sequence
     uint64_t seq_id_;
     // The data stream id providing data for the sequence

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -131,7 +131,7 @@ class TestConcurrencyManager : public TestLoadManagerBase,
         stats.completed_request_count ==
         doctest::Approx(expected_count1).epsilon(0.10));
 
-    PauseWorkers();
+    PauseSequenceWorkers();
     CheckSequences(concurrency1);
     ResetStats();
 

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -131,6 +131,10 @@ class TestConcurrencyManager : public TestLoadManagerBase,
         stats.completed_request_count ==
         doctest::Approx(expected_count1).epsilon(0.10));
 
+    PauseWorkers();
+    CheckSequences(concurrency1);
+    ResetStats();
+
     // Run and check request rate 2
     //
     ChangeConcurrencyLevel(concurrency2);
@@ -146,7 +150,7 @@ class TestConcurrencyManager : public TestLoadManagerBase,
     //
     StopWorkerThreads();
 
-    CheckSequences(true /* is_concurrency_manager */);
+    CheckSequences(concurrency2);
   }
 
  private:

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -106,12 +106,47 @@ class TestConcurrencyManager : public TestLoadManagerBase,
   ///
   void TestSequences()
   {
-    auto sleep_time = std::chrono::milliseconds(500);
+    int delay_ms = 10;
+    stats_->response_delay = std::chrono::milliseconds(delay_ms);
 
-    ChangeConcurrencyLevel(params_.max_concurrency);
+    auto stats = cb::InferStat();
+    double concurrency1 = params_.max_concurrency / 2;
+    double concurrency2 = params_.max_concurrency;
+    int sleep_ms = 500;
+    double num_seconds = sleep_ms / 1000;
+
+    auto sleep_time = std::chrono::milliseconds(sleep_ms);
+    size_t expected_count1 = sleep_ms * concurrency1 / delay_ms;
+    size_t expected_count2 =
+        sleep_ms * concurrency2 / delay_ms + expected_count1;
+
+    // Run and check request rate 1
+    //
+    ChangeConcurrencyLevel(concurrency1);
     std::this_thread::sleep_for(sleep_time);
 
-    CheckSequences();
+    stats = cb::InferStat();
+    GetAccumulatedClientStat(&stats);
+    CHECK(
+        stats.completed_request_count ==
+        doctest::Approx(expected_count1).epsilon(0.10));
+
+    // Run and check request rate 2
+    //
+    ChangeConcurrencyLevel(concurrency2);
+    std::this_thread::sleep_for(sleep_time);
+
+    stats = cb::InferStat();
+    GetAccumulatedClientStat(&stats);
+    CHECK(
+        stats.completed_request_count ==
+        doctest::Approx(expected_count2).epsilon(0.10));
+
+    // Stop all threads and make sure everything is as expected
+    //
+    StopWorkerThreads();
+
+    CheckSequences(true /* is_concurrency_manager */);
   }
 
  private:
@@ -268,36 +303,7 @@ TEST_CASE("concurrency_concurrency")
 ///
 TEST_CASE("concurrency_sequence")
 {
-  PerfAnalyzerParameters params{};
-
-  // Generally we want short sequences for testing
-  // so we can hit the corner cases more often
-  //
-  params.sequence_length = 3;
-
-  SUBCASE("Normal") {}
-  SUBCASE("sequence IDs 1")
-  {
-    params.start_sequence_id = 1;
-    params.sequence_id_range = 5;
-  }
-  SUBCASE("sequence IDs 2")
-  {
-    params.start_sequence_id = 17;
-    params.sequence_id_range = 8;
-  }
-  SUBCASE("num_of_sequences 1") { params.num_of_sequences = 1; }
-  SUBCASE("num_of_sequences 10")
-  {
-    params.num_of_sequences = 10;
-    // Make sequences longer so we actually get 10 in flight at a time
-    params.sequence_length = 8;
-  }
-  SUBCASE("sequence_length 1") { params.sequence_length = 1; }
-  SUBCASE("sequence_length 10") { params.sequence_length = 10; }
-
-  params.max_concurrency = params.num_of_sequences;
-
+  PerfAnalyzerParameters params = TestLoadManagerBase::GetSequenceTestParams();
   const bool is_sequence_model{true};
   TestConcurrencyManager tcm(params, is_sequence_model);
   tcm.TestSequences();

--- a/src/c++/perf_analyzer/test_load_manager_base.h
+++ b/src/c++/perf_analyzer/test_load_manager_base.h
@@ -111,6 +111,9 @@ class TestLoadManagerBase {
   {
     auto stats = GetStats();
 
+    // Make sure no live sequences remain
+    CHECK(stats->sequence_status.live_seq_ids_to_length.size() == 0);
+
     // Make sure all seq IDs are within range
     //
     for (auto seq_id : stats->sequence_status.used_seq_ids) {

--- a/src/c++/perf_analyzer/test_load_manager_base.h
+++ b/src/c++/perf_analyzer/test_load_manager_base.h
@@ -107,7 +107,7 @@ class TestLoadManagerBase {
     }
   }
 
-  void CheckSequences(bool is_concurrency_manager)
+  void CheckSequences(uint64_t expected_num_seq)
   {
     auto stats = GetStats();
 
@@ -127,31 +127,32 @@ class TestLoadManagerBase {
     // there are never any overlapping requests -- they always immediately exit
     //
     if (params_.sequence_length != 1) {
-      uint64_t expected_num_seq = is_concurrency_manager
-                                      ? params_.max_concurrency
-                                      : params_.num_of_sequences;
       expected_num_seq = std::min(expected_num_seq, params_.sequence_id_range);
       CHECK(expected_num_seq == stats->sequence_status.max_live_seq_count);
     }
 
     // Make sure that the length of each sequence is as expected
-    // (The code explicitly has a 20% slop, so that is what we are checking)
     //
-    auto num_sequences = params_.num_of_sequences;
+    // All but X of them should be within 20% (The code explicitly has a 20%
+    // slop) of the requested sequence length, where X is the number for
+    // sequences (This is due to the shutdown of sequences at the end that will
+    // create shorter than expected sequences)
+    //
     auto num_values = stats->sequence_status.seq_lengths.size();
+    auto max_len = params_.sequence_length * 1.2;
+    auto min_len = params_.sequence_length * 0.8;
+    auto num_allowed_to_be_below_min_len = expected_num_seq;
+    auto num_below_min_len = 0;
+
     for (size_t i = 0; i < num_values; i++) {
       auto len = stats->sequence_status.seq_lengths[i];
 
-      if (i + num_sequences < num_values) {
-        CHECK(len == doctest::Approx(params_.sequence_length).epsilon(0.20));
-      }
-      // The last instance of each sequence might be shorter than expected, as
-      // they may be terminated part way through
-      //
-      else {
-        CHECK(len <= doctest::Approx(params_.sequence_length).epsilon(0.20));
+      CHECK(len <= max_len);
+      if (len < min_len) {
+        num_below_min_len++;
       }
     }
+    CHECK(num_below_min_len <= num_allowed_to_be_below_min_len);
   }
 
   std::shared_ptr<cb::MockClientStats> stats_;
@@ -178,27 +179,27 @@ class TestLoadManagerBase {
     // Generally we want short sequences for testing
     // so we can hit the corner cases more often
     //
-    params.sequence_length = 3;
+    params.sequence_length = 4;
     params.max_concurrency = 8;
     params.max_threads = 8;
 
     SUBCASE("Normal") {}
-    SUBCASE("sequence IDs 1")
+    SUBCASE("sequence IDs test 1")
     {
       params.start_sequence_id = 1;
       params.sequence_id_range = 3;
     }
-    SUBCASE("sequence IDs 2")
+    SUBCASE("sequence IDs test 2")
     {
       params.start_sequence_id = 17;
       params.sequence_id_range = 8;
     }
     SUBCASE("num_of_sequences 1") { params.num_of_sequences = 1; }
-    SUBCASE("num_of_sequences 10")
+    SUBCASE("num_of_sequences 8")
     {
-      params.num_of_sequences = 10;
-      // Make sequences longer so we actually get 10 in flight at a time
-      params.sequence_length = 10;
+      params.num_of_sequences = 8;
+      // Make sequences long so we actually get 8 in flight at a time
+      params.sequence_length = 20;
     }
     SUBCASE("sequence_length 1") { params.sequence_length = 1; }
     SUBCASE("sequence_length 10") { params.sequence_length = 10; }

--- a/src/c++/perf_analyzer/test_load_manager_base.h
+++ b/src/c++/perf_analyzer/test_load_manager_base.h
@@ -134,7 +134,7 @@ class TestLoadManagerBase {
     // Make sure that the length of each sequence is as expected
     //
     // All but X of them should be within 20% (The code explicitly has a 20%
-    // slop) of the requested sequence length, where X is the number for
+    // slop) of the requested sequence length, where X is the number of
     // sequences (This is due to the shutdown of sequences at the end that will
     // create shorter than expected sequences)
     //

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -187,10 +187,17 @@ class TestRequestRateManager : public TestLoadManagerBase,
   void TestSequences()
   {
     stats_->response_delay = std::chrono::milliseconds(10);
+    double request_rate1 = 100;
+    double request_rate2 = 200;
+
+    // A single sequence can't maintain the above rates
+    //
+    if (params_.num_of_sequences == 1) {
+      request_rate1 = 50;
+      request_rate2 = 100;
+    }
 
     auto stats = cb::InferStat();
-    double request_rate1 = 50;
-    double request_rate2 = 100;
     int sleep_ms = 500;
     double num_seconds = sleep_ms / 1000;
 
@@ -210,8 +217,8 @@ class TestRequestRateManager : public TestLoadManagerBase,
         doctest::Approx(expected_count1).epsilon(0.10));
 
     PauseWorkers();
-    CheckSequences(false /* is_concurrency_manager */);
-
+    CheckSequences(params_.num_of_sequences);
+    ResetStats();
 
     // Run and check request rate 2
     //
@@ -228,7 +235,7 @@ class TestRequestRateManager : public TestLoadManagerBase,
     //
     StopWorkerThreads();
 
-    CheckSequences(false /* is_concurrency_manager */);
+    CheckSequences(params_.num_of_sequences);
   }
 
   struct ThreadStat : RequestRateManager::ThreadStat {

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -186,14 +186,49 @@ class TestRequestRateManager : public TestLoadManagerBase,
   ///
   void TestSequences()
   {
-    double request_rate = 200;
-    auto sleep_time = std::chrono::milliseconds(500);
+    stats_->response_delay = std::chrono::milliseconds(10);
 
-    ChangeRequestRate(request_rate);
+    auto stats = cb::InferStat();
+    double request_rate1 = 50;
+    double request_rate2 = 100;
+    int sleep_ms = 500;
+    double num_seconds = sleep_ms / 1000;
+
+    auto sleep_time = std::chrono::milliseconds(sleep_ms);
+    size_t expected_count1 = 0.5 * request_rate1;
+    size_t expected_count2 = 0.5 * request_rate2 + expected_count1;
+
+    // Run and check request rate 1
+    //
+    ChangeRequestRate(request_rate1);
     std::this_thread::sleep_for(sleep_time);
+
+    stats = cb::InferStat();
+    GetAccumulatedClientStat(&stats);
+    CHECK(
+        stats.completed_request_count ==
+        doctest::Approx(expected_count1).epsilon(0.10));
+
+    PauseWorkers();
+    CheckSequences(false /* is_concurrency_manager */);
+
+
+    // Run and check request rate 2
+    //
+    ChangeRequestRate(request_rate2);
+    std::this_thread::sleep_for(sleep_time);
+
+    stats = cb::InferStat();
+    GetAccumulatedClientStat(&stats);
+    CHECK(
+        stats.completed_request_count ==
+        doctest::Approx(expected_count2).epsilon(0.10));
+
+    // Stop all threads and make sure everything is as expected
+    //
     StopWorkerThreads();
 
-    CheckSequences();
+    CheckSequences(false /* is_concurrency_manager */);
   }
 
   struct ThreadStat : RequestRateManager::ThreadStat {
@@ -370,34 +405,7 @@ TEST_CASE("request_rate_multiple")
 ///
 TEST_CASE("request_rate_sequence")
 {
-  PerfAnalyzerParameters params;
-
-  // Generally we want short sequences for testing
-  // so we can hit the corner cases more often
-  //
-  params.sequence_length = 3;
-
-  SUBCASE("Normal") {}
-  SUBCASE("sequence IDs 1")
-  {
-    params.start_sequence_id = 1;
-    params.sequence_id_range = 5;
-  }
-  SUBCASE("sequence IDs 2")
-  {
-    params.start_sequence_id = 17;
-    params.sequence_id_range = 8;
-  }
-  SUBCASE("num_of_sequences 1") { params.num_of_sequences = 1; }
-  SUBCASE("num_of_sequences 10")
-  {
-    params.num_of_sequences = 10;
-    // Make sequences longer so we actually get 10 in flight at a time
-    params.sequence_length = 8;
-  }
-  SUBCASE("sequence_length 1") { params.sequence_length = 1; }
-  SUBCASE("sequence_length 10") { params.sequence_length = 10; }
-
+  PerfAnalyzerParameters params = TestLoadManagerBase::GetSequenceTestParams();
   bool is_sequence_model = true;
   TestRequestRateManager trrm(params, is_sequence_model);
   trrm.TestSequences();


### PR DESCRIPTION
The following image shows how the load managers used to behave, and how they will behave now:

![image](https://user-images.githubusercontent.com/50968584/201115702-d1ce6467-4645-4c8d-a4e8-527a05b8f2ea.png)


Changes:
- ConcurrencyManager:
  - Refactor ChangeConcurrencyLevel into 3 functions
    - Update the pause/resume code to happen for all sequences, not just async sequences
  - Finish all sequences immediately instead of executing the full length
  - Finish all sequences instead of just async

- RequestRateManager:
  - Finish all sequences (immediately) between rates
  - Because any thread can issue to any sequence, I needed a way to communicate between threads to make sure one thread didn't "finish" a sequence only to have another thread restart it. 
    - This resulted in adding a pause variable into SequenceStat

- Testing:
  - Move all param creation code for testing sequences into test_load_manager_base so it can be shared
    - Duplicate all sequence testing for async
  - Update sequence tests to do both the "inbetween rates" case as well as "end of test" case
  - Check that no live sequences remain inbetween rates or at end of test