### PR TITLE
Fix free_ctx_id tracking, and decouple total_ongoing_request tracking

### DIFF
--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -642,6 +642,9 @@ LoadWorker::AsyncCallbackFuncImpl(cb::InferResult* result)
       }
     }
   }
+
+  total_ongoing_requests_--;
+
   AsyncCallbackFinalize(ctx_id);
 }
 

--- a/src/c++/perf_analyzer/request_rate_worker.h
+++ b/src/c++/perf_analyzer/request_rate_worker.h
@@ -113,10 +113,7 @@ class RequestRateWorker : public LoadWorker {
   // Returns true if the request was delayed
   bool SleepIfNecessary();
 
-  void AsyncCallbackFinalize(uint32_t ctx_id) override
-  {
-    total_ongoing_requests_--;
-  }
+  void AsyncCallbackFinalize(uint32_t ctx_id) override {}
 
   size_t GetNumActiveThreads() override { return max_threads_; }
 };


### PR DESCRIPTION
old code had potential race conditions around free_ctx_ids and total_ongoing_requests, which prevented me from putting total_ongoing_requests in a common location. This fixes that. It also fixes a bug where in some cases free_ctx_ids was being pushed and not popped.