### PR TITLE
Remove Name Collision (Min)

### DIFF
--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -37,6 +37,10 @@
 #include <iostream>
 #include "http_client.h"
 
+#ifdef _WIN32
+#undef min
+#endif
+
 extern "C" {
 #include "cencode.h"
 }


### PR DESCRIPTION
The HTTP client uses std::min, which will collide with the `min` macro included with `windows.h` on Windows machines. This leads to compilation issues here.

Undefine it to eliminate this collision here.

See more information about this fix here: https://stackoverflow.com/questions/21483038/undefining-min-and-max-macros