### PR TITLE
Test and fix request schedules

### DIFF
--- a/src/c++/perf_analyzer/custom_load_manager.cc
+++ b/src/c++/perf_analyzer/custom_load_manager.cc
@@ -33,7 +33,7 @@ namespace triton { namespace perfanalyzer {
 cb::Error
 CustomLoadManager::Create(
     const bool async, const bool streaming,
-    const uint64_t measurement_window_ms,
+    const uint64_t measurement_window_ms, const size_t max_trials,
     const std::string& request_intervals_file, const int32_t batch_size,
     const size_t max_threads, const uint32_t num_of_sequences,
     const size_t sequence_length, const SharedMemoryType shared_memory_type,
@@ -45,9 +45,9 @@ CustomLoadManager::Create(
 {
   std::unique_ptr<CustomLoadManager> local_manager(new CustomLoadManager(
       async, streaming, request_intervals_file, batch_size,
-      measurement_window_ms, max_threads, num_of_sequences, sequence_length,
-      shared_memory_type, output_shm_size, start_sequence_id, sequence_id_range,
-      parser, factory));
+      measurement_window_ms, max_trials, max_threads, num_of_sequences,
+      sequence_length, shared_memory_type, output_shm_size, start_sequence_id,
+      sequence_id_range, parser, factory));
 
   *manager = std::move(local_manager);
 
@@ -57,17 +57,18 @@ CustomLoadManager::Create(
 CustomLoadManager::CustomLoadManager(
     const bool async, const bool streaming,
     const std::string& request_intervals_file, int32_t batch_size,
-    const uint64_t measurement_window_ms, const size_t max_threads,
-    const uint32_t num_of_sequences, const size_t sequence_length,
-    const SharedMemoryType shared_memory_type, const size_t output_shm_size,
-    const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+    const uint64_t measurement_window_ms, const size_t max_trials,
+    const size_t max_threads, const uint32_t num_of_sequences,
+    const size_t sequence_length, const SharedMemoryType shared_memory_type,
+    const size_t output_shm_size, const uint64_t start_sequence_id,
+    const uint64_t sequence_id_range,
     const std::shared_ptr<ModelParser>& parser,
     const std::shared_ptr<cb::ClientBackendFactory>& factory)
     : RequestRateManager(
           async, streaming, Distribution::CUSTOM, batch_size,
-          measurement_window_ms, max_threads, num_of_sequences, sequence_length,
-          shared_memory_type, output_shm_size, start_sequence_id,
-          sequence_id_range, parser, factory),
+          measurement_window_ms, max_trials, max_threads, num_of_sequences,
+          sequence_length, shared_memory_type, output_shm_size,
+          start_sequence_id, sequence_id_range, parser, factory),
       request_intervals_file_(request_intervals_file)
 {
 }

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -96,7 +96,7 @@ class CustomLoadManager : public RequestRateManager {
   /// \return cb::Error object indicating success or failure.
   cb::Error GetCustomRequestRate(double* request_rate);
 
- protected:
+ private:
   CustomLoadManager(
       const bool async, const bool streaming,
       const std::string& request_intervals_file, const int32_t batch_size,
@@ -108,7 +108,6 @@ class CustomLoadManager : public RequestRateManager {
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
 
- private:
   /// Reads the time intervals file and stores intervals in vector
   /// \param path Filesystem path of the time intervals file.
   /// \param contents Output intervals vector.

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -52,6 +52,7 @@ class CustomLoadManager : public RequestRateManager {
   /// request.
   /// \param streaming Whether to use gRPC streaming API for infer request
   /// \param measurement_window_ms The time window for measurements.
+  /// \param max_trials The maximum number of windows that will be measured
   /// \param request_intervals_file The path to the file to use to pick up the
   /// time intervals between the successive requests.
   /// \param batch_size The batch size used for each request.

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -95,7 +95,7 @@ class CustomLoadManager : public RequestRateManager {
   /// \return cb::Error object indicating success or failure.
   cb::Error GetCustomRequestRate(double* request_rate);
 
- private:
+ protected:
   CustomLoadManager(
       const bool async, const bool streaming,
       const std::string& request_intervals_file, const int32_t batch_size,
@@ -106,6 +106,7 @@ class CustomLoadManager : public RequestRateManager {
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
 
+ private:
   /// Reads the time intervals file and stores intervals in vector
   /// \param path Filesystem path of the time intervals file.
   /// \param contents Output intervals vector.

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -73,7 +73,7 @@ class CustomLoadManager : public RequestRateManager {
   /// \return cb::Error object indicating success or failure.
   static cb::Error Create(
       const bool async, const bool streaming,
-      const uint64_t measurement_window_ms,
+      const uint64_t measurement_window_ms, const size_t max_trials,
       const std::string& request_intervals_file, const int32_t batch_size,
       const size_t max_threads, const uint32_t num_of_sequences,
       const size_t sequence_length, const SharedMemoryType shared_memory_type,
@@ -99,10 +99,11 @@ class CustomLoadManager : public RequestRateManager {
   CustomLoadManager(
       const bool async, const bool streaming,
       const std::string& request_intervals_file, const int32_t batch_size,
-      const uint64_t measurement_window_ms, const size_t max_threads,
-      const uint32_t num_of_sequences, const size_t sequence_length,
-      const SharedMemoryType shared_memory_type, const size_t output_shm_size,
-      const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+      const uint64_t measurement_window_ms, const size_t max_trials,
+      const size_t max_threads, const uint32_t num_of_sequences,
+      const size_t sequence_length, const SharedMemoryType shared_memory_type,
+      const size_t output_shm_size, const uint64_t start_sequence_id,
+      const uint64_t sequence_id_range,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
 

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -219,11 +219,12 @@ PerfAnalyzer::CreateAnalyzerObjects()
     FAIL_IF_ERR(
         pa::RequestRateManager::Create(
             params_->async, params_->streaming, params_->measurement_window_ms,
-            params_->request_distribution, params_->batch_size,
-            params_->max_threads, params_->num_of_sequences,
-            params_->sequence_length, params_->shared_memory_type,
-            params_->output_shm_size, params_->start_sequence_id,
-            params_->sequence_id_range, parser_, factory, &manager),
+            params_->max_trials, params_->request_distribution,
+            params_->batch_size, params_->max_threads,
+            params_->num_of_sequences, params_->sequence_length,
+            params_->shared_memory_type, params_->output_shm_size,
+            params_->start_sequence_id, params_->sequence_id_range, parser_,
+            factory, &manager),
         "failed to create request rate manager");
 
   } else {
@@ -238,11 +239,12 @@ PerfAnalyzer::CreateAnalyzerObjects()
     FAIL_IF_ERR(
         pa::CustomLoadManager::Create(
             params_->async, params_->streaming, params_->measurement_window_ms,
-            params_->request_intervals_file, params_->batch_size,
-            params_->max_threads, params_->num_of_sequences,
-            params_->sequence_length, params_->shared_memory_type,
-            params_->output_shm_size, params_->start_sequence_id,
-            params_->sequence_id_range, parser_, factory, &manager),
+            params_->max_trials, params_->request_intervals_file,
+            params_->batch_size, params_->max_threads,
+            params_->num_of_sequences, params_->sequence_length,
+            params_->shared_memory_type, params_->output_shm_size,
+            params_->start_sequence_id, params_->sequence_id_range, parser_,
+            factory, &manager),
         "failed to create custom load manager");
   }
 

--- a/src/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/c++/perf_analyzer/request_rate_manager.cc
@@ -79,6 +79,7 @@ RequestRateManager::RequestRateManager(
       sequence_stat_.emplace_back(new SequenceStat(0));
     }
   }
+  // FIXME TODO TMA-1018 - remove the +1
   gen_duration_.reset(new std::chrono::nanoseconds(
       (max_trials + 1) * measurement_window_ms * 1000 * 1000));
 

--- a/src/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/c++/perf_analyzer/request_rate_manager.cc
@@ -38,19 +38,21 @@ RequestRateManager::~RequestRateManager()
 cb::Error
 RequestRateManager::Create(
     const bool async, const bool streaming,
-    const uint64_t measurement_window_ms, Distribution request_distribution,
-    const int32_t batch_size, const size_t max_threads,
-    const uint32_t num_of_sequences, const size_t sequence_length,
-    const SharedMemoryType shared_memory_type, const size_t output_shm_size,
-    const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+    const uint64_t measurement_window_ms, const size_t max_trials,
+    Distribution request_distribution, const int32_t batch_size,
+    const size_t max_threads, const uint32_t num_of_sequences,
+    const size_t sequence_length, const SharedMemoryType shared_memory_type,
+    const size_t output_shm_size, const uint64_t start_sequence_id,
+    const uint64_t sequence_id_range,
     const std::shared_ptr<ModelParser>& parser,
     const std::shared_ptr<cb::ClientBackendFactory>& factory,
     std::unique_ptr<LoadManager>* manager)
 {
   std::unique_ptr<RequestRateManager> local_manager(new RequestRateManager(
       async, streaming, request_distribution, batch_size, measurement_window_ms,
-      max_threads, num_of_sequences, sequence_length, shared_memory_type,
-      output_shm_size, start_sequence_id, sequence_id_range, parser, factory));
+      max_trials, max_threads, num_of_sequences, sequence_length,
+      shared_memory_type, output_shm_size, start_sequence_id, sequence_id_range,
+      parser, factory));
 
   *manager = std::move(local_manager);
 
@@ -60,10 +62,10 @@ RequestRateManager::Create(
 RequestRateManager::RequestRateManager(
     const bool async, const bool streaming, Distribution request_distribution,
     int32_t batch_size, const uint64_t measurement_window_ms,
-    const size_t max_threads, const uint32_t num_of_sequences,
-    const size_t sequence_length, const SharedMemoryType shared_memory_type,
-    const size_t output_shm_size, const uint64_t start_sequence_id,
-    const uint64_t sequence_id_range,
+    const size_t max_trials, const size_t max_threads,
+    const uint32_t num_of_sequences, const size_t sequence_length,
+    const SharedMemoryType shared_memory_type, const size_t output_shm_size,
+    const uint64_t start_sequence_id, const uint64_t sequence_id_range,
     const std::shared_ptr<ModelParser>& parser,
     const std::shared_ptr<cb::ClientBackendFactory>& factory)
     : LoadManager(
@@ -77,8 +79,8 @@ RequestRateManager::RequestRateManager(
       sequence_stat_.emplace_back(new SequenceStat(0));
     }
   }
-  gen_duration_.reset(
-      new std::chrono::nanoseconds(2 * measurement_window_ms * 1000 * 1000));
+  gen_duration_.reset(new std::chrono::nanoseconds(
+      (max_trials + 1) * measurement_window_ms * 1000 * 1000));
 
   threads_config_.reserve(max_threads);
 }

--- a/src/c++/perf_analyzer/request_rate_manager.h
+++ b/src/c++/perf_analyzer/request_rate_manager.h
@@ -63,6 +63,7 @@ class RequestRateManager : public LoadManager {
   /// request.
   /// \param streaming Whether to use gRPC streaming API for infer request
   /// \param measurement_window_ms The time window for measurements.
+  /// \param max_trials The maximum number of windows that will be measured
   /// \param request_distribution The kind of distribution to use for drawing
   /// out intervals between successive requests.
   /// \param batch_size The batch size used for each request.
@@ -85,11 +86,12 @@ class RequestRateManager : public LoadManager {
   /// \return cb::Error object indicating success or failure.
   static cb::Error Create(
       const bool async, const bool streaming,
-      const uint64_t measurement_window_ms, Distribution request_distribution,
-      const int32_t batch_size, const size_t max_threads,
-      const uint32_t num_of_sequences, const size_t sequence_length,
-      const SharedMemoryType shared_memory_type, const size_t output_shm_size,
-      const uint64_t start_sequence_id, const uint64_t sequence_id_range,
+      const uint64_t measurement_window_ms, const size_t max_trials,
+      Distribution request_distribution, const int32_t batch_size,
+      const size_t max_threads, const uint32_t num_of_sequences,
+      const size_t sequence_length, const SharedMemoryType shared_memory_type,
+      const size_t output_shm_size, const uint64_t start_sequence_id,
+      const uint64_t sequence_id_range,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory,
       std::unique_ptr<LoadManager>* manager);
@@ -108,10 +110,10 @@ class RequestRateManager : public LoadManager {
   RequestRateManager(
       const bool async, const bool streaming, Distribution request_distribution,
       const int32_t batch_size, const uint64_t measurement_window_ms,
-      const size_t max_threads, const uint32_t num_of_sequences,
-      const size_t sequence_length, const SharedMemoryType shared_memory_type,
-      const size_t output_shm_size, const uint64_t start_sequence_id,
-      const uint64_t sequence_id_range,
+      const size_t max_trials, const size_t max_threads,
+      const uint32_t num_of_sequences, const size_t sequence_length,
+      const SharedMemoryType shared_memory_type, const size_t output_shm_size,
+      const uint64_t start_sequence_id, const uint64_t sequence_id_range,
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
 

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -43,6 +43,10 @@ RequestRateWorker::Infer()
   do {
     HandleExecuteOff();
 
+    if (HandleExitConditions()) {
+      return;
+    }
+
     bool is_delayed = SleepIfNecessary();
     uint32_t ctx_id = GetCtxId();
     SendInferRequest(ctx_id, is_delayed);
@@ -86,21 +90,27 @@ RequestRateWorker::HandleExecuteOff()
   thread_config_->is_paused_ = false;
 }
 
-bool
-RequestRateWorker::SleepIfNecessary()
+std::chrono::nanoseconds
+RequestRateWorker::GetNextTimestamp()
 {
-  // Sleep if required
-  std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-
-  std::chrono::nanoseconds wait_time =
-      (schedule_[thread_config_->index_] +
-       (thread_config_->rounds_ * (*gen_duration_))) -
-      (now - start_time_);
+  auto next_timestamp = schedule_[thread_config_->index_] +
+                        (thread_config_->rounds_ * (*gen_duration_));
 
   thread_config_->index_ = (thread_config_->index_ + thread_config_->stride_);
   // Loop around the schedule to keep running
   thread_config_->rounds_ += (thread_config_->index_ / schedule_.size());
   thread_config_->index_ = thread_config_->index_ % schedule_.size();
+
+  return next_timestamp;
+}
+
+bool
+RequestRateWorker::SleepIfNecessary()
+{
+  std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+  std::chrono::nanoseconds next_timestamp = GetNextTimestamp();
+  std::chrono::nanoseconds current_timestamp = now - start_time_;
+  std::chrono::nanoseconds wait_time = current_timestamp - next_timestamp;
 
   bool delayed = false;
   if (wait_time.count() < 0) {

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -43,10 +43,6 @@ RequestRateWorker::Infer()
   do {
     HandleExecuteOff();
 
-    if (HandleExitConditions()) {
-      return;
-    }
-
     bool is_delayed = SleepIfNecessary();
     uint32_t ctx_id = GetCtxId();
     SendInferRequest(ctx_id, is_delayed);

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -118,7 +118,6 @@ RequestRateWorker::SleepIfNecessary()
   } else {
     std::this_thread::sleep_for(wait_time);
   }
-
   return delayed;
 }
 

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -110,7 +110,7 @@ RequestRateWorker::SleepIfNecessary()
   std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
   std::chrono::nanoseconds next_timestamp = GetNextTimestamp();
   std::chrono::nanoseconds current_timestamp = now - start_time_;
-  std::chrono::nanoseconds wait_time = current_timestamp - next_timestamp;
+  std::chrono::nanoseconds wait_time = next_timestamp - current_timestamp;
 
   bool delayed = false;
   if (wait_time.count() < 0) {
@@ -118,6 +118,7 @@ RequestRateWorker::SleepIfNecessary()
   } else {
     std::this_thread::sleep_for(wait_time);
   }
+
   return delayed;
 }
 

--- a/src/c++/perf_analyzer/request_rate_worker.h
+++ b/src/c++/perf_analyzer/request_rate_worker.h
@@ -30,6 +30,12 @@
 
 namespace triton { namespace perfanalyzer {
 
+
+#ifndef DOCTEST_CONFIG_DISABLE
+class TestRequestRateManager;
+class TestCustomLoadManager;
+#endif
+
 /// Worker thread for RequestRateManager
 ///
 /// If the model is non-sequence model, each worker uses only one context
@@ -86,9 +92,6 @@ class RequestRateWorker : public LoadWorker {
 
   void Infer() override;
 
- protected:
-  virtual std::chrono::nanoseconds GetNextTimestamp();
-
  private:
   const size_t max_threads_;
   std::chrono::steady_clock::time_point& start_time_;
@@ -99,6 +102,8 @@ class RequestRateWorker : public LoadWorker {
   std::shared_ptr<std::chrono::nanoseconds> gen_duration_;
 
   std::shared_ptr<ThreadConfig> thread_config_;
+
+  std::chrono::nanoseconds GetNextTimestamp();
 
   // Request Rate Worker only ever has a single context
   uint32_t GetCtxId() { return 0; }
@@ -120,6 +125,12 @@ class RequestRateWorker : public LoadWorker {
   {
     ctx->SetNumActiveThreads(max_threads_);
   }
+
+#ifndef DOCTEST_CONFIG_DISABLE
+  friend TestCustomLoadManager;
+  friend TestRequestRateManager;
+
+#endif
 };
 
 

--- a/src/c++/perf_analyzer/request_rate_worker.h
+++ b/src/c++/perf_analyzer/request_rate_worker.h
@@ -86,6 +86,9 @@ class RequestRateWorker : public LoadWorker {
 
   void Infer() override;
 
+ protected:
+  virtual std::chrono::nanoseconds GetNextTimestamp();
+
  private:
   const size_t max_threads_;
   std::chrono::steady_clock::time_point& start_time_;

--- a/src/c++/perf_analyzer/test_custom_load_manager.cc
+++ b/src/c++/perf_analyzer/test_custom_load_manager.cc
@@ -37,10 +37,9 @@
 
 namespace triton { namespace perfanalyzer {
 
-// FIXME duplicate
-class RequestRateWorkerMockedInferInput : public RequestRateWorker {
+class TestRequestRateWorker : public RequestRateWorker {
  public:
-  RequestRateWorkerMockedInferInput(
+  TestRequestRateWorker(
       uint32_t id, std::shared_ptr<ThreadStat> thread_stat,
       std::shared_ptr<ThreadConfig> thread_config,
       const std::shared_ptr<ModelParser> parser,
@@ -72,16 +71,6 @@ class RequestRateWorkerMockedInferInput : public RequestRateWorker {
   std::chrono::nanoseconds GetNextTimestamp() override
   {
     return RequestRateWorker::GetNextTimestamp();
-  }
-
-  std::shared_ptr<InferContext> CreateInferContext() override
-  {
-    return std::make_shared<InferContextMockedInferInput>(
-        ctxs_.size(), async_, streaming_, on_sequence_model_, using_json_data_,
-        batch_size_, backend_kind_, shared_memory_type_, shared_memory_regions_,
-        start_sequence_id_, sequence_id_range_, sequence_length_, curr_seq_id_,
-        distribution_, thread_stat_, sequence_stat_, data_loader_, parser_,
-        factory_);
   }
 };
 
@@ -115,7 +104,7 @@ class TestCustomLoadManager : public TestLoadManagerBase,
       std::shared_ptr<RequestRateWorker::ThreadConfig> thread_config) override
   {
     uint32_t id = workers_.size();
-    return std::make_shared<RequestRateWorkerMockedInferInput>(
+    return std::make_shared<TestRequestRateWorker>(
         id, thread_stat, thread_config, LoadManager::parser_, data_loader_,
         backend_->Kind(), RequestRateManager::factory_, sequence_length_,
         start_sequence_id_, sequence_id_range_, on_sequence_model_, async_,
@@ -141,7 +130,7 @@ class TestCustomLoadManager : public TestLoadManagerBase,
     while (expected_current_timestamp.count() < max_test_duration.count()) {
       for (auto worker : workers_) {
         auto timestamp =
-            std::dynamic_pointer_cast<RequestRateWorkerMockedInferInput>(worker)
+            std::dynamic_pointer_cast<TestRequestRateWorker>(worker)
                 ->GetNextTimestamp();
         REQUIRE(timestamp.count() == expected_current_timestamp.count());
         expected_current_timestamp += custom_intervals_[intervals_index];

--- a/src/c++/perf_analyzer/test_custom_load_manager.cc
+++ b/src/c++/perf_analyzer/test_custom_load_manager.cc
@@ -33,11 +33,124 @@
 #include "custom_load_manager.h"
 #include "doctest.h"
 #include "request_rate_manager.h"
+#include "test_load_manager_base.h"
 
 namespace triton { namespace perfanalyzer {
 
-class TestCustomLoadManager : public CustomLoadManager {
+// FIXME duplicate
+class RequestRateWorkerMockedInferInput : public RequestRateWorker {
  public:
+  RequestRateWorkerMockedInferInput(
+      uint32_t id, std::shared_ptr<ThreadStat> thread_stat,
+      std::shared_ptr<ThreadConfig> thread_config,
+      const std::shared_ptr<ModelParser> parser,
+      std::shared_ptr<DataLoader> data_loader, cb::BackendKind backend_kind,
+      const std::shared_ptr<cb::ClientBackendFactory> factory,
+      const size_t sequence_length, const uint64_t start_sequence_id,
+      const uint64_t sequence_id_range, const bool on_sequence_model,
+      const bool async, const size_t max_threads, const bool using_json_data,
+      const bool streaming, const SharedMemoryType shared_memory_type,
+      const int32_t batch_size,
+      std::vector<std::shared_ptr<SequenceStat>>& sequence_stat,
+      std::unordered_map<std::string, SharedMemoryData>& shared_memory_regions,
+      std::condition_variable& wake_signal, std::mutex& wake_mutex,
+      bool& execute, std::atomic<uint64_t>& curr_seq_id,
+      std::chrono::steady_clock::time_point& start_time,
+      std::vector<std::chrono::nanoseconds>& schedule,
+      std::shared_ptr<std::chrono::nanoseconds> gen_duration,
+      std::uniform_int_distribution<uint64_t>& distribution)
+      : RequestRateWorker(
+            id, thread_stat, thread_config, parser, data_loader, backend_kind,
+            factory, sequence_length, start_sequence_id, sequence_id_range,
+            on_sequence_model, async, max_threads, using_json_data, streaming,
+            shared_memory_type, batch_size, sequence_stat,
+            shared_memory_regions, wake_signal, wake_mutex, execute,
+            curr_seq_id, start_time, schedule, gen_duration, distribution)
+  {
+  }
+
+  std::chrono::nanoseconds GetNextTimestamp() override
+  {
+    return RequestRateWorker::GetNextTimestamp();
+  }
+
+  std::shared_ptr<InferContext> CreateInferContext() override
+  {
+    return std::make_shared<InferContextMockedInferInput>(
+        ctxs_.size(), async_, streaming_, on_sequence_model_, using_json_data_,
+        batch_size_, backend_kind_, shared_memory_type_, shared_memory_regions_,
+        start_sequence_id_, sequence_id_range_, sequence_length_, curr_seq_id_,
+        distribution_, thread_stat_, sequence_stat_, data_loader_, parser_,
+        factory_);
+  }
+};
+
+/// Class to test the CustomLoadManager
+///
+class TestCustomLoadManager : public TestLoadManagerBase,
+                              public CustomLoadManager {
+ public:
+  TestCustomLoadManager() = default;
+
+  TestCustomLoadManager(
+      PerfAnalyzerParameters params, bool is_sequence_model = false,
+      bool is_decoupled_model = false)
+      : TestLoadManagerBase(params, is_sequence_model, is_decoupled_model),
+        CustomLoadManager(
+            params.async, params.streaming, "INTERVALS_FILE", params.batch_size,
+            params.measurement_window_ms, params.max_threads,
+            params.num_of_sequences, params.sequence_length,
+            params.shared_memory_type, params.output_shm_size,
+            params.start_sequence_id, params.sequence_id_range, GetParser(),
+            GetFactory())
+  {
+    InitManager(
+        params.string_length, params.string_data, params.zero_input,
+        params.user_data);
+  }
+
+
+  std::shared_ptr<IWorker> MakeWorker(
+      std::shared_ptr<ThreadStat> thread_stat,
+      std::shared_ptr<RequestRateWorker::ThreadConfig> thread_config) override
+  {
+    uint32_t id = workers_.size();
+    return std::make_shared<RequestRateWorkerMockedInferInput>(
+        id, thread_stat, thread_config, LoadManager::parser_, data_loader_,
+        backend_->Kind(), RequestRateManager::factory_, sequence_length_,
+        start_sequence_id_, sequence_id_range_, on_sequence_model_, async_,
+        max_threads_, using_json_data_, streaming_, shared_memory_type_,
+        batch_size_, sequence_stat_, shared_memory_regions_, wake_signal_,
+        wake_mutex_, execute_, curr_seq_id_, start_time_, schedule_,
+        gen_duration_, distribution_);
+  }
+
+  void TestSchedule(
+      std::vector<uint64_t> intervals, PerfAnalyzerParameters params)
+  {
+    for (auto x : intervals) {
+      custom_intervals_.push_back(std::chrono::nanoseconds{x});
+    }
+    std::chrono::nanoseconds max_test_duration{params.measurement_window_ms *
+                                               1000000 * params.max_trials};
+    std::chrono::nanoseconds expected_current_timestamp{0};
+    size_t intervals_index = 0;
+
+    PauseWorkers();
+    InitCustomIntervals();
+    while (expected_current_timestamp.count() < max_test_duration.count()) {
+      for (auto worker : workers_) {
+        auto timestamp =
+            std::dynamic_pointer_cast<RequestRateWorkerMockedInferInput>(worker)
+                ->GetNextTimestamp();
+        REQUIRE(timestamp.count() == expected_current_timestamp.count());
+        expected_current_timestamp += custom_intervals_[intervals_index];
+        intervals_index = (intervals_index + 1) % custom_intervals_.size();
+      }
+    }
+  }
+
+
   std::shared_ptr<std::chrono::nanoseconds>& gen_duration_{
       RequestRateManager::gen_duration_};
   std::vector<std::chrono::nanoseconds>& schedule_{
@@ -54,6 +167,92 @@ class TestCustomLoadManager : public CustomLoadManager {
     return cb::Error::Success;
   }
 };
+
+TEST_CASE("custom_load_schedule")
+{
+  PerfAnalyzerParameters params;
+  params.measurement_window_ms = 1000;
+  params.max_trials = 10;
+  bool is_sequence = false;
+  bool is_decoupled = false;
+  bool use_mock_infer = false;
+  std::vector<uint64_t> intervals;
+
+  TestCustomLoadManager tclm(params, is_sequence, is_decoupled);
+
+
+  const auto& ParameterizeIntervals{[&]() {
+    SUBCASE("intervals A") { intervals = {100000000, 110000000, 130000000}; }
+    SUBCASE("intervals B") { intervals = {150000000}; }
+    SUBCASE("intervals C")
+    {
+      intervals = {100000000, 110000000, 120000000, 130000000, 140000000};
+    }
+  }};
+
+  const auto& ParameterizeThreads{[&]() {
+    SUBCASE("threads 1")
+    {
+      ParameterizeIntervals();
+      params.max_threads = 1;
+    }
+    SUBCASE("threads 2")
+    {
+      ParameterizeIntervals();
+      params.max_threads = 2;
+    }
+    SUBCASE("threads 4")
+    {
+      ParameterizeIntervals();
+      params.max_threads = 4;
+    }
+    SUBCASE("threads 7")
+    {
+      ParameterizeIntervals();
+      params.max_threads = 7;
+    }
+  }};
+
+  const auto& ParameterizeTrials{[&]() {
+    SUBCASE("trials 3")
+    {
+      ParameterizeThreads();
+      params.max_trials = 3;
+    }
+    SUBCASE("trials 10")
+    {
+      ParameterizeThreads();
+      params.max_trials = 10;
+    }
+    SUBCASE("trials 20")
+    {
+      ParameterizeThreads();
+      params.max_trials = 20;
+    }
+  }};
+
+  const auto& ParameterizeMeasurementWindow{[&]() {
+    SUBCASE("window 1000")
+    {
+      ParameterizeTrials();
+      params.measurement_window_ms = 1000;
+    }
+    SUBCASE("window 10000")
+    {
+      ParameterizeTrials();
+      params.measurement_window_ms = 10000;
+    }
+    SUBCASE("window 500")
+    {
+      ParameterizeTrials();
+      params.measurement_window_ms = 500;
+    }
+  }};
+
+  ParameterizeMeasurementWindow();
+
+  tclm.TestSchedule(intervals, params);
+}
 
 TEST_CASE("testing the InitCustomIntervals function")
 {
@@ -86,6 +285,46 @@ TEST_CASE("testing the InitCustomIntervals function")
     CHECK(tclm.schedule_[3] == std::chrono::nanoseconds(340000000));
     CHECK(tclm.schedule_[4] == std::chrono::nanoseconds(440000000));
   }
+
+  SUBCASE("FIXME")
+  {
+    tclm.request_intervals_file_ = "nonexistent_file.txt";
+    tclm.gen_duration_ = std::make_unique<std::chrono::nanoseconds>(200000000);
+    tclm.custom_intervals_.push_back(std::chrono::nanoseconds(100000000));
+    tclm.custom_intervals_.push_back(std::chrono::nanoseconds(110000000));
+    tclm.custom_intervals_.push_back(std::chrono::nanoseconds(130000000));
+
+    cb::Error result{tclm.InitCustomIntervals()};
+
+    std::shared_ptr<ThreadStat> thread_stat{std::make_shared<ThreadStat>()};
+    std::shared_ptr<RequestRateWorker::ThreadConfig> thread_config{
+        std::make_shared<RequestRateWorker::ThreadConfig>(0, 1)};
+
+    auto x = tclm.MakeWorker(thread_stat, thread_config);
+
+    std::shared_ptr<RequestRateWorkerMockedInferInput> rrw =
+        std::dynamic_pointer_cast<RequestRateWorkerMockedInferInput>(x);
+    auto t = rrw->GetNextTimestamp();
+    std::cout << "TKG :: " << t.count() << std::endl;
+    t = rrw->GetNextTimestamp();
+    std::cout << "TKG :: " << t.count() << std::endl;
+    t = rrw->GetNextTimestamp();
+    std::cout << "TKG :: " << t.count() << std::endl;
+    t = rrw->GetNextTimestamp();
+    std::cout << "TKG :: " << t.count() << std::endl;
+    t = rrw->GetNextTimestamp();
+    std::cout << "TKG :: " << t.count() << std::endl;
+    t = rrw->GetNextTimestamp();
+    std::cout << "TKG :: " << t.count() << std::endl;
+
+    // CHECK(result.Err() == SUCCESS);
+    // CHECK(tclm.schedule_.size() == 5);
+    // CHECK(tclm.schedule_[0] == std::chrono::nanoseconds(0));
+    // CHECK(tclm.schedule_[1] == std::chrono::nanoseconds(100000000));
+    // CHECK(tclm.schedule_[2] == std::chrono::nanoseconds(210000000));
+    // CHECK(tclm.schedule_[3] == std::chrono::nanoseconds(340000000));
+    // CHECK(tclm.schedule_[4] == std::chrono::nanoseconds(440000000));
+  }
 }
 
 TEST_CASE("testing the GetCustomRequestRate function")
@@ -113,5 +352,4 @@ TEST_CASE("testing the GetCustomRequestRate function")
     CHECK(request_rate == doctest::Approx(8.0));
   }
 }
-
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_load_manager_base.h
+++ b/src/c++/perf_analyzer/test_load_manager_base.h
@@ -94,6 +94,7 @@ struct MockInputPipeline {
 ///
 class TestLoadManagerBase {
  public:
+  TestLoadManagerBase() = default;
   TestLoadManagerBase(
       PerfAnalyzerParameters params, bool is_sequence_model,
       bool is_decoupled_model)

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -601,7 +601,6 @@ TEST_CASE("request_rate_infer_type")
 TEST_CASE("request_rate_distribution")
 {
   PerfAnalyzerParameters params;
-  params.max_trials = 1;
   uint request_rate = 500;
   uint duration_ms = 1000;
 

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -112,8 +112,8 @@ class TestRequestRateManager : public TestLoadManagerBase,
         TestLoadManagerBase(params, is_sequence_model, is_decoupled_model),
         RequestRateManager(
             params.async, params.streaming, params.request_distribution,
-            params.batch_size, params.measurement_window_ms, params.max_threads,
-            params.num_of_sequences, params.sequence_length,
+            params.batch_size, params.measurement_window_ms, params.max_trials,
+            params.max_threads, params.num_of_sequences, params.sequence_length,
             params.shared_memory_type, params.output_shm_size,
             params.start_sequence_id, params.sequence_id_range, GetParser(),
             GetFactory())
@@ -136,8 +136,8 @@ class TestRequestRateManager : public TestLoadManagerBase,
         TestLoadManagerBase(params, is_sequence_model, is_decoupled_model),
         RequestRateManager(
             params.async, params.streaming, params.request_distribution,
-            params.batch_size, params.measurement_window_ms, params.max_threads,
-            params.num_of_sequences, params.sequence_length,
+            params.batch_size, params.measurement_window_ms, params.max_trials,
+            params.max_threads, params.num_of_sequences, params.sequence_length,
             params.shared_memory_type, params.output_shm_size,
             params.start_sequence_id, params.sequence_id_range, parser,
             GetFactory())
@@ -477,10 +477,8 @@ TEST_CASE("request_rate_schedule")
 
 
   const auto& ParameterizeRate{[&]() {
-    // FIXME
-    // SUBCASE("rate 1") { rate = 1; }
-    // SUBCASE("rate 3") { rate = 3; }
     SUBCASE("rate 10") { rate = 10; }
+    SUBCASE("rate 30") { rate = 30; }
     SUBCASE("rate 100") { rate = 100; }
   }};
 
@@ -603,6 +601,7 @@ TEST_CASE("request_rate_infer_type")
 TEST_CASE("request_rate_distribution")
 {
   PerfAnalyzerParameters params;
+  params.max_trials = 1;
   uint request_rate = 500;
   uint duration_ms = 1000;
 


### PR DESCRIPTION
There were some corner case bugs at the boundaries of the request_rate and custom_load schedules. 
The request_rate bug was minor, but having an odd request_rate that couldn't perfectly divide the window would have a minor hiccup when wrapping
The custom_load bug was more significant -- when wrapping around the schedule we could actually go back in time.

This PR adds unit tests to expose them, and then fixes the issue by creating a full schedule instead of a partial schedule that has to be looped.