### PR TITLE
[Java] Fix the phenomenon that null is set in path

### DIFF
--- a/src/java/src/main/java/triton/client/InferenceServerClient.java
+++ b/src/java/src/main/java/triton/client/InferenceServerClient.java
@@ -313,7 +313,8 @@ public class InferenceServerClient implements AutoCloseable {
         String requestUri = Util.isEmpty(arg.modelVersion) ?
             String.format("/v2/models/%s/infer", safeModelName) :
             String.format("/v2/models/%s/versions/%s/infer", safeModelName, arg.modelVersion);
-        ub.setPath(ub.getPath() + requestUri);
+        String addPath = ub.getPath() == null ? requestUri : ub.getPath() + requestUri;
+        ub.setPath(addPath);
         arg.queryParams.forEach(ub::addParameter);
 
         // Crete HttpPost, uri, body and headers.


### PR DESCRIPTION
If there is no path, `null` is included in the url and the post request is sent.
`/null/v2/models/<model_name>/infer`

So, defense logic is added so that only `requestUri` is added in case of null.

---
Environment: spring boot + kotlin
Used by importing `jar`
