### PR TITLE
Add deadlock/livelock testing

### DIFF
--- a/src/c++/perf_analyzer/client_backend/mock_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/mock_client_backend.h
@@ -210,9 +210,21 @@ class MockClientStats {
 
   void SetDelays(std::vector<size_t> times)
   {
-    response_delays.clear();
+    response_delays_.clear();
     for (size_t t : times) {
-      response_delays.push_back(std::chrono::milliseconds{t});
+      response_delays_.push_back(std::chrono::milliseconds{t});
+    }
+  }
+
+  void SetReturnStatuses(std::vector<bool> statuses)
+  {
+    response_statuses_.clear();
+    for (bool success : statuses) {
+      if (success) {
+        response_statuses_.push_back(cb::Error::Success);
+      } else {
+        response_statuses_.push_back(cb::Error("Injected test error"));
+      }
     }
   }
 
@@ -220,10 +232,22 @@ class MockClientStats {
   {
     std::lock_guard<std::mutex> lock(mtx_);
 
-    auto val = response_delays[response_delays_index];
-    response_delays_index++;
-    if (response_delays_index == response_delays.size()) {
-      response_delays_index = 0;
+    auto val = response_delays_[response_delays_index_];
+    response_delays_index_++;
+    if (response_delays_index_ == response_delays_.size()) {
+      response_delays_index_ = 0;
+    }
+    return val;
+  }
+
+  cb::Error GetNextReturnStatus()
+  {
+    std::lock_guard<std::mutex> lock(mtx_);
+
+    auto val = response_statuses_[response_statuses_index_];
+    response_statuses_index_++;
+    if (response_statuses_index_ == response_statuses_.size()) {
+      response_statuses_index_ = 0;
     }
     return val;
   }
@@ -275,9 +299,11 @@ class MockClientStats {
   }
 
  private:
-  std::vector<std::chrono::milliseconds> response_delays{
+  std::vector<std::chrono::milliseconds> response_delays_{
       std::chrono::milliseconds{0}};
-  std::atomic<size_t> response_delays_index{0};
+  std::vector<cb::Error> response_statuses_{cb::Error::Success};
+  std::atomic<size_t> response_delays_index_{0};
+  std::atomic<size_t> response_statuses_index_{0};
 
   std::mutex mtx_;
 
@@ -351,7 +377,7 @@ class MockClientBackend : public ClientBackend {
     local_completed_req_count_++;
     stats_->num_active_infer_calls--;
 
-    return Error::Success;
+    return stats_->GetNextReturnStatus();
   }
 
   Error AsyncInfer(
@@ -366,7 +392,7 @@ class MockClientBackend : public ClientBackend {
 
     LaunchAsyncMockRequest(options, callback);
 
-    return Error::Success;
+    return stats_->GetNextReturnStatus();
   }
 
   Error AsyncStreamInfer(
@@ -380,7 +406,7 @@ class MockClientBackend : public ClientBackend {
 
     LaunchAsyncMockRequest(options, stream_callback_);
 
-    return Error::Success;
+    return stats_->GetNextReturnStatus();
   }
 
   Error StartStream(OnCompleteFn callback, bool enable_stats)
@@ -388,7 +414,7 @@ class MockClientBackend : public ClientBackend {
     stats_->CaptureStreamStart();
     stats_->start_stream_enable_stats_value = enable_stats;
     stream_callback_ = callback;
-    return Error::Success;
+    return stats_->GetNextReturnStatus();
   }
 
   Error ClientInferStat(InferStat* infer_stat) override

--- a/src/c++/perf_analyzer/client_backend/mock_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/mock_client_backend.h
@@ -208,6 +208,11 @@ class MockClientStats {
     }
   };
 
+  /// Determines how long the backend will delay before sending a "response".
+  /// If a single value vector is passed in, all responses will take that long.
+  /// If a list of values is passed in, then the mock backend will loop through
+  /// the values (and loop back to the start when it hits the end of the vector)
+  ///
   void SetDelays(std::vector<size_t> times)
   {
     response_delays_.clear();
@@ -216,6 +221,12 @@ class MockClientStats {
     }
   }
 
+  /// Determines the return status of requests.
+  /// If a single value vector is passed in, all responses will return that
+  /// status. If a list of values is passed in, then the mock backend will loop
+  /// through the values (and loop back to the start when it hits the end of the
+  /// vector)
+  ///
   void SetReturnStatuses(std::vector<bool> statuses)
   {
     response_statuses_.clear();

--- a/src/c++/perf_analyzer/concurrency_worker.cc
+++ b/src/c++/perf_analyzer/concurrency_worker.cc
@@ -52,15 +52,12 @@ ConcurrencyWorker::Infer()
 
     CreateContextsAsNecessary();
 
-    if (!thread_stat_->status_.IsOk()) {
+    if (HandleExitConditions()) {
       return;
     }
 
     SendInferRequests();
 
-    if (!thread_stat_->status_.IsOk()) {
-      return;
-    }
     if (HandleExitConditions()) {
       return;
     }
@@ -156,8 +153,7 @@ ConcurrencyWorker::CreateContextsAsNecessary()
 void
 ConcurrencyWorker::SendInferRequests()
 {
-  while (free_ctx_ids_.size() && early_exit == false && execute_ &&
-         thread_stat_->status_.IsOk()) {
+  while (free_ctx_ids_.size() && execute_ && !ShouldExit()) {
     uint32_t ctx_id = GetCtxId();
     SendInferRequest(ctx_id);
     RestoreFreeCtxId(ctx_id);

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -104,6 +104,10 @@ InferContext::CompleteOngoingSequence(uint32_t seq_stat_index)
 void
 InferContext::SendRequest(const uint64_t request_id, const bool delayed)
 {
+  if (!thread_stat_->status_.IsOk()) {
+    return;
+  }
+
   if (async_) {
     options_->request_id_ = std::to_string(request_id);
     {

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -104,10 +104,6 @@ InferContext::CompleteOngoingSequence(uint32_t seq_stat_index)
 void
 InferContext::SendRequest(const uint64_t request_id, const bool delayed)
 {
-  if (!thread_stat_->status_.IsOk()) {
-    return;
-  }
-
   if (async_) {
     options_->request_id_ = std::to_string(request_id);
     {

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -34,9 +34,16 @@
 namespace triton { namespace perfanalyzer {
 
 bool
+LoadWorker::ShouldExit()
+{
+  return early_exit || !thread_stat_->cb_status_.IsOk() ||
+         !thread_stat_->status_.IsOk();
+}
+
+bool
 LoadWorker::HandleExitConditions()
 {
-  if (early_exit || (!thread_stat_->cb_status_.IsOk())) {
+  if (ShouldExit()) {
     CompleteOngoingSequences();
     WaitForOngoingRequests();
     return true;

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -55,7 +55,7 @@ void
 LoadWorker::WaitForOngoingRequests()
 {
   while (GetNumOngoingRequests() != 0) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
   }
 }
 

--- a/src/c++/perf_analyzer/load_worker.h
+++ b/src/c++/perf_analyzer/load_worker.h
@@ -80,8 +80,7 @@ class LoadWorker : public IWorker {
 
   void SendInferRequest(uint32_t ctx_id, bool delayed = false)
   {
-    if (early_exit || !thread_stat_->status_.IsOk() ||
-        !thread_stat_->cb_status_.IsOk()) {
+    if (ShouldExit()) {
       return;
     }
 

--- a/src/c++/perf_analyzer/load_worker.h
+++ b/src/c++/perf_analyzer/load_worker.h
@@ -109,6 +109,9 @@ class LoadWorker : public IWorker {
   // Any code that needs to execute after the Context has been created
   virtual void CreateContextFinalize(std::shared_ptr<InferContext> ctx) = 0;
 
+  // Detect the cases where this thread needs to exit
+  bool ShouldExit();
+
   // Detect and handle the case where this thread needs to exit
   // Returns true if an exit condition was met
   bool HandleExitConditions();

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -38,9 +38,6 @@ void
 RequestRateWorker::Infer()
 {
   CreateContext();
-  if (!thread_stat_->status_.IsOk()) {
-    return;
-  }
 
   // run inferencing until receiving exit signal to maintain server load.
   do {

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -253,7 +253,7 @@ class TestConcurrencyManager : public TestLoadManagerBase,
   ///
   void TestTimeouts()
   {
-    WatchDog watchdog(1000);
+    TestWatchDog watchdog(1000);
     ChangeConcurrencyLevel(params_.max_concurrency);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     StopWorkerThreads();
@@ -685,7 +685,7 @@ TEST_CASE("concurrency_deadlock")
   bool is_sequence_model{true};
   bool some_infer_failures{false};
 
-  const auto& ParameterizeSync{[&]() {
+  const auto& ParameterizeSyncStreaming{[&]() {
     SUBCASE("sync")
     {
       params.async = false;
@@ -704,29 +704,17 @@ TEST_CASE("concurrency_deadlock")
   }};
 
   const auto& ParameterizeConcurrency{[&]() {
-    SUBCASE("1 concurrency, 1 thread")
+    SUBCASE("10 concurrency, 10 thread")
     {
-      ParameterizeSync();
-      params.max_concurrency = 1;
-      params.max_threads = 1;
+      ParameterizeSyncStreaming();
+      params.max_concurrency = 10;
+      params.max_threads = 10;
     }
-    SUBCASE("4 concurrency, 4 thread")
+    SUBCASE("10 concurrency, 4 thread")
     {
-      ParameterizeSync();
-      params.max_concurrency = 4;
+      ParameterizeSyncStreaming();
+      params.max_concurrency = 10;
       params.max_threads = 4;
-    }
-    SUBCASE("4 concurrency, 3 thread")
-    {
-      ParameterizeSync();
-      params.max_concurrency = 4;
-      params.max_threads = 3;
-    }
-    SUBCASE("4 concurrency, 1 thread")
-    {
-      ParameterizeSync();
-      params.max_concurrency = 4;
-      params.max_threads = 1;
     }
   }};
 
@@ -740,7 +728,6 @@ TEST_CASE("concurrency_deadlock")
     {
       ParameterizeConcurrency();
       is_sequence_model = true;
-      params.num_of_sequences = 3;
     }
   }};
 
@@ -767,7 +754,7 @@ TEST_CASE("concurrency_deadlock")
     }
     SUBCASE("random_delay")
     {
-      delays = {1, 5, 2, 4, 3};
+      delays = {1, 5, 20, 4, 3};
       ParameterizeFailures();
     }
   }};

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -350,7 +350,7 @@ class TestRequestRateManager : public TestLoadManagerBase,
   ///
   void TestTimeouts()
   {
-    WatchDog watchdog(1000);
+    TestWatchDog watchdog(1000);
     ChangeRequestRate(100);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     StopWorkerThreads();
@@ -926,42 +926,28 @@ TEST_CASE("request_rate_deadlock")
     }
   }};
 
-  const auto& ParameterizeConcurrency{[&]() {
-    SUBCASE("1 concurrency, 1 thread")
+  const auto& ParameterizeThreads{[&]() {
+    SUBCASE("2 thread")
     {
       ParameterizeSync();
-      params.max_concurrency = 1;
-      params.max_threads = 1;
+      params.max_threads = 2;
     }
-    SUBCASE("4 concurrency, 4 thread")
+    SUBCASE("10 thread")
     {
       ParameterizeSync();
-      params.max_concurrency = 4;
-      params.max_threads = 4;
-    }
-    SUBCASE("4 concurrency, 3 thread")
-    {
-      ParameterizeSync();
-      params.max_concurrency = 4;
-      params.max_threads = 3;
-    }
-    SUBCASE("4 concurrency, 1 thread")
-    {
-      ParameterizeSync();
-      params.max_concurrency = 4;
-      params.max_threads = 1;
+      params.max_threads = 10;
     }
   }};
 
   const auto& ParameterizeSequence{[&]() {
     SUBCASE("non-sequence")
     {
-      ParameterizeConcurrency();
+      ParameterizeThreads();
       is_sequence_model = false;
     }
     SUBCASE("sequence")
     {
-      ParameterizeConcurrency();
+      ParameterizeThreads();
       is_sequence_model = true;
       params.num_of_sequences = 3;
     }
@@ -990,7 +976,7 @@ TEST_CASE("request_rate_deadlock")
     }
     SUBCASE("random_delay")
     {
-      delays = {1, 5, 2, 4, 3};
+      delays = {1, 5, 20, 4, 3};
       ParameterizeFailures();
     }
   }};

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -346,13 +346,15 @@ class TestRequestRateManager : public TestLoadManagerBase,
     StopWorkerThreads();
   }
 
-  // FIXME
+  /// Test that tries to find deadlocks and livelocks
   ///
   void TestTimeouts()
   {
+    WatchDog watchdog(1000);
     ChangeRequestRate(100);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     StopWorkerThreads();
+    watchdog.stop();
   }
 
   std::shared_ptr<ModelParser>& parser_{LoadManager::parser_};
@@ -899,9 +901,8 @@ TEST_CASE("Request rate - Shared memory infer input calls")
   }
 }
 
-TEST_CASE("request_rate_timeouts")
+TEST_CASE("request_rate_deadlock")
 {
-  WatchDog watchdog(2000);
   PerfAnalyzerParameters params{};
   params.max_concurrency = 6;
   bool is_sequence_model{true};
@@ -979,12 +980,26 @@ TEST_CASE("request_rate_timeouts")
     }
   }};
 
-  ParameterizeFailures();
+  std::vector<uint64_t> delays;
+
+  const auto& ParameterizeDelays{[&]() {
+    SUBCASE("no_delay")
+    {
+      delays = {0};
+      ParameterizeFailures();
+    }
+    SUBCASE("random_delay")
+    {
+      delays = {1, 5, 2, 4, 3};
+      ParameterizeFailures();
+    }
+  }};
+
+  ParameterizeDelays();
 
   TestRequestRateManager trrm(params, is_sequence_model);
 
-  // Randomize the delays of the responses
-  trrm.stats_->SetDelays({1, 5, 2, 4, 3});
+  trrm.stats_->SetDelays(delays);
 
   // Sometimes have a request fail
   if (some_infer_failures) {
@@ -992,8 +1007,6 @@ TEST_CASE("request_rate_timeouts")
   }
 
   trrm.TestTimeouts();
-
-  watchdog.stop();
 }
 
 

--- a/src/c++/perf_analyzer/test_utils.h
+++ b/src/c++/perf_analyzer/test_utils.h
@@ -35,11 +35,22 @@
 
 namespace triton { namespace perfanalyzer {
 
-// FIXME
-class WatchDog {
+/// This class will create a thread that will raise an error after a fixed
+/// amount of time, unless the stop function is called.
+///
+/// It can be used to detect livelock/deadlock cases in tests so that the test
+/// will be guarenteed to finish instead of hang
+///
+class TestWatchDog {
  public:
-  WatchDog(unsigned int max_time_ms) { start(max_time_ms); }
+  /// Create the watchdog
+  ///
+  /// @param max_time_ms How long (in milliseconds) until this watchdog will
+  /// raise an error
+  TestWatchDog(unsigned int max_time_ms) { start(max_time_ms); }
 
+  /// Stop the watchdog so that it will not raise any errors
+  ///
   void stop()
   {
     running_ = false;
@@ -47,7 +58,7 @@ class WatchDog {
   }
 
  private:
-  uint interval{100};
+  uint sleep_interval_ms{40};
   uint max_time_ms_;
   std::atomic<unsigned int> timer_;
   std::atomic<bool> running_;
@@ -58,7 +69,7 @@ class WatchDog {
     max_time_ms_ = max_time_ms;
     timer_ = 0;
     running_ = true;
-    thread_ = std::thread(&WatchDog::loop, this);
+    thread_ = std::thread(&TestWatchDog::loop, this);
   }
 
   void loop()
@@ -69,8 +80,8 @@ class WatchDog {
         REQUIRE_MESSAGE(false, "WATCHDOG TIMEOUT!");
       }
 
-      std::this_thread::sleep_for(std::chrono::milliseconds(interval));
-      timer_ += interval;
+      std::this_thread::sleep_for(std::chrono::milliseconds(sleep_interval_ms));
+      timer_ += sleep_interval_ms;
     }
   }
 };


### PR DESCRIPTION
Standardized exit condition detection for the workers
Created ability to control when the mock backend returns failure instead of success
Created a Watchdog to detect livelock/deadlock in tests
Created tests to try to stress timing to try to find deadlocks

Note: This adds 90 seconds to our unit test runtime. We may decide to pull some of this back or shorten it.