### PR TITLE
Update grpcio versions

### DIFF
--- a/src/python/library/requirements/requirements_grpc.txt
+++ b/src/python/library/requirements/requirements_grpc.txt
@@ -31,6 +31,6 @@ protobuf>=3.5.0,<3.20
 # There is memory leak in later Python GRPC (1.43.0 to be specific),
 # use known working version until the memory leak is resolved in the future
 # (see https://github.com/grpc/grpc/issues/28513)
-grpcio==1.41.0
+grpcio==1.42.0
 numpy>=1.19.1
 python-rapidjson>=0.9.1


### PR DESCRIPTION
Update to 1.42.0 to still avoid the memory leak but updated enough to allow using python 3.10 +
https://github.com/triton-inference-server/client/pull/92#issuecomment-1296376735