### PR TITLE
Fix the infer_response clean-up logic in perf_analyzer C-API

### DIFF
--- a/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.cc
+++ b/src/c++/perf_analyzer/client_backend/triton_c_api/triton_loader.cc
@@ -914,7 +914,7 @@ TritonLoader::Infer(
   timer.CaptureTimestamp(tc::RequestTimers::Kind::REQUEST_START);
 
   RETURN_IF_ERROR(InitializeRequest(options, outputs, &allocator, &irequest));
-  ScopedDefer error_handler([&error, completed_response, allocator, this] {
+  ScopedDefer error_handler([&error, &completed_response, &allocator, this] {
     error = CleanUp(completed_response, allocator);
   });
   RETURN_IF_ERROR(AddInputs(inputs, irequest));


### PR DESCRIPTION
Capturing by the reference in lambda function to properly clear out the response object.