### PR TITLE
Python InferInput: set_data_from_numpy is not necessary in some cases.  

### DIFF
--- a/src/python/library/tritonclient/grpc/__init__.py
+++ b/src/python/library/tritonclient/grpc/__init__.py
@@ -1852,6 +1852,17 @@ class InferInput:
         else:
             self._raw_content = input_tensor.tobytes()
 
+    def set_data_from_numpy(self, raw_content):
+        """Set the tensor data from the specified bytes for
+        input associated with this object.
+
+        Parameters
+        ----------
+        input_tensor : bytes
+            The tensor data in bytes format
+        """
+        self._raw_content = raw_content
+
     def set_shared_memory(self, region_name, byte_size, offset=0):
         """Set the tensor data from the specified shared memory region.
 

--- a/src/python/library/tritonclient/grpc/__init__.py
+++ b/src/python/library/tritonclient/grpc/__init__.py
@@ -1852,13 +1852,13 @@ class InferInput:
         else:
             self._raw_content = input_tensor.tobytes()
 
-    def set_data_from_numpy(self, raw_content):
+    def set_data_from_bytes(self, raw_content):
         """Set the tensor data from the specified bytes for
         input associated with this object.
 
         Parameters
         ----------
-        input_tensor : bytes
+        raw_content : bytes
             The tensor data in bytes format
         """
         self._raw_content = raw_content

--- a/src/python/library/tritonclient/http/__init__.py
+++ b/src/python/library/tritonclient/http/__init__.py
@@ -140,7 +140,7 @@ class InferenceServerClient:
     Parameters
     ----------
     url : str
-        The inference server name, port and optional base path 
+        The inference server name, port and optional base path
         in the following format: host:port/<base-path>, e.g.
         'localhost:8000'.
 
@@ -1300,7 +1300,7 @@ class InferenceServerClient:
         Int
             The byte size of the inference request header in the request body.
             Returns None if the whole request body constitutes the request header.
-            
+
 
         Raises
         ------
@@ -1335,7 +1335,7 @@ class InferenceServerClient:
         content_encoding : string
             The encoding of the response body if it is compressed.
             Default value is None.
-        
+
         Returns
         -------
         InferResult
@@ -1868,6 +1868,17 @@ class InferInput:
                 self._raw_data = input_tensor.tobytes()
             self._parameters['binary_data_size'] = len(self._raw_data)
 
+    def set_data_from_numpy(self, raw_content):
+        """Set the tensor data from the specified bytes for
+        input associated with this object.
+
+        Parameters
+        ----------
+        input_tensor : bytes
+            The tensor data in bytes format
+        """
+        self._raw_content = raw_content
+
     def set_shared_memory(self, region_name, byte_size, offset=0):
         """Set the tensor data from the specified shared memory region.
 
@@ -2104,7 +2115,7 @@ class InferResult:
         content_encoding : string
             The encoding of the response body if it is compressed.
             Default value is None.
-        
+
         Returns
         -------
         InferResult

--- a/src/python/library/tritonclient/http/__init__.py
+++ b/src/python/library/tritonclient/http/__init__.py
@@ -1868,13 +1868,13 @@ class InferInput:
                 self._raw_data = input_tensor.tobytes()
             self._parameters['binary_data_size'] = len(self._raw_data)
 
-    def set_data_from_numpy(self, raw_content):
+    def set_data_from_bytes(self, raw_content):
         """Set the tensor data from the specified bytes for
         input associated with this object.
 
         Parameters
         ----------
-        input_tensor : bytes
+        raw_content : bytes
             The tensor data in bytes format
         """
         self._raw_content = raw_content


### PR DESCRIPTION

# Objective

In python, `InferInput` only support `set_data_from_numpy`. It means that users have to convert their data to numpy array even though it it not necessary.

So, I added an interface that can set raw_content without converting to numpy array.


## Detail

When model in triton server can process data that has bytes datatype,  User don't have to converting it to numpy array.

For example, if we use dali as preprocessor, dali can process bytes data.



