### PR TITLE
Make json code self-contained in load_worker

### DIFF
--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -165,8 +165,10 @@ ConcurrencyManager::MakeWorker(
     std::shared_ptr<ThreadStat> thread_stat,
     std::shared_ptr<ConcurrencyWorker::ThreadConfig> thread_config)
 {
+  uint32_t id = workers_.size();
+
   return std::make_shared<ConcurrencyWorker>(
-      thread_stat, thread_config, parser_, data_loader_, backend_->Kind(),
+      id, thread_stat, thread_config, parser_, data_loader_, backend_->Kind(),
       factory_, sequence_length_, start_sequence_id_, sequence_id_range_,
       on_sequence_model_, async_, max_concurrency_, using_json_data_,
       streaming_, shared_memory_type_, batch_size_, threads_config_,

--- a/src/c++/perf_analyzer/concurrency_worker.cc
+++ b/src/c++/perf_analyzer/concurrency_worker.cc
@@ -158,14 +158,6 @@ ConcurrencyWorker::PrepAndSendInferRequests()
 }
 
 void
-ConcurrencyWorker::UpdateJsonData(uint32_t ctx_id)
-{
-  LoadWorker::UpdateJsonData(
-      std::static_pointer_cast<DataStepIdTracker>(thread_config_), ctx_id,
-      active_threads_);
-}
-
-void
 ConcurrencyWorker::RestoreFreeCtxId(uint32_t ctx_id)
 {
   // FIXME TMA-1023 we are clearly pushing and not popping in some cases

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -646,14 +646,13 @@ LoadWorker::AsyncCallbackFuncImpl(cb::InferResult* result)
 }
 
 void
-LoadWorker::UpdateJsonData(
-    std::shared_ptr<DataStepIdTracker> step_id_tracker, const uint32_t ctx_id,
-    const size_t num_threads)
+LoadWorker::UpdateJsonData(const uint32_t ctx_id)
 {
-  size_t curr_step_id = step_id_tracker->GetDataStepId();
+  size_t num_threads = GetNumActiveThreads();
+  size_t curr_step_id = data_step_id_tracker_->GetDataStepId();
   int step_id =
       (curr_step_id % data_loader_->GetTotalStepsNonSequence()) * batch_size_;
-  step_id_tracker->SetDataStepId(curr_step_id + num_threads);
+  data_step_id_tracker_->SetDataStepId(curr_step_id + num_threads);
   thread_stat_->status_ = UpdateInputs(
       ctxs_[ctx_id]->inputs_, ctxs_[ctx_id]->valid_inputs_, 0, step_id);
   if (thread_stat_->status_.IsOk()) {

--- a/src/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/c++/perf_analyzer/request_rate_manager.cc
@@ -177,8 +177,9 @@ RequestRateManager::MakeWorker(
     std::shared_ptr<ThreadStat> thread_stat,
     std::shared_ptr<RequestRateWorker::ThreadConfig> thread_config)
 {
+  size_t id = workers_.size();
   return std::make_shared<RequestRateWorker>(
-      thread_stat, thread_config, parser_, data_loader_, backend_->Kind(),
+      id, thread_stat, thread_config, parser_, data_loader_, backend_->Kind(),
       factory_, sequence_length_, start_sequence_id_, sequence_id_range_,
       on_sequence_model_, async_, max_threads_, using_json_data_, streaming_,
       shared_memory_type_, batch_size_, sequence_stat_, shared_memory_regions_,

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -114,12 +114,4 @@ RequestRateWorker::SleepIfNecessary()
   return delayed;
 }
 
-void
-RequestRateWorker::UpdateJsonData(uint32_t ctx_id)
-{
-  LoadWorker::UpdateJsonData(
-      std::static_pointer_cast<DataStepIdTracker>(thread_config_), ctx_id,
-      max_threads_);
-}
-
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/request_rate_worker.h
+++ b/src/c++/perf_analyzer/request_rate_worker.h
@@ -39,10 +39,10 @@ namespace triton { namespace perfanalyzer {
 ///
 class RequestRateWorker : public LoadWorker {
  public:
-  struct ThreadConfig : public DataStepIdTracker {
+  struct ThreadConfig {
     ThreadConfig(uint32_t index, uint32_t stride)
-        : DataStepIdTracker(index), index_(index), id_(index), stride_(stride),
-          is_paused_(false), rounds_(0)
+        : index_(index), id_(index), stride_(stride), is_paused_(false),
+          rounds_(0)
     {
     }
 
@@ -54,7 +54,7 @@ class RequestRateWorker : public LoadWorker {
   };
 
   RequestRateWorker(
-      std::shared_ptr<ThreadStat> thread_stat,
+      uint32_t id, std::shared_ptr<ThreadStat> thread_stat,
       std::shared_ptr<ThreadConfig> thread_config,
       const std::shared_ptr<ModelParser> parser,
       std::shared_ptr<DataLoader> data_loader, cb::BackendKind backend_kind,
@@ -73,7 +73,7 @@ class RequestRateWorker : public LoadWorker {
       std::shared_ptr<std::chrono::nanoseconds> gen_duration,
       std::uniform_int_distribution<uint64_t>& distribution)
       : LoadWorker(
-            thread_stat, parser, data_loader, factory, sequence_stat,
+            id, thread_stat, parser, data_loader, factory, sequence_stat,
             shared_memory_regions, backend_kind, shared_memory_type,
             on_sequence_model, async, streaming, batch_size, using_json_data,
             sequence_length, start_sequence_id, sequence_id_range, curr_seq_id,
@@ -105,10 +105,6 @@ class RequestRateWorker : public LoadWorker {
     return (rand() % sequence_stat_.size());
   }
 
-  // TODO REFACTOR TMA-1020 this can go away once we are decoupled and share the
-  // same thread_config_
-  void UpdateJsonData(uint32_t ctx_id) override;
-
   void CompleteOngoingSequences() override;
 
   void HandleExecuteOff();
@@ -121,6 +117,8 @@ class RequestRateWorker : public LoadWorker {
   {
     total_ongoing_requests_--;
   }
+
+  size_t GetNumActiveThreads() override { return max_threads_; }
 };
 
 

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -38,7 +38,7 @@ namespace triton { namespace perfanalyzer {
 class TestConcurrencyWorker : public ConcurrencyWorker {
  public:
   TestConcurrencyWorker(
-      std::shared_ptr<ThreadStat> thread_stat,
+      uint32_t id, std::shared_ptr<ThreadStat> thread_stat,
       std::shared_ptr<ThreadConfig> thread_config,
       const std::shared_ptr<ModelParser> parser,
       std::shared_ptr<DataLoader> data_loader, cb::BackendKind backend_kind,
@@ -55,7 +55,7 @@ class TestConcurrencyWorker : public ConcurrencyWorker {
       size_t& active_threads, bool& execute, std::atomic<uint64_t>& curr_seq_id,
       std::uniform_int_distribution<uint64_t>& distribution)
       : ConcurrencyWorker(
-            thread_stat, thread_config, parser, data_loader, backend_kind,
+            id, thread_stat, thread_config, parser, data_loader, backend_kind,
             factory, sequence_length, start_sequence_id, sequence_id_range,
             on_sequence_model, async, max_concurrency, using_json_data,
             streaming, shared_memory_type, batch_size, threads_config,
@@ -144,16 +144,19 @@ class TestConcurrencyManager : public TestLoadManagerBase,
       std::shared_ptr<ThreadStat> thread_stat,
       std::shared_ptr<ConcurrencyWorker::ThreadConfig> thread_config) override
   {
+    uint32_t id = workers_.size();
+
     if (use_mock_infer_) {
       return std::make_shared<MockConcurrencyWorker>(thread_config);
     } else {
       return std::make_shared<TestConcurrencyWorker>(
-          thread_stat, thread_config, parser_, data_loader_, backend_->Kind(),
-          ConcurrencyManager::factory_, sequence_length_, start_sequence_id_,
-          sequence_id_range_, on_sequence_model_, async_, max_concurrency_,
-          using_json_data_, streaming_, shared_memory_type_, batch_size_,
-          threads_config_, sequence_stat_, shared_memory_regions_, wake_signal_,
-          wake_mutex_, active_threads_, execute_, curr_seq_id_, distribution_);
+          id, thread_stat, thread_config, parser_, data_loader_,
+          backend_->Kind(), ConcurrencyManager::factory_, sequence_length_,
+          start_sequence_id_, sequence_id_range_, on_sequence_model_, async_,
+          max_concurrency_, using_json_data_, streaming_, shared_memory_type_,
+          batch_size_, threads_config_, sequence_stat_, shared_memory_regions_,
+          wake_signal_, wake_mutex_, active_threads_, execute_, curr_seq_id_,
+          distribution_);
     }
   }
 

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -42,7 +42,7 @@ namespace triton { namespace perfanalyzer {
 class TestRequestRateWorker : public RequestRateWorker {
  public:
   TestRequestRateWorker(
-      std::shared_ptr<ThreadStat> thread_stat,
+      uint32_t id, std::shared_ptr<ThreadStat> thread_stat,
       std::shared_ptr<ThreadConfig> thread_config,
       const std::shared_ptr<ModelParser> parser,
       std::shared_ptr<DataLoader> data_loader, cb::BackendKind backend_kind,
@@ -61,7 +61,7 @@ class TestRequestRateWorker : public RequestRateWorker {
       std::shared_ptr<std::chrono::nanoseconds> gen_duration,
       std::uniform_int_distribution<uint64_t>& distribution)
       : RequestRateWorker(
-            thread_stat, thread_config, parser, data_loader, backend_kind,
+            id, thread_stat, thread_config, parser, data_loader, backend_kind,
             factory, sequence_length, start_sequence_id, sequence_id_range,
             on_sequence_model, async, max_threads, using_json_data, streaming,
             shared_memory_type, batch_size, sequence_stat,
@@ -155,17 +155,18 @@ class TestRequestRateManager : public TestLoadManagerBase,
       std::shared_ptr<ThreadStat> thread_stat,
       std::shared_ptr<RequestRateWorker::ThreadConfig> thread_config) override
   {
+    uint32_t id = workers_.size();
     if (use_mock_infer_) {
       return std::make_shared<MockRequestRateWorker>(thread_config);
     } else {
       return std::make_shared<TestRequestRateWorker>(
-          thread_stat, thread_config, parser_, data_loader_, backend_->Kind(),
-          RequestRateManager::factory_, sequence_length_, start_sequence_id_,
-          sequence_id_range_, on_sequence_model_, async_, max_threads_,
-          using_json_data_, streaming_, shared_memory_type_, batch_size_,
-          sequence_stat_, shared_memory_regions_, wake_signal_, wake_mutex_,
-          execute_, curr_seq_id_, start_time_, schedule_, gen_duration_,
-          distribution_);
+          id, thread_stat, thread_config, parser_, data_loader_,
+          backend_->Kind(), RequestRateManager::factory_, sequence_length_,
+          start_sequence_id_, sequence_id_range_, on_sequence_model_, async_,
+          max_threads_, using_json_data_, streaming_, shared_memory_type_,
+          batch_size_, sequence_stat_, shared_memory_regions_, wake_signal_,
+          wake_mutex_, execute_, curr_seq_id_, start_time_, schedule_,
+          gen_duration_, distribution_);
     }
   }
 


### PR DESCRIPTION
The main thing this does is makes it so that UpdateJsonData doesn't have to be implemented in child classes. That way it is self-contained in the load worker base class.

Also:
- removed DataStepIdTracker from ThreadConfig so it is common
- Gave load_worker an ID (which I think we will need for other reasons later)