### PR TITLE
Fix CTX IDs bug for concurrency manager

### DIFF
--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -92,6 +92,12 @@ class ConcurrencyManager : public LoadManager {
   /// \return cb::Error object indicating success or failure.
   cb::Error ChangeConcurrencyLevel(const size_t concurrent_request_count);
 
+ protected:
+  // Makes a new worker
+  virtual std::shared_ptr<IWorker> MakeWorker(
+      std::shared_ptr<ThreadStat>,
+      std::shared_ptr<ConcurrencyWorker::ThreadConfig>);
+
  private:
   ConcurrencyManager(
       const bool async, const bool streaming, const int32_t batch_size,
@@ -114,11 +120,6 @@ class ConcurrencyManager : public LoadManager {
   // Restart all worker threads that were working on sequences
   //
   void ResumeSequenceWorkers();
-
-  // Makes a new worker
-  virtual std::shared_ptr<IWorker> MakeWorker(
-      std::shared_ptr<ThreadStat>,
-      std::shared_ptr<ConcurrencyWorker::ThreadConfig>);
 
   // The number of worker threads with non-zero concurrencies
   size_t active_threads_;

--- a/src/c++/perf_analyzer/concurrency_worker.cc
+++ b/src/c++/perf_analyzer/concurrency_worker.cc
@@ -135,10 +135,12 @@ ConcurrencyWorker::CreateContextsAsNecessary()
   // maintain concurrency for this thread.
   size_t active_ctx_cnt = on_sequence_model_ ? thread_config_->concurrency_ : 1;
 
-  while (active_ctx_cnt > ctxs_.size()) {
-    CreateContext();
+  if (active_ctx_cnt > ctxs_.size()) {
+    while (active_ctx_cnt > ctxs_.size()) {
+      CreateContext();
+    }
+    ResetFreeCtxIds();
   }
-  ResetFreeCtxIds();
 }
 
 void

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -274,7 +274,7 @@ class TestRequestRateManager : public TestLoadManagerBase,
   ///
   void TestSequences()
   {
-    stats_->response_delay = std::chrono::milliseconds(10);
+    stats_->SetDelays({10});
     double request_rate1 = 100;
     double request_rate2 = 200;
 


### PR DESCRIPTION
CTX IDs were being incorrectly reset over and over instead of just when the contexts are created during setup.
Added a test to expose the issue, which involved adding the ability to specify multiple response latencies instead of just one fixed one.