### PR TITLE
Clarify timeout documentation and added formatting

### DIFF
--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -204,7 +204,7 @@ struct InferOptions {
   /// cannot be completed within the time by the server. The server can take a
   /// model-specific action such as terminating the request. If not
   /// provided, the server will handle the request using default setting
-  /// for the model.
+  /// for the model. This is only used for dynamically batched models.
   uint64_t server_timeout_;
   // The maximum end-to-end time, in microseconds, the request is allowed
   // to take. Note the HTTP library only offer the precision upto

--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -204,7 +204,9 @@ struct InferOptions {
   /// cannot be completed within the time by the server. The server can take a
   /// model-specific action such as terminating the request. If not
   /// provided, the server will handle the request using default setting
-  /// for the model. This is only used for dynamically batched models.
+  /// for the model. This option is only respected by the model that is
+  /// configured with dynamic batching. See here for more details:
+  /// https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#dynamic-batcher
   uint64_t server_timeout_;
   // The maximum end-to-end time, in microseconds, the request is allowed
   // to take. Note the HTTP library only offer the precision upto

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -30,8 +30,8 @@
 
 #include <curl/curl.h>
 #include <zlib.h>
-#include <climits>
 #include <atomic>
+#include <climits>
 #include <cstdint>
 #include <deque>
 #include <iostream>
@@ -49,7 +49,7 @@ extern "C" {
 #ifdef _WIN32
 #define strncasecmp(x, y, z) _strnicmp(x, y, z)
 #undef min  // NOMINMAX did not resolve std::min compile error
-#endif  //_WIN32
+#endif      //_WIN32
 
 namespace triton { namespace client {
 
@@ -1905,8 +1905,7 @@ InferenceServerHttpClient::AsyncTransfer()
     if (mc == CURLM_OK) {
       // Wait for activity. If there are no descripters in the multi_handle_
       // then curl_multi_wait will return immediately
-      mc =
-          curl_multi_wait(multi_handle_, NULL, 0, INT_MAX, &numfds);
+      mc = curl_multi_wait(multi_handle_, NULL, 0, INT_MAX, &numfds);
       if (mc == CURLM_OK) {
         while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
           uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);

--- a/src/c++/perf_analyzer/doctest.h
+++ b/src/c++/perf_analyzer/doctest.h
@@ -4488,7 +4488,7 @@ wildcmp(const char* str, const char* wild, bool caseSensitive)
 }
 
 //// C string hash function (djb2) - taken from
-///http://www.cse.yorku.ca/~oz/hash.html
+/// http://www.cse.yorku.ca/~oz/hash.html
 // unsigned hashStr(unsigned const char* str) {
 //    unsigned long hash = 5381;
 //    char          c;
@@ -6220,7 +6220,8 @@ fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb)
                      : "did NOT throw at all!")
       << Color::Cyan << rb.m_exception << "\n";
   } else if (rb.m_at & assertType::is_throws_with) {  //! OCLINT bitwise
-                                                      //! operator in conditional
+                                                      //! operator in
+                                                      //! conditional
     s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
       << rb.m_exception_string << "\" ) " << Color::None
       << (rb.m_threw ? (!rb.m_failed ? "threw as expected!"
@@ -7689,8 +7690,8 @@ Context::run()
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
         try {
 #endif  // DOCTEST_CONFIG_NO_EXCEPTIONS
-          // MSVC 2015 diagnoses fatalConditionHandler as unused (because
-          // reset() is a static method)
+        // MSVC 2015 diagnoses fatalConditionHandler as unused (because
+        // reset() is a static method)
           DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(
               4101)  // unreferenced local variable
           FatalConditionHandler fatalConditionHandler;  // Handle signals

--- a/src/c++/perf_analyzer/test_utils.h
+++ b/src/c++/perf_analyzer/test_utils.h
@@ -35,20 +35,25 @@ namespace triton { namespace perfanalyzer {
 
 /// Calculate the average of a vector of integers
 ///
-static double CalculateAverage(const std::vector<int64_t>& values) {
-    double avg = std::accumulate(values.begin(), values.end(), 0.0) / values.size();
-    return avg;
+static double
+CalculateAverage(const std::vector<int64_t>& values)
+{
+  double avg =
+      std::accumulate(values.begin(), values.end(), 0.0) / values.size();
+  return avg;
 }
 
 /// Calculate the variance of a vector of integers
 ///
-static double CalculateVariance(const std::vector<int64_t>& values, double average) {
-    double tmp = 0;
-    for (auto value : values) {
-        tmp += (value - average) * (value - average) / values.size();
-    }
-    double variance = std::sqrt(tmp);
-    return variance;
+static double
+CalculateVariance(const std::vector<int64_t>& values, double average)
+{
+  double tmp = 0;
+  for (auto value : values) {
+    tmp += (value - average) * (value - average) / values.size();
+  }
+  double variance = std::sqrt(tmp);
+  return variance;
 }
 
-}}
+}}  // namespace triton::perfanalyzer

--- a/src/python/examples/simple_http_aio_infer_client.py
+++ b/src/python/examples/simple_http_aio_infer_client.py
@@ -186,8 +186,8 @@ async def main(FLAGS):
 
     # Infer with incorrect model name
     try:
-        (await test_infer(triton_client, "wrong_model_name",
-                                     input0_data, input1_data)).get_response()
+        (await test_infer(triton_client, "wrong_model_name", input0_data,
+                          input1_data)).get_response()
         print("expected error message for wrong model name")
         sys.exit(1)
     except InferenceServerException as ex:

--- a/src/python/library/tritonclient/grpc/__init__.py
+++ b/src/python/library/tritonclient/grpc/__init__.py
@@ -1370,7 +1370,7 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model.
+            for the model. This is only used for dynamically batched models.
         client_timeout : float
             The maximum end-to-end time, in seconds, the request is allowed
             to take. The client will abort request and raise
@@ -1499,7 +1499,7 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model.
+            for the model. This is only used for dynamically batched models.
         client_timeout : float
             The maximum end-to-end time, in seconds, the request is allowed
             to take. The client will abort request and provide
@@ -1694,7 +1694,8 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model. This does not stop the grpc stream itself.
+            for the model. This does not stop the grpc stream itself and
+            is only used for dynamically batched models.
 
         Raises
         ------

--- a/src/python/library/tritonclient/grpc/__init__.py
+++ b/src/python/library/tritonclient/grpc/__init__.py
@@ -1588,8 +1588,8 @@ class InferenceServerClient:
             ownership of these objects will be given to the user. The
             'error' would be None for a successful inference.
         stream_timeout : float
-            Optional stream timeout. The stream will be closed once the
-            specified timeout expires.
+            Optional stream timeout (in seconds). The stream will be closed 
+            once the specified timeout expires.
         headers: dict
             Optional dictionary specifying additional HTTP
             headers to include in the request.
@@ -1694,7 +1694,7 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model.
+            for the model. This does not stop the grpc stream itself.
 
         Raises
         ------

--- a/src/python/library/tritonclient/grpc/__init__.py
+++ b/src/python/library/tritonclient/grpc/__init__.py
@@ -1370,7 +1370,9 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model. This is only used for dynamically batched models.
+            for the model. This option is only respected by the model that is 
+            configured with dynamic batching. See here for more details: 
+            https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#dynamic-batcher
         client_timeout : float
             The maximum end-to-end time, in seconds, the request is allowed
             to take. The client will abort request and raise
@@ -1499,8 +1501,9 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model. This is only used for dynamically batched models.
-        client_timeout : float
+            for the model. This option is only respected by the model that is 
+            configured with dynamic batching. See here for more details: 
+            https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#dynamic-batcher
             The maximum end-to-end time, in seconds, the request is allowed
             to take. The client will abort request and provide
             error with message "Deadline Exceeded" in the callback when the
@@ -1694,9 +1697,10 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model. This does not stop the grpc stream itself and
-            is only used for dynamically batched models.
-
+            for the model. This does not stop the grpc stream itself and is only 
+            respected by the model that is configured with dynamic batching. 
+            See here for more details: 
+            https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#dynamic-batcher
         Raises
         ------
         InferenceServerException

--- a/src/python/library/tritonclient/http/__init__.py
+++ b/src/python/library/tritonclient/http/__init__.py
@@ -1291,7 +1291,7 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model.
+            for the model. This is only used for dynamically batched models.
 
         Returns
         -------
@@ -1406,7 +1406,7 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model.
+            for the model. This is only used for dynamically batched models.
         headers: dict
             Optional dictionary specifying additional HTTP
             headers to include in the request.
@@ -1555,7 +1555,7 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model.
+            for the model. This is only used for dynamically batched models.
         headers: dict
             Optional dictionary specifying additional HTTP
             headers to include in the request

--- a/src/python/library/tritonclient/http/__init__.py
+++ b/src/python/library/tritonclient/http/__init__.py
@@ -1291,7 +1291,9 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model. This is only used for dynamically batched models.
+            for the model. This option is only respected by the model that is 
+            configured with dynamic batching. See here for more details: 
+            https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#dynamic-batcher
 
         Returns
         -------
@@ -1406,7 +1408,9 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model. This is only used for dynamically batched models.
+            for the model. This option is only respected by the model that is 
+            configured with dynamic batching. See here for more details: 
+            https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#dynamic-batcher
         headers: dict
             Optional dictionary specifying additional HTTP
             headers to include in the request.
@@ -1555,7 +1559,9 @@ class InferenceServerClient:
             cannot be completed within the time the server can take a
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
-            for the model. This is only used for dynamically batched models.
+            for the model. This option is only respected by the model that is 
+            configured with dynamic batching. See here for more details: 
+            https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#dynamic-batcher
         headers: dict
             Optional dictionary specifying additional HTTP
             headers to include in the request

--- a/src/python/library/tritonclient/utils/__init__.py
+++ b/src/python/library/tritonclient/utils/__init__.py
@@ -216,10 +216,10 @@ def serialize_byte_tensor(input_tensor):
     # actual element bytes. All elements are concatenated together in row-major
     # order.
 
-    if (input_tensor.dtype != np.object_) and (input_tensor.dtype.type
-                                              != np.bytes_):
+    if (input_tensor.dtype != np.object_) and (input_tensor.dtype.type !=
+                                               np.bytes_):
         raise_error("cannot serialize bytes tensor: invalid datatype")
-    
+
     flattened_ls = []
     # 'C' order is row-major.
     for obj in np.nditer(input_tensor, flags=["refs_ok"], order='C'):
@@ -239,7 +239,7 @@ def serialize_byte_tensor(input_tensor):
     flattened_array = np.asarray(flattened, dtype=np.object_)
     if not flattened_array.flags['C_CONTIGUOUS']:
         flattened_array = np.ascontiguousarray(flattened_array,
-                                                dtype=np.object_)
+                                               dtype=np.object_)
     return flattened_array
 
 
@@ -303,7 +303,7 @@ def serialize_bf16_tensor(input_tensor):
 
     if (input_tensor.dtype != np.float32):
         raise_error("cannot serialize bf16 tensor: invalid datatype")
-    
+
     flattened_ls = []
     # 'C' order is row-major.
     for obj in np.nditer(input_tensor, flags=["refs_ok"], order='C'):
@@ -314,7 +314,7 @@ def serialize_bf16_tensor(input_tensor):
     flattened_array = np.asarray(flattened, dtype=np.object_)
     if not flattened_array.flags['C_CONTIGUOUS']:
         flattened_array = np.ascontiguousarray(flattened_array,
-                                                dtype=np.object_)
+                                               dtype=np.object_)
     return flattened_array
 
 


### PR DESCRIPTION
Clarify `server_timeout` usage in documentation
Related server PR: https://github.com/triton-inference-server/server/pull/5169
Formatted:
```
        modified:   src/c++/library/http_client.cc
        modified:   src/c++/perf_analyzer/doctest.h
        modified:   src/c++/perf_analyzer/test_perf_utils.cc
        modified:   src/c++/perf_analyzer/test_utils.h
        modified:   src/python/examples/simple_http_aio_infer_client.py
        modified:   src/python/library/tritonclient/utils/__init__.py
```