### PR TITLE
Fix bug where first window had no starting server stats

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1092,9 +1092,6 @@ InferenceProfiler::Measure(
     if (include_server_stats_) {
       RETURN_IF_ERROR(GetServerSideStatus(&start_status));
     }
-    // Need to zero out start stats when window start is 0
-    start_status = std::map<cb::ModelIdentifier, cb::ModelStatistics>();
-    start_stat = cb::InferStat();
     RETURN_IF_ERROR(manager_->GetAccumulatedClientStat(&start_stat));
   }
 


### PR DESCRIPTION
The code was incorrectly clearing out the server stats. What was supposed to happen (and already was immediately above it) was to synchronize the server stats at the start of the first window.