### PR TITLE
Fix input json reading bug

### DIFF
--- a/src/c++/perf_analyzer/data_loader.cc
+++ b/src/c++/perf_analyzer/data_loader.cc
@@ -138,11 +138,11 @@ DataLoader::ReadDataFromJSON(
   char readBuffer[65536];
   rapidjson::FileReadStream fs(data_file, readBuffer, sizeof(readBuffer));
 
-  fclose(data_file);
-
   rapidjson::Document d{};
   const unsigned int parseFlags = rapidjson::kParseNanAndInfFlag;
   d.ParseStream<parseFlags>(fs);
+
+  fclose(data_file);
 
   return ParseData(d, inputs, outputs);
 }


### PR DESCRIPTION
File was being closed too early. RapidJson documentation shows closing file after call to `ParseStream()`:

https://rapidjson.org/md_doc_stream.html#FileReadStream