### PR TITLE
Add sequence manager

### DIFF
--- a/src/c++/perf_analyzer/CMakeLists.txt
+++ b/src/c++/perf_analyzer/CMakeLists.txt
@@ -53,6 +53,7 @@ set(
   mpi_utils.cc
   metrics_manager.cc
   infer_data_manager.cc
+  sequence_manager.cc
 )
 
 set(
@@ -81,6 +82,8 @@ set(
   test_load_manager_base.h
   infer_data_manager.h
   infer_data.h
+  sequence_manager.h
+  sequence_status.h
 )
 
 add_executable(
@@ -170,6 +173,7 @@ add_executable(
   test_request_rate_manager.cc
   test_concurrency_manager.cc
   test_custom_load_manager.cc
+  test_sequence_manager.cc
   $<TARGET_OBJECTS:json-utils-library>
 )
 

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -62,7 +62,6 @@ class ConcurrencyManager : public LoadManager {
   /// \param batch_size The batch size used for each request.
   /// \param max_threads The maximum number of working threads to be spawned.
   /// \param max_concurrency The maximum concurrency which will be requested.
-  /// \param sequence_length The base length of each sequence.
   /// \param string_length The length of the string to create for input.
   /// \param string_data The data to use for generating string input.
   /// \param zero_input Whether to fill the input tensors with zero.
@@ -79,9 +78,7 @@ class ConcurrencyManager : public LoadManager {
   static cb::Error Create(
       const bool async, const bool streaming, const int32_t batch_size,
       const size_t max_threads, const size_t max_concurrency,
-      const size_t sequence_length, const SharedMemoryType shared_memory_type,
-      const size_t output_shm_size, const uint64_t start_sequence_id,
-      const uint64_t sequence_id_range,
+      const SharedMemoryType shared_memory_type, const size_t output_shm_size,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory,
       std::unique_ptr<LoadManager>* manager);
@@ -102,11 +99,11 @@ class ConcurrencyManager : public LoadManager {
   ConcurrencyManager(
       const bool async, const bool streaming, const int32_t batch_size,
       const size_t max_threads, const size_t max_concurrency,
-      const size_t sequence_length, const SharedMemoryType shared_memory_type,
-      const size_t output_shm_size, const uint64_t start_sequence_id,
-      const uint64_t sequence_id_range,
+      const SharedMemoryType shared_memory_type, const size_t output_shm_size,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
+
+  void InitManagerFinalize() override;
 
   // Pause all worker threads that are working on sequences
   //

--- a/src/c++/perf_analyzer/concurrency_worker.h
+++ b/src/c++/perf_analyzer/concurrency_worker.h
@@ -31,6 +31,7 @@
 #include <random>
 
 #include "load_worker.h"
+#include "sequence_manager.h"
 
 namespace triton { namespace perfanalyzer {
 
@@ -67,22 +68,18 @@ class ConcurrencyWorker : public LoadWorker {
       const std::shared_ptr<ModelParser> parser,
       std::shared_ptr<DataLoader> data_loader,
       const std::shared_ptr<cb::ClientBackendFactory> factory,
-      const size_t sequence_length, const uint64_t start_sequence_id,
-      const uint64_t sequence_id_range, const bool on_sequence_model,
-      const bool async, const size_t max_concurrency,
-      const bool using_json_data, const bool streaming,
-      const int32_t batch_size,
+      const bool on_sequence_model, const bool async,
+      const size_t max_concurrency, const bool using_json_data,
+      const bool streaming, const int32_t batch_size,
       std::vector<std::shared_ptr<ThreadConfig>>& threads_config,
-      std::vector<std::shared_ptr<SequenceStat>>& sequence_stat,
       std::condition_variable& wake_signal, std::mutex& wake_mutex,
-      size_t& active_threads, bool& execute, std::atomic<uint64_t>& curr_seq_id,
-      std::uniform_int_distribution<uint64_t>& distribution,
-      const std::shared_ptr<InferDataManager>& infer_data_manager)
+      size_t& active_threads, bool& execute,
+      const std::shared_ptr<InferDataManager>& infer_data_manager,
+      std::shared_ptr<SequenceManager> sequence_manager)
       : LoadWorker(
-            id, thread_stat, parser, data_loader, factory, sequence_stat,
-            on_sequence_model, async, streaming, batch_size, using_json_data,
-            sequence_length, start_sequence_id, sequence_id_range, curr_seq_id,
-            distribution, wake_signal, wake_mutex, execute, infer_data_manager),
+            id, thread_stat, parser, data_loader, factory, on_sequence_model,
+            async, streaming, batch_size, using_json_data, wake_signal,
+            wake_mutex, execute, infer_data_manager, sequence_manager),
         thread_config_(thread_config), max_concurrency_(max_concurrency),
         threads_config_(threads_config), active_threads_(active_threads)
   {

--- a/src/c++/perf_analyzer/custom_load_manager.cc
+++ b/src/c++/perf_analyzer/custom_load_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -36,9 +36,7 @@ CustomLoadManager::Create(
     const uint64_t measurement_window_ms, const size_t max_trials,
     const std::string& request_intervals_file, const int32_t batch_size,
     const size_t max_threads, const uint32_t num_of_sequences,
-    const size_t sequence_length, const SharedMemoryType shared_memory_type,
-    const size_t output_shm_size, const uint64_t start_sequence_id,
-    const uint64_t sequence_id_range,
+    const SharedMemoryType shared_memory_type, const size_t output_shm_size,
     const std::shared_ptr<ModelParser>& parser,
     const std::shared_ptr<cb::ClientBackendFactory>& factory,
     std::unique_ptr<LoadManager>* manager)
@@ -46,8 +44,7 @@ CustomLoadManager::Create(
   std::unique_ptr<CustomLoadManager> local_manager(new CustomLoadManager(
       async, streaming, request_intervals_file, batch_size,
       measurement_window_ms, max_trials, max_threads, num_of_sequences,
-      sequence_length, shared_memory_type, output_shm_size, start_sequence_id,
-      sequence_id_range, parser, factory));
+      shared_memory_type, output_shm_size, parser, factory));
 
   *manager = std::move(local_manager);
 
@@ -59,16 +56,13 @@ CustomLoadManager::CustomLoadManager(
     const std::string& request_intervals_file, int32_t batch_size,
     const uint64_t measurement_window_ms, const size_t max_trials,
     const size_t max_threads, const uint32_t num_of_sequences,
-    const size_t sequence_length, const SharedMemoryType shared_memory_type,
-    const size_t output_shm_size, const uint64_t start_sequence_id,
-    const uint64_t sequence_id_range,
+    const SharedMemoryType shared_memory_type, const size_t output_shm_size,
     const std::shared_ptr<ModelParser>& parser,
     const std::shared_ptr<cb::ClientBackendFactory>& factory)
     : RequestRateManager(
           async, streaming, Distribution::CUSTOM, batch_size,
           measurement_window_ms, max_trials, max_threads, num_of_sequences,
-          sequence_length, shared_memory_type, output_shm_size,
-          start_sequence_id, sequence_id_range, parser, factory),
+          shared_memory_type, output_shm_size, parser, factory),
       request_intervals_file_(request_intervals_file)
 {
 }

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -59,7 +59,6 @@ class CustomLoadManager : public RequestRateManager {
   /// \param max_threads The maximum number of working threads to be spawned.
   /// \param num_of_sequences The number of concurrent sequences that must be
   /// maintained on the server.
-  /// \param sequence_length The base length of each sequence.
   /// \param zero_input Whether to fill the input tensors with zero.
   /// \param input_shapes The shape of the input tensors.
   /// \param user_data The vector containing path/paths to user-provided data
@@ -77,9 +76,7 @@ class CustomLoadManager : public RequestRateManager {
       const uint64_t measurement_window_ms, const size_t max_trials,
       const std::string& request_intervals_file, const int32_t batch_size,
       const size_t max_threads, const uint32_t num_of_sequences,
-      const size_t sequence_length, const SharedMemoryType shared_memory_type,
-      const size_t output_shm_size, const uint64_t start_sequence_id,
-      const uint64_t sequence_id_range,
+      const SharedMemoryType shared_memory_type, const size_t output_shm_size,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory,
       std::unique_ptr<LoadManager>* manager);
@@ -102,9 +99,7 @@ class CustomLoadManager : public RequestRateManager {
       const std::string& request_intervals_file, const int32_t batch_size,
       const uint64_t measurement_window_ms, const size_t max_trials,
       const size_t max_threads, const uint32_t num_of_sequences,
-      const size_t sequence_length, const SharedMemoryType shared_memory_type,
-      const size_t output_shm_size, const uint64_t start_sequence_id,
-      const uint64_t sequence_id_range,
+      const SharedMemoryType shared_memory_type, const size_t output_shm_size,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
 

--- a/src/c++/perf_analyzer/data_loader.h
+++ b/src/c++/perf_analyzer/data_loader.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -30,6 +30,10 @@
 #include "perf_utils.h"
 
 namespace triton { namespace perfanalyzer {
+
+#ifndef DOCTEST_CONFIG_DISABLE
+class MockDataLoader;
+#endif
 
 class DataLoader {
  public:
@@ -168,6 +172,8 @@ class DataLoader {
   std::vector<uint8_t> input_buf_;
 
 #ifndef DOCTEST_CONFIG_DISABLE
+  friend MockDataLoader;
+
  protected:
   DataLoader() = default;
 #endif

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -202,9 +202,8 @@ PerfAnalyzer::CreateAnalyzerObjects()
         pa::ConcurrencyManager::Create(
             params_->async, params_->streaming, params_->batch_size,
             params_->max_threads, params_->max_concurrency,
-            params_->sequence_length, params_->shared_memory_type,
-            params_->output_shm_size, params_->start_sequence_id,
-            params_->sequence_id_range, parser_, factory, &manager),
+            params_->shared_memory_type, params_->output_shm_size, parser_,
+            factory, &manager),
         "failed to create concurrency manager");
 
   } else if (params_->using_request_rate_range) {
@@ -221,10 +220,8 @@ PerfAnalyzer::CreateAnalyzerObjects()
             params_->async, params_->streaming, params_->measurement_window_ms,
             params_->max_trials, params_->request_distribution,
             params_->batch_size, params_->max_threads,
-            params_->num_of_sequences, params_->sequence_length,
-            params_->shared_memory_type, params_->output_shm_size,
-            params_->start_sequence_id, params_->sequence_id_range, parser_,
-            factory, &manager),
+            params_->num_of_sequences, params_->shared_memory_type,
+            params_->output_shm_size, parser_, factory, &manager),
         "failed to create request rate manager");
 
   } else {
@@ -241,16 +238,15 @@ PerfAnalyzer::CreateAnalyzerObjects()
             params_->async, params_->streaming, params_->measurement_window_ms,
             params_->max_trials, params_->request_intervals_file,
             params_->batch_size, params_->max_threads,
-            params_->num_of_sequences, params_->sequence_length,
-            params_->shared_memory_type, params_->output_shm_size,
-            params_->start_sequence_id, params_->sequence_id_range, parser_,
-            factory, &manager),
+            params_->num_of_sequences, params_->shared_memory_type,
+            params_->output_shm_size, parser_, factory, &manager),
         "failed to create custom load manager");
   }
 
   manager->InitManager(
       params_->string_length, params_->string_data, params_->zero_input,
-      params_->user_data);
+      params_->user_data, params_->start_sequence_id,
+      params_->sequence_id_range, params_->sequence_length);
 
   FAIL_IF_ERR(
       pa::InferenceProfiler::Create(

--- a/src/c++/perf_analyzer/request_rate_manager.h
+++ b/src/c++/perf_analyzer/request_rate_manager.h
@@ -70,7 +70,6 @@ class RequestRateManager : public LoadManager {
   /// \param max_threads The maximum number of working threads to be spawned.
   /// \param num_of_sequences The number of concurrent sequences that must be
   /// maintained on the server.
-  /// \param sequence_length The base length of each sequence.
   /// \param string_length The length of the string to create for input.
   /// \param string_data The data to use for generating string input.
   /// \param zero_input Whether to fill the input tensors with zero.
@@ -89,9 +88,7 @@ class RequestRateManager : public LoadManager {
       const uint64_t measurement_window_ms, const size_t max_trials,
       Distribution request_distribution, const int32_t batch_size,
       const size_t max_threads, const uint32_t num_of_sequences,
-      const size_t sequence_length, const SharedMemoryType shared_memory_type,
-      const size_t output_shm_size, const uint64_t start_sequence_id,
-      const uint64_t sequence_id_range,
+      const SharedMemoryType shared_memory_type, const size_t output_shm_size,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory,
       std::unique_ptr<LoadManager>* manager);
@@ -111,11 +108,12 @@ class RequestRateManager : public LoadManager {
       const bool async, const bool streaming, Distribution request_distribution,
       const int32_t batch_size, const uint64_t measurement_window_ms,
       const size_t max_trials, const size_t max_threads,
-      const uint32_t num_of_sequences, const size_t sequence_length,
+      const uint32_t num_of_sequences,
       const SharedMemoryType shared_memory_type, const size_t output_shm_size,
-      const uint64_t start_sequence_id, const uint64_t sequence_id_range,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
+
+  void InitManagerFinalize() override;
 
   /// Generates and update the request schedule as per the given request rate.
   /// \param request_rate The request rate to use for new schedule.
@@ -149,6 +147,7 @@ class RequestRateManager : public LoadManager {
   Distribution request_distribution_;
   std::chrono::steady_clock::time_point start_time_;
   bool execute_;
+  const size_t num_of_sequences_{0};
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend TestRequestRateManager;

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -73,7 +73,7 @@ RequestRateWorker::CompleteOngoingSequences()
     for (size_t ctx_id = 0; ctx_id < ctxs_.size(); ++ctx_id) {
       // Finish off all the ongoing sequences for graceful exit
       for (size_t seq_stat_index = thread_config_->id_;
-           seq_stat_index < sequence_stat_.size();
+           seq_stat_index < sequence_manager_->GetNumSequenceStatuses();
            seq_stat_index += thread_config_->stride_) {
         ctxs_[ctx_id]->CompleteOngoingSequence(seq_stat_index);
       }

--- a/src/c++/perf_analyzer/sequence_manager.cc
+++ b/src/c++/perf_analyzer/sequence_manager.cc
@@ -1,0 +1,155 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "sequence_manager.h"
+
+namespace triton { namespace perfanalyzer {
+
+SequenceManager::SequenceManager(
+    const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+    const size_t sequence_length, const bool using_json_data,
+    std::shared_ptr<DataLoader> data_loader)
+    : start_sequence_id_(start_sequence_id),
+      sequence_id_range_(sequence_id_range), sequence_length_(sequence_length),
+      using_json_data_(using_json_data), data_loader_(data_loader)
+{
+  distribution_ = std::uniform_int_distribution<uint64_t>(
+      0, data_loader_->GetDataStreamsCount() - 1);
+}
+
+void
+SequenceManager::InitSequenceStatuses(size_t num_sequence_statuses)
+{
+  sequence_statuses_.clear();
+  for (size_t sequence_status_index{0};
+       sequence_status_index < num_sequence_statuses; sequence_status_index++) {
+    sequence_statuses_.push_back(std::make_shared<SequenceStatus>());
+  }
+}
+
+std::mutex&
+SequenceManager::GetMutex(size_t sequence_status_index)
+{
+  return sequence_statuses_.at(sequence_status_index)->mtx_;
+}
+
+const uint64_t
+SequenceManager::GetDataStreamID(size_t sequence_status_index) const
+{
+  return sequence_statuses_.at(sequence_status_index)->data_stream_id_;
+}
+
+const size_t
+SequenceManager::GetRemainingQueries(size_t sequence_status_index) const
+{
+  return sequence_statuses_.at(sequence_status_index)->remaining_queries_;
+}
+
+void
+SequenceManager::SetRemainingQueries(
+    size_t sequence_status_index, size_t remaining_queries)
+{
+  sequence_statuses_.at(sequence_status_index)->remaining_queries_ =
+      remaining_queries;
+}
+
+void
+SequenceManager::DecrementRemainingQueries(size_t sequence_status_index)
+{
+  sequence_statuses_.at(sequence_status_index)->remaining_queries_--;
+}
+
+const size_t
+SequenceManager::GetNumSequenceStatuses() const
+{
+  return sequence_statuses_.size();
+}
+
+void
+SequenceManager::SetInferSequenceOptions(
+    const uint32_t seq_stat_index, std::unique_ptr<cb::InferOptions>& options)
+{
+  options->sequence_start_ =
+      (sequence_statuses_[seq_stat_index]->remaining_queries_ == 0);
+
+  // New sequence must be intialized before setting the id.
+  if (options->sequence_start_) {
+    InitNewSequence(seq_stat_index);
+  }
+  options->sequence_id_ = sequence_statuses_[seq_stat_index]->seq_id_;
+  options->sequence_end_ =
+      (sequence_statuses_[seq_stat_index]->remaining_queries_ == 1);
+}
+
+void
+SequenceManager::InitNewSequence(int seq_stat_index)
+{
+  sequence_statuses_[seq_stat_index]->seq_id_ = GetNextSeqId(seq_stat_index);
+  if (!using_json_data_) {
+    size_t new_length = GetRandomSequenceLength(0.2);
+    sequence_statuses_[seq_stat_index]->remaining_queries_ =
+        new_length == 0 ? 1 : new_length;
+  } else {
+    // Selecting next available data stream based on uniform distribution.
+    sequence_statuses_[seq_stat_index]->data_stream_id_ =
+        distribution_(rng_generator_);
+    sequence_statuses_[seq_stat_index]->remaining_queries_ =
+        data_loader_->GetTotalSteps(
+            sequence_statuses_[seq_stat_index]->data_stream_id_);
+  }
+}
+
+uint64_t
+SequenceManager::GetNextSeqId(int seq_stat_index)
+{
+  uint64_t old_seq_id = sequence_statuses_[seq_stat_index]->seq_id_;
+  uint64_t next_seq_id =
+      curr_seq_id_++ % sequence_id_range_ + start_sequence_id_;
+
+  // If the next sequence ID is still in use, reuse the same sequence ID
+  // that this sequence_status used last time
+  //
+  for (uint i = 0; i < sequence_statuses_.size(); i++) {
+    if (next_seq_id == sequence_statuses_[i]->seq_id_) {
+      next_seq_id = old_seq_id;
+      break;
+    }
+  }
+  return next_seq_id;
+}
+
+size_t
+SequenceManager::GetRandomSequenceLength(double offset_ratio)
+{
+  int random_offset = ((2.0 * rand() / double(RAND_MAX)) - 1.0) * offset_ratio *
+                      sequence_length_;
+  if (int(sequence_length_) + random_offset <= 0) {
+    return 1;
+  }
+  return sequence_length_ + random_offset;
+}
+
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/sequence_manager.h
+++ b/src/c++/perf_analyzer/sequence_manager.h
@@ -1,0 +1,186 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "client_backend/client_backend.h"
+#include "data_loader.h"
+#include "sequence_status.h"
+
+namespace triton { namespace perfanalyzer {
+
+#ifndef DOCTEST_CONFIG_DISABLE
+class TestSequenceManager;
+#endif
+
+/// Manages operations related to preparing requests to sequence models.
+///
+class SequenceManager {
+ public:
+  /// Constructs the sequence manager object. Involves initializing the
+  /// distribution for randomly assigning input data streams to new sequences.
+  /// \param start_sequence_id See associated data member description.
+  /// \param sequence_id_range See associated data member description.
+  /// \param sequence_length See associated data member description.
+  /// \param using_json_data See associated data member description.
+  /// \param data_loader See associated data member description.
+  /// \return The constructed sequence manager object.
+  ///
+  SequenceManager(
+      const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+      const size_t sequence_length, const bool using_json_data,
+      std::shared_ptr<DataLoader> data_loader);
+
+  /// Initializes the sequence statuses data structure.
+  /// \param num_sequence_statuses The number of sequence status objects to
+  /// create.
+  ///
+  void InitSequenceStatuses(size_t num_sequence_statuses);
+
+  /// Gets a non-const reference to the mutex for the specified sequence status
+  /// object.
+  /// \param sequence_status_index The index of the sequence status object.
+  /// \return A non-const reference to the mutex for the specified sequence
+  /// status object.
+  ///
+  std::mutex& GetMutex(size_t sequence_status_index);
+
+  /// Gets the data stream ID for the specified sequence status object.
+  /// \param sequence_status_index The index of the sequence status object.
+  /// \return The data stream ID for the specified sequence status object.
+  ///
+  const uint64_t GetDataStreamID(size_t sequence_status_index) const;
+
+  /// Gets the remaining queries for the specified sequence status object.
+  /// \param sequence_status_index The index of the sequence status object.
+  /// \return The remaining queries for the specified sequence status object.
+  ///
+  const size_t GetRemainingQueries(size_t sequence_status_index) const;
+
+  /// Sets the remaining queries for the specified sequence status object.
+  /// \param sequence_status_index The index of the sequence status object.
+  /// \param remaining_queries The new value of the remaining queries for the
+  /// specified sequence status object.
+  ///
+  void SetRemainingQueries(
+      size_t sequence_status_index, size_t remaining_queries);
+
+  /// Decrements the remaining queries for the specified sequence status object.
+  /// \param sequence_status_index The index of the sequence status object.
+  ///
+  void DecrementRemainingQueries(size_t sequence_status_index);
+
+  /// Gets the number of sequence status objects in the sequence statuses data
+  /// structure.
+  /// \param sequence_status_index The index of the sequence status object.
+  /// \return The number of sequence status objects in the sequence statuses
+  /// data structure.
+  ///
+  const size_t GetNumSequenceStatuses() const;
+
+  /// Sets options related to a single request to a sequence model.
+  /// \param seq_stat_index The index for the sequence status object that is
+  /// having its options set.
+  /// \param options The options object for the request that is being prepared.
+  ///
+  void SetInferSequenceOptions(
+      const uint32_t seq_stat_index,
+      std::unique_ptr<cb::InferOptions>& options);
+
+ private:
+  /// Initializes values for a sequence status object.
+  /// \param seq_stat_index The index for the sequence status object that is
+  /// being initialized.
+  ///
+  void InitNewSequence(int seq_stat_index);
+
+  /// Determines an appropriate next sequence ID for a renewed sequence status
+  /// object.
+  /// \param seq_stat_index The index for the sequence for which a request is
+  /// being prepared.
+  /// \return The potentially new sequence ID to be used by a renewed sequence
+  /// status object.
+  ///
+  uint64_t GetNextSeqId(int seq_stat_index);
+
+  /// Generates a random sequence length based on a threshold.
+  /// \param offset_ratio The offset ratio/threshold of the generated length.
+  /// \return A random sequence length.
+  ///
+  size_t GetRandomSequenceLength(double offset_ratio);
+
+  /// Data structure holding sequence status objects
+  ///
+  std::vector<std::shared_ptr<SequenceStatus>> sequence_statuses_{};
+
+  /// Current sequence id (for issuing new sequences)
+  ///
+  std::atomic<uint64_t> curr_seq_id_{0};
+
+  /// Data loader to be used for various sequence operations.
+  ///
+  std::shared_ptr<DataLoader> data_loader_{nullptr};
+
+  /// The starting sequence ID to be used for iterating through valid sequence
+  /// IDs.
+  ///
+  const uint64_t start_sequence_id_{0};
+
+  /// The maximum sequence ID to be used for iterating through valid sequence
+  /// IDs.
+  ///
+  const uint64_t sequence_id_range_{0};
+
+  /// The base length of new sequences.
+  ///
+  const size_t sequence_length_{0};
+
+  /// Indicates whether to generate sequence request input data or read it from
+  /// a JSON file.
+  ///
+  const bool using_json_data_{false};
+
+  /// The distribution for randomly assigning new sequences a data stream in the
+  /// input data JSON.
+  ///
+  std::uniform_int_distribution<uint64_t> distribution_;
+
+  /// The random number generator for randomly assigning new sequences a data
+  /// stream in the input data JSON.
+  ///
+  std::default_random_engine rng_generator_{};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+  friend TestSequenceManager;
+#endif
+};
+
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_custom_load_manager.cc
+++ b/src/c++/perf_analyzer/test_custom_load_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -53,14 +53,13 @@ class TestCustomLoadManager : public TestLoadManagerBase,
         CustomLoadManager(
             params.async, params.streaming, "INTERVALS_FILE", params.batch_size,
             params.measurement_window_ms, params.max_trials, params.max_threads,
-            params.num_of_sequences, params.sequence_length,
-            params.shared_memory_type, params.output_shm_size,
-            params.start_sequence_id, params.sequence_id_range, GetParser(),
-            GetFactory())
+            params.num_of_sequences, params.shared_memory_type,
+            params.output_shm_size, GetParser(), GetFactory())
   {
     InitManager(
         params.string_length, params.string_data, params.zero_input,
-        params.user_data);
+        params.user_data, params.start_sequence_id, params.sequence_id_range,
+        params.sequence_length);
   }
 
   void TestSchedule(

--- a/src/c++/perf_analyzer/test_load_manager.cc
+++ b/src/c++/perf_analyzer/test_load_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -42,10 +42,8 @@ class TestLoadManager : public TestLoadManagerBase, public LoadManager {
       : TestLoadManagerBase(params, is_sequence_model, is_decoupled_model),
         LoadManager(
             params.async, params.streaming, params.batch_size,
-            params.max_threads, params.sequence_length,
-            params.shared_memory_type, params.output_shm_size,
-            params.start_sequence_id, params.sequence_id_range, GetParser(),
-            GetFactory())
+            params.max_threads, params.shared_memory_type,
+            params.output_shm_size, GetParser(), GetFactory())
   {
   }
 

--- a/src/c++/perf_analyzer/test_load_manager_base.h
+++ b/src/c++/perf_analyzer/test_load_manager_base.h
@@ -26,11 +26,14 @@
 #pragma once
 
 #include <algorithm>
+#include <memory>
+
 #include "command_line_parser.h"
 #include "doctest.h"
 #include "mock_client_backend.h"
 #include "mock_data_loader.h"
 #include "mock_model_parser.h"
+#include "sequence_manager.h"
 
 namespace cb = triton::perfanalyzer::clientbackend;
 
@@ -71,10 +74,11 @@ class TestLoadManagerBase {
   // Helper function to process custom json data in testing
   // Creates a model tensor to pass to a mock parser which is consumed by the
   // mock data loader
-  static MockInputPipeline ProcessCustomJsonData(const std::string& json_str)
+  static MockInputPipeline ProcessCustomJsonData(
+      const std::string& json_str, const bool is_sequence_model = false)
   {
     std::shared_ptr<MockModelParser> mmp{
-        std::make_shared<MockModelParser>(false, false)};
+        std::make_shared<MockModelParser>(is_sequence_model, false)};
     ModelTensor model_tensor{};
     model_tensor.datatype_ = "INT32";
     model_tensor.is_optional_ = false;

--- a/src/c++/perf_analyzer/test_sequence_manager.cc
+++ b/src/c++/perf_analyzer/test_sequence_manager.cc
@@ -1,0 +1,274 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "doctest.h"
+#include "mock_data_loader.h"
+#include "sequence_manager.h"
+
+namespace triton { namespace perfanalyzer {
+
+class TestSequenceManager : public SequenceManager {
+ public:
+  TestSequenceManager(
+      const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+      const size_t sequence_length, const bool using_json_data,
+      std::shared_ptr<DataLoader> data_loader)
+      : SequenceManager(
+            start_sequence_id, sequence_id_range, sequence_length,
+            using_json_data, data_loader)
+  {
+  }
+
+  void InitNewSequence(int& seq_stat_index)
+  {
+    SequenceManager::InitNewSequence(seq_stat_index);
+  }
+
+  uint64_t GetNextSeqId(int& seq_stat_index)
+  {
+    return SequenceManager::GetNextSeqId(seq_stat_index);
+  }
+
+  size_t GetRandomSequenceLength(double& offset_ratio)
+  {
+    return SequenceManager::GetRandomSequenceLength(offset_ratio);
+  }
+
+  std::vector<std::shared_ptr<SequenceStatus>>& sequence_statuses_{
+      SequenceManager::sequence_statuses_};
+  std::atomic<uint64_t>& curr_seq_id_{SequenceManager::curr_seq_id_};
+};
+
+TEST_CASE(
+    "test_set_infer_sequence_options: testing the SetInferSequenceOptions "
+    "function")
+{
+  const uint64_t seq_id{5};
+  std::vector<std::shared_ptr<SequenceStatus>> sequence_statuses{
+      std::make_shared<SequenceStatus>(seq_id)};
+  std::uniform_int_distribution<uint64_t> distribution(0, 0);
+  const uint64_t start_sequence_id{1};
+  const uint64_t sequence_id_range{UINT32_MAX};
+  const size_t sequence_length{20};
+  bool using_json_data{false};
+  std::shared_ptr<MockDataLoader> data_loader{
+      std::make_shared<MockDataLoader>()};
+  const uint32_t seq_stat_index{0};
+  const std::string model_name{"model"};
+  std::unique_ptr<cb::InferOptions> options{
+      std::make_unique<cb::InferOptions>(model_name)};
+
+  SUBCASE("start false, end false")
+  {
+    sequence_statuses[seq_stat_index]->remaining_queries_ = 2;
+
+    TestSequenceManager tsm(
+        start_sequence_id, sequence_id_range, sequence_length, using_json_data,
+        data_loader);
+    tsm.sequence_statuses_ = sequence_statuses;
+    tsm.curr_seq_id_ = 5;
+
+    tsm.SetInferSequenceOptions(seq_stat_index, options);
+
+    CHECK(options->sequence_start_ == false);
+    CHECK(options->sequence_id_ == 5);
+    CHECK(options->sequence_end_ == false);
+  }
+  SUBCASE("start true, end false")
+  {
+    sequence_statuses[seq_stat_index]->remaining_queries_ = 0;
+
+    TestSequenceManager tsm(
+        start_sequence_id, sequence_id_range, sequence_length, using_json_data,
+        data_loader);
+    tsm.sequence_statuses_ = sequence_statuses;
+    tsm.curr_seq_id_ = 5;
+
+    tsm.SetInferSequenceOptions(seq_stat_index, options);
+
+    CHECK(options->sequence_start_ == true);
+    CHECK(options->sequence_id_ == 6);
+    CHECK(options->sequence_end_ == false);
+  }
+  SUBCASE("start false, end true")
+  {
+    sequence_statuses[seq_stat_index]->remaining_queries_ = 1;
+
+    TestSequenceManager tsm(
+        start_sequence_id, sequence_id_range, sequence_length, using_json_data,
+        data_loader);
+    tsm.sequence_statuses_ = sequence_statuses;
+    tsm.curr_seq_id_ = 5;
+
+    tsm.SetInferSequenceOptions(seq_stat_index, options);
+
+    CHECK(options->sequence_start_ == false);
+    CHECK(options->sequence_id_ == 5);
+    CHECK(options->sequence_end_ == true);
+  }
+  SUBCASE("start true, end true")
+  {
+    sequence_statuses[seq_stat_index]->remaining_queries_ = 0;
+    using_json_data = true;
+    data_loader->step_num_.push_back(1);
+    data_loader->data_stream_cnt_ = 1;
+
+    TestSequenceManager tsm(
+        start_sequence_id, sequence_id_range, sequence_length, using_json_data,
+        data_loader);
+    tsm.sequence_statuses_ = sequence_statuses;
+    tsm.curr_seq_id_ = 5;
+
+    tsm.SetInferSequenceOptions(seq_stat_index, options);
+
+    CHECK(options->sequence_start_ == true);
+    CHECK(options->sequence_id_ == 6);
+    CHECK(options->sequence_end_ == true);
+  }
+}
+
+TEST_CASE("init_new_sequence: testing the InitNewSequence function")
+{
+  const uint64_t seq_id{5};
+  std::vector<std::shared_ptr<SequenceStatus>> sequence_statuses{
+      std::make_shared<SequenceStatus>(seq_id)};
+  std::uniform_int_distribution<uint64_t> distribution(0, 0);
+  const uint64_t start_sequence_id{1};
+  const uint64_t sequence_id_range{UINT32_MAX};
+  const size_t sequence_length{20};
+  bool using_json_data{false};
+  std::shared_ptr<MockDataLoader> data_loader{
+      std::make_shared<MockDataLoader>()};
+  int seq_stat_index{0};
+
+  SUBCASE("not using json data")
+  {
+    TestSequenceManager tsm(
+        start_sequence_id, sequence_id_range, sequence_length, using_json_data,
+        data_loader);
+    tsm.sequence_statuses_ = sequence_statuses;
+    tsm.curr_seq_id_ = 5;
+
+    tsm.InitNewSequence(seq_stat_index);
+
+    CHECK(tsm.sequence_statuses_[seq_stat_index]->seq_id_ == 6);
+    CHECK(tsm.sequence_statuses_[seq_stat_index]->remaining_queries_ > 0);
+  }
+
+  SUBCASE("using json data")
+  {
+    using_json_data = true;
+    data_loader->step_num_.push_back(5);
+    data_loader->data_stream_cnt_ = 1;
+
+    TestSequenceManager tsm(
+        start_sequence_id, sequence_id_range, sequence_length, using_json_data,
+        data_loader);
+    tsm.sequence_statuses_ = sequence_statuses;
+    tsm.curr_seq_id_ = 5;
+
+    tsm.InitNewSequence(seq_stat_index);
+
+    CHECK(tsm.sequence_statuses_[seq_stat_index]->seq_id_ == 6);
+    CHECK(tsm.sequence_statuses_[seq_stat_index]->remaining_queries_ == 5);
+  }
+}
+
+TEST_CASE("get_next_seq_id: testing the GetNextSeqId function")
+{
+  std::vector<std::shared_ptr<SequenceStatus>> sequence_statuses{};
+  std::uniform_int_distribution<uint64_t> distribution(0, 0);
+  uint64_t start_sequence_id{0};
+  uint64_t sequence_id_range{0};
+  const size_t sequence_length{20};
+  const bool using_json_data{false};
+  std::shared_ptr<MockDataLoader> data_loader{
+      std::make_shared<MockDataLoader>()};
+  int seq_stat_index{0};
+
+  SUBCASE("next sequence id not in use")
+  {
+    sequence_statuses.push_back(std::make_shared<SequenceStatus>(1));
+    start_sequence_id = 1;
+    sequence_id_range = 2;
+
+    TestSequenceManager tsm(
+        start_sequence_id, sequence_id_range, sequence_length, using_json_data,
+        data_loader);
+    tsm.sequence_statuses_ = sequence_statuses;
+    tsm.curr_seq_id_ = 3;
+
+    uint64_t result{tsm.GetNextSeqId(seq_stat_index)};
+
+    CHECK(result == 2);
+  }
+
+  SUBCASE("next sequence id in use")
+  {
+    sequence_statuses.push_back(std::make_shared<SequenceStatus>(1));
+    sequence_statuses.push_back(std::make_shared<SequenceStatus>(2));
+    start_sequence_id = 1;
+    sequence_id_range = 2;
+
+    TestSequenceManager tsm(
+        start_sequence_id, sequence_id_range, sequence_length, using_json_data,
+        data_loader);
+    tsm.sequence_statuses_ = sequence_statuses;
+    tsm.curr_seq_id_ = 3;
+
+    uint64_t result{tsm.GetNextSeqId(seq_stat_index)};
+
+    CHECK(result == 1);
+  }
+}
+
+TEST_CASE(
+    "get_random_sequence_length: testing the GetRandomSequenceLength function")
+{
+  std::vector<std::shared_ptr<SequenceStatus>> sequence_statuses{};
+  std::uniform_int_distribution<uint64_t> distribution(0, 0);
+  const uint64_t start_sequence_id{0};
+  const uint64_t sequence_id_range{0};
+  size_t sequence_length{20};
+  const bool using_json_data{false};
+  std::shared_ptr<MockDataLoader> data_loader{
+      std::make_shared<MockDataLoader>()};
+  int seq_stat_index{0};
+  double offset_ratio{0.2};
+
+  TestSequenceManager tsm(
+      start_sequence_id, sequence_id_range, sequence_length, using_json_data,
+      data_loader);
+  tsm.sequence_statuses_ = sequence_statuses;
+  tsm.curr_seq_id_ = 3;
+
+  uint64_t result{tsm.GetRandomSequenceLength(offset_ratio)};
+
+  CHECK(result >= 16);
+  CHECK(result <= 24);
+}
+
+}}  // namespace triton::perfanalyzer


### PR DESCRIPTION
* Pulls some sequence code out from InferContext and moves it into its own SequenceManager class.
* Adds SequenceManager testing
* Removes concept of SequenceStat.paused
* Removes disseminating of sequence length, start sequence id, and sequence id range from a lot of classes (now only kept in SequenceManager)