### PR TITLE
Remove SyncClientStats()

### DIFF
--- a/src/c++/perf_analyzer/concurrency_worker.cc
+++ b/src/c++/perf_analyzer/concurrency_worker.cc
@@ -94,7 +94,6 @@ ConcurrencyWorker::HandleExecuteOff()
       // Ensures the clean exit of the sequences
       CompleteOngoingSequences();
       WaitForOngoingRequests();
-      SyncClientStats();
 
       // Reconstruct 'free_ctx_ids_' because CompleteOngoingSequences()
       // has destructive side affects
@@ -214,16 +213,6 @@ ConcurrencyWorker::CompleteOngoingSequences()
       size_t seq_stat_index = GetSeqStatIndex(ctx_id);
       ctxs_[ctx_id]->CompleteOngoingSequence(seq_stat_index);
     }
-  }
-}
-
-void
-ConcurrencyWorker::SyncClientStats()
-{
-  // Make sure all contexts are in sync with the client's stats
-  //
-  for (size_t i = 0; i < ctxs_.size(); ++i) {
-    ctxs_[i]->SyncClientStats();
   }
 }
 

--- a/src/c++/perf_analyzer/concurrency_worker.h
+++ b/src/c++/perf_analyzer/concurrency_worker.h
@@ -130,8 +130,6 @@ class ConcurrencyWorker : public LoadWorker {
 
   void WaitForResponses();
 
-  void SyncClientStats();
-
   void RestoreFreeCtxId(uint32_t ctx_id);
   void ResetFreeCtxIds();
 

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -173,14 +173,6 @@ class InferContext {
     async_callback_finalize_func_ = callback;
   }
 
-  // TODO REFACTOR TMA-1047 - This is likely no longer needed
-  // Copy the client statistics into this object's local copy
-  // of the statistics
-  void SyncClientStats()
-  {
-    infer_backend_->ClientInferStat(&(thread_stat_->contexts_stat_[id_]));
-  }
-
   // TODO REFACTOR TMA-1043 this should be in memory class
   void SetNumActiveThreads(size_t num_threads)
   {


### PR DESCRIPTION
SyncClientStats is no longer needed. It was added to fix a bug (https://github.com/triton-inference-server/client/pull/195). As [this](https://github.com/triton-inference-server/client/pull/195/files#r1026567361) comment mentions, there were two ways to fix it. We have since also implemented the 2nd fix, which means that this first fix is no longer needed.

I confirmed that a unit test was added in 195 that would catch this error if it was reintroduced.