### PR TITLE
Fix bugs where stats carried forward between rates

### DIFF
--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -314,6 +314,12 @@ ConcurrencyManager::Infer(
         while (total_ongoing_requests != 0) {
           std::this_thread::sleep_for(std::chrono::milliseconds(500));
         }
+        // Make sure all threads are in sync with the client's stats
+        //
+        for (size_t i = 0; i < ctxs.size(); ++i) {
+          ctxs[i]->infer_backend_->ClientInferStat(
+              &(thread_stat->contexts_stat_[i]));
+        }
         // Reconstruct 'free_ctx_ids' because complete_ongoing_sequence_func()
         // has destructive side affects
         free_ctx_ids = std::queue<int>();

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -648,6 +648,11 @@ InferenceProfiler::ProfileHelper(
   all_timestamps_.clear();
   previous_window_end_ns_ = 0;
 
+  // Start with a fresh empty timestamp vector in the manager
+  //
+  TimestampVector empty_timestamps;
+  RETURN_IF_ERROR(manager_->SwapTimestamps(empty_timestamps));
+
   do {
     PerfStatus status_summary;
     RETURN_IF_ERROR(manager_->CheckHealth());


### PR DESCRIPTION
- Fixed a bug where timestamps after the last window of the previous rate were incorrectly carried over to the next rate
- Added a check to confirm that after Pausing workers, the clients and the manager are in sync with their stats. This exposed a bug in ConcurrencyManager (and confirmed correct behavior in RequestRateManager)
- Fixed the bug mentioned above in ConcurrencyManager


