### PR TITLE
Fix bug in GetAccumulatedClientStat

### DIFF
--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -174,6 +174,11 @@ LoadManager::CountCollectedRequests()
 cb::Error
 LoadManager::GetAccumulatedClientStat(cb::InferStat* contexts_stat)
 {
+  contexts_stat->completed_request_count = 0;
+  contexts_stat->cumulative_receive_time_ns = 0;
+  contexts_stat->cumulative_send_time_ns = 0;
+  contexts_stat->cumulative_total_request_time_ns = 0;
+
   for (auto& thread_stat : threads_stat_) {
     std::lock_guard<std::mutex> lock(thread_stat->mu_);
     for (auto& context_stat : thread_stat->contexts_stat_) {

--- a/src/c++/perf_analyzer/test_load_manager.cc
+++ b/src/c++/perf_analyzer/test_load_manager.cc
@@ -217,31 +217,6 @@ class TestLoadManager : public TestLoadManagerBase, public LoadManager {
       CHECK(result_stat.cumulative_receive_time_ns == 5);
       CHECK(ret.IsOk() == true);
     }
-    SUBCASE("Existing data in function arg")
-    {
-      // If the input InferStat already has data in it,
-      // it will be included in the output result
-      //
-      result_stat.completed_request_count = 10;
-      result_stat.cumulative_total_request_time_ns = 10;
-      result_stat.cumulative_send_time_ns = 10;
-      result_stat.cumulative_receive_time_ns = 10;
-
-      auto stat1 = std::make_shared<ThreadStat>();
-      stat1->contexts_stat_.push_back(cb::InferStat());
-      stat1->contexts_stat_[0].completed_request_count = 2;
-      stat1->contexts_stat_[0].cumulative_total_request_time_ns = 3;
-      stat1->contexts_stat_[0].cumulative_send_time_ns = 4;
-      stat1->contexts_stat_[0].cumulative_receive_time_ns = 5;
-      threads_stat_.push_back(stat1);
-
-      auto ret = GetAccumulatedClientStat(&result_stat);
-      CHECK(result_stat.completed_request_count == 12);
-      CHECK(result_stat.cumulative_total_request_time_ns == 13);
-      CHECK(result_stat.cumulative_send_time_ns == 14);
-      CHECK(result_stat.cumulative_receive_time_ns == 15);
-      CHECK(ret.IsOk() == true);
-    }
     SUBCASE("Multiple thread multiple contexts")
     {
       auto stat1 = std::make_shared<ThreadStat>();


### PR DESCRIPTION
Any existing value in the object should be ignored. The result of the function should only factor in the data in the contexts and nothing else