### PR TITLE
Track overhead

### DIFF
--- a/src/c++/perf_analyzer/CMakeLists.txt
+++ b/src/c++/perf_analyzer/CMakeLists.txt
@@ -79,7 +79,6 @@ set(
   constants.h
   metrics.h
   metrics_manager.h
-  test_load_manager_base.h
   infer_data_manager.h
   infer_data.h
   sequence_manager.h
@@ -164,6 +163,8 @@ add_executable(
   mock_data_loader.h
   test_inference_profiler.cc
   test_command_line_parser.cc
+  test_idle_timer.cc
+  test_load_manager_base.h
   test_load_manager.cc
   test_model_parser.cc
   test_metrics_manager.cc

--- a/src/c++/perf_analyzer/concurrency_worker.cc
+++ b/src/c++/perf_analyzer/concurrency_worker.cc
@@ -177,6 +177,7 @@ ConcurrencyWorker::WaitForResponses()
     {
       // If async, then wait for signal from callback.
       std::unique_lock<std::mutex> lk(cb_mtx_);
+      auto start = std::chrono::steady_clock::now();
       cb_cv_.wait(lk, [this] {
         if (notified_) {
           notified_ = false;
@@ -184,6 +185,9 @@ ConcurrencyWorker::WaitForResponses()
         }
         return false;
       });
+      auto end = std::chrono::steady_clock::now();
+      auto duration = end - start;
+      thread_stat_->accumulated_idle_ns += duration.count();
     }
   }
 }

--- a/src/c++/perf_analyzer/concurrency_worker.cc
+++ b/src/c++/perf_analyzer/concurrency_worker.cc
@@ -177,6 +177,7 @@ ConcurrencyWorker::WaitForResponses()
     {
       // If async, then wait for signal from callback.
       std::unique_lock<std::mutex> lk(cb_mtx_);
+      thread_stat_->idle_timer.Start();
       auto start = std::chrono::steady_clock::now();
       cb_cv_.wait(lk, [this] {
         if (notified_) {
@@ -185,9 +186,7 @@ ConcurrencyWorker::WaitForResponses()
         }
         return false;
       });
-      auto end = std::chrono::steady_clock::now();
-      auto duration = end - start;
-      thread_stat_->accumulated_idle_ns += duration.count();
+      thread_stat_->idle_timer.Stop();
     }
   }
 }

--- a/src/c++/perf_analyzer/concurrency_worker.cc
+++ b/src/c++/perf_analyzer/concurrency_worker.cc
@@ -178,7 +178,6 @@ ConcurrencyWorker::WaitForResponses()
       // If async, then wait for signal from callback.
       std::unique_lock<std::mutex> lk(cb_mtx_);
       thread_stat_->idle_timer.Start();
-      auto start = std::chrono::steady_clock::now();
       cb_cv_.wait(lk, [this] {
         if (notified_) {
           notified_ = false;

--- a/src/c++/perf_analyzer/idle_timer.h
+++ b/src/c++/perf_analyzer/idle_timer.h
@@ -59,17 +59,6 @@ class IdleTimer {
     idle_ns_ += duration.count();
   }
 
-  /// Restart the timer. This means that if the timer was already active, then
-  /// stop it (and count the pending time), and then restart it
-  ///
-  void Restart()
-  {
-    if (is_idle_) {
-      Stop();
-      Start();
-    }
-  }
-
   /// Reset the time counter, and restart the timer if it is active
   ///
   void Reset()
@@ -79,13 +68,27 @@ class IdleTimer {
   }
 
   /// Returns the number of nanoseconds this timer has counted as being idle
+  /// If the timer was already active, then it will first stop (and count the
+  /// pending time), and then start back up
   ///
-  uint64_t GetIdleTime() { return idle_ns_; }
+  uint64_t GetIdleTime()
+  {
+    Restart();
+    return idle_ns_;
+  }
 
  private:
   uint64_t idle_ns_{0};
   bool is_idle_{false};
   std::chrono::_V2::steady_clock::time_point start_time_;
+
+  void Restart()
+  {
+    if (is_idle_) {
+      Stop();
+      Start();
+    }
+  }
 
 
 #ifndef DOCTEST_CONFIG_DISABLE

--- a/src/c++/perf_analyzer/idle_timer.h
+++ b/src/c++/perf_analyzer/idle_timer.h
@@ -1,0 +1,87 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <chrono>
+
+namespace triton { namespace perfanalyzer {
+
+#ifndef DOCTEST_CONFIG_DISABLE
+class TestLoadManager;
+#endif
+
+
+// Class to track idle periods of time
+class IdleTimer {
+ public:
+  void Start()
+  {
+    is_idle_ = true;
+    start_time_ = std::chrono::steady_clock::now();
+  }
+
+  void Stop()
+  {
+    is_idle_ = false;
+    auto end = std::chrono::steady_clock::now();
+    auto duration = end - start_time_;
+    idle_ns_ += duration.count();
+  }
+
+  /// Restart the timer. This means that if the timer was already active, then
+  /// stop it (and count the pending time), and then restart it
+  ///
+  void Restart()
+  {
+    if (is_idle_) {
+      Stop();
+      Start();
+    }
+  }
+
+  /// Reset the time counter
+  ///
+  void Reset()
+  {
+    Restart();
+    idle_ns_ = 0;
+  }
+
+  /// Returns the number of nanoseconds this timer has counted as being idle
+  ///
+  uint64_t GetIdleTime() { return idle_ns_; }
+
+ private:
+  uint64_t idle_ns_{0};
+  bool is_idle_{false};
+  std::chrono::_V2::steady_clock::time_point start_time_;
+
+
+#ifndef DOCTEST_CONFIG_DISABLE
+  friend TestLoadManager;
+#endif
+};
+
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/idle_timer.h
+++ b/src/c++/perf_analyzer/idle_timer.h
@@ -38,12 +38,19 @@ class IdleTimer {
  public:
   void Start()
   {
+    if (is_idle_) {
+      throw std::runtime_error("Can't start a timer that is already active\n");
+    }
     is_idle_ = true;
     start_time_ = std::chrono::steady_clock::now();
   }
 
   void Stop()
   {
+    if (!is_idle_) {
+      throw std::runtime_error("Can't stop a timer that isn't active\n");
+    }
+
     is_idle_ = false;
     auto end = std::chrono::steady_clock::now();
     auto duration = end - start_time_;
@@ -61,7 +68,7 @@ class IdleTimer {
     }
   }
 
-  /// Reset the time counter
+  /// Reset the time counter, and restart the timer if it is active
   ///
   void Reset()
   {

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -151,6 +151,8 @@ InferContext::SendRequest(const uint64_t request_id, const bool delayed)
       // Add the request timestamp to thread Timestamp vector with proper
       // locking
       std::lock_guard<std::mutex> lock(thread_stat_->mu_);
+      auto total = end_time_sync - start_time_sync;
+      thread_stat_->accumulated_idle_ns += total.count();
       thread_stat_->request_timestamps_.emplace_back(std::make_tuple(
           start_time_sync, end_time_sync, infer_data_.options_->sequence_end_,
           delayed));

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -50,7 +50,7 @@ struct ThreadStat {
   std::vector<cb::InferStat> contexts_stat_;
 
   // The total amount of time spent sleeping or waiting
-  uint64_t accumulated_idle_ns;
+  uint64_t accumulated_idle_ns{0};
 
   // A vector of request timestamps <start_time, end_time>
   // Request latency will be end_time - start_time

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <vector>
 #include "data_loader.h"
+#include "idle_timer.h"
 #include "infer_data.h"
 #include "infer_data_manager.h"
 #include "perf_utils.h"
@@ -48,9 +49,10 @@ struct ThreadStat {
   // TODO REFACTOR TMA-1046 -- This should be in the InferContext class
   // The statistics of the InferContext
   std::vector<cb::InferStat> contexts_stat_;
-
+  std::chrono::_V2::steady_clock::time_point start_time;
   // The total amount of time spent sleeping or waiting
-  uint64_t accumulated_idle_ns{0};
+
+  IdleTimer idle_timer;
 
   // A vector of request timestamps <start_time, end_time>
   // Request latency will be end_time - start_time

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -49,9 +49,8 @@ struct ThreadStat {
   // TODO REFACTOR TMA-1046 -- This should be in the InferContext class
   // The statistics of the InferContext
   std::vector<cb::InferStat> contexts_stat_;
-  std::chrono::_V2::steady_clock::time_point start_time;
-  // The total amount of time spent sleeping or waiting
 
+  // Tracks the amount of time this thread spent sleeping or waiting
   IdleTimer idle_timer;
 
   // A vector of request timestamps <start_time, end_time>

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -48,6 +48,10 @@ struct ThreadStat {
   // TODO REFACTOR TMA-1046 -- This should be in the InferContext class
   // The statistics of the InferContext
   std::vector<cb::InferStat> contexts_stat_;
+
+  // The total amount of time spent sleeping or waiting
+  uint64_t accumulated_idle_ns;
+
   // A vector of request timestamps <start_time, end_time>
   // Request latency will be end_time - start_time
   TimestampVector request_timestamps_;

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1484,10 +1484,10 @@ InferenceProfiler::SummarizeOverhead(
     const uint64_t window_duration_ns, const uint64_t idle_ns,
     PerfStatus& summary)
 {
-  // It is possible for the overhead to be larger than the duration, based on
-  // the way idle windows are added. For that case, just mark 100% overhead
+  // It is possible for the idle to be larger than the duration, based on
+  // the way idle windows are added. For that case, just mark 0% overhead
   if (idle_ns > window_duration_ns) {
-    summary.overhead_pct = 100;
+    summary.overhead_pct = 0;
   } else {
     uint64_t overhead_ns = window_duration_ns - idle_ns;
     double overhead_pct = double(overhead_ns) / window_duration_ns * 100;

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1484,15 +1484,13 @@ InferenceProfiler::SummarizeOverhead(
     const uint64_t window_duration_ns, const uint64_t idle_ns,
     PerfStatus& summary)
 {
-  // It is possible for the idle to be larger than the duration, based on
-  // the way idle windows are added. For that case, just mark 0% overhead
   if (idle_ns > window_duration_ns) {
-    summary.overhead_pct = 0;
-  } else {
-    uint64_t overhead_ns = window_duration_ns - idle_ns;
-    double overhead_pct = double(overhead_ns) / window_duration_ns * 100;
-    summary.overhead_pct = overhead_pct;
+    throw std::runtime_error("Idle time can't be larger than window");
   }
+
+  uint64_t overhead_ns = window_duration_ns - idle_ns;
+  double overhead_pct = double(overhead_ns) / window_duration_ns * 100;
+  summary.overhead_pct = overhead_pct;
 }
 
 bool

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1484,13 +1484,17 @@ InferenceProfiler::SummarizeOverhead(
     const uint64_t window_duration_ns, const uint64_t idle_ns,
     PerfStatus& summary)
 {
+  // The window start/stop is not instantaneous. It is possible that the PA
+  // overhead is smaller than the delay in the window start/stop process. Treat
+  // it as 0% overhead (100% idle) in that case
+  //
   if (idle_ns > window_duration_ns) {
-    throw std::runtime_error("Idle time can't be larger than window");
+    summary.overhead_pct = 0;
+  } else {
+    uint64_t overhead_ns = window_duration_ns - idle_ns;
+    double overhead_pct = double(overhead_ns) / window_duration_ns * 100;
+    summary.overhead_pct = overhead_pct;
   }
-
-  uint64_t overhead_ns = window_duration_ns - idle_ns;
-  double overhead_pct = double(overhead_ns) / window_duration_ns * 100;
-  summary.overhead_pct = overhead_pct;
 }
 
 bool

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -152,6 +152,7 @@ struct PerfStatus {
   ServerSideStats server_stats;
   ClientSideStats client_stats;
   std::vector<Metrics> metrics{};
+  double overhead_pct;
   bool on_sequence_model;
 
   // placeholder for the latency value that is used for conditional checking
@@ -500,6 +501,16 @@ class InferenceProfiler {
       const std::map<cb::ModelIdentifier, cb::ModelStatistics>& start_status,
       const std::map<cb::ModelIdentifier, cb::ModelStatistics>& end_status,
       ServerSideStats* server_stats);
+
+  /// Calculate the overhead and put the results into the summary
+  ///
+  /// \param window_duration_ns The duration of the window
+  /// \param idle_ns The average worker idle time during the window
+  /// \param summary The summary object to be updated with overhead stats
+  ///
+  void SummarizeOverhead(
+      const uint64_t window_duration_ns, const uint64_t idle_ns,
+      PerfStatus& summary);
 
   /// Returns true if all MPI ranks (models) are stable. Should only be run if
   /// and only if IsMPIRun() returns true.

--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -117,7 +117,6 @@ LoadManager::GetIdleTime()
   size_t num_active_threads = 0;
   for (auto& thread_stat : threads_stat_) {
     std::lock_guard<std::mutex> lock(thread_stat->mu_);
-    thread_stat->idle_timer.Restart();
     uint64_t idle_time = thread_stat->idle_timer.GetIdleTime();
     if (idle_time) {
       total += idle_time;

--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -110,6 +110,37 @@ LoadManager::GetAccumulatedClientStat(cb::InferStat* contexts_stat)
   return cb::Error::Success;
 }
 
+uint64_t
+LoadManager::GetIdleTime()
+{
+  uint64_t total{0};
+  size_t num_active_threads = 0;
+  for (auto& thread_stat : threads_stat_) {
+    std::lock_guard<std::mutex> lock(thread_stat->mu_);
+    if (thread_stat->accumulated_idle_ns) {
+      total += thread_stat->accumulated_idle_ns;
+      num_active_threads++;
+    }
+  }
+
+  // TODO REFACTOR TMA-1043 InferDataManager should have an API to get
+  // num_active_threads. This method isn't fully accurate
+  if (num_active_threads) {
+    total /= num_active_threads;
+  }
+
+  return total;
+}
+
+void
+LoadManager::ResetIdleTime()
+{
+  for (auto& thread_stat : threads_stat_) {
+    std::lock_guard<std::mutex> lock(thread_stat->mu_);
+    thread_stat->accumulated_idle_ns = 0;
+  }
+}
+
 LoadManager::LoadManager(
     const bool async, const bool streaming, const int32_t batch_size,
     const size_t max_threads, const SharedMemoryType shared_memory_type,

--- a/src/c++/perf_analyzer/load_manager.h
+++ b/src/c++/perf_analyzer/load_manager.h
@@ -77,6 +77,15 @@ class LoadManager {
   /// in load manager
   cb::Error GetAccumulatedClientStat(cb::InferStat* contexts_stat);
 
+  /// Returns the amount of valid time each worker thread has averaged in
+  /// nanoseconds
+  ///
+  uint64_t GetIdleTime();
+
+  /// Resets the counter for tracking valid time
+  ///
+  void ResetIdleTime();
+
   /// \return the batch size used for the inference requests
   size_t BatchSize() const { return batch_size_; }
 

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -111,8 +111,9 @@ RequestRateWorker::SleepIfNecessary()
   if (wait_time.count() < 0) {
     delayed = true;
   } else {
+    thread_stat_->idle_timer.Start();
     std::this_thread::sleep_for(wait_time);
-    thread_stat_->accumulated_idle_ns += wait_time.count();
+    thread_stat_->idle_timer.Stop();
   }
   return delayed;
 }

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -111,8 +111,8 @@ RequestRateWorker::SleepIfNecessary()
   if (wait_time.count() < 0) {
     delayed = true;
   } else {
-    thread_stat_->accumulated_idle_ns += wait_time.count();
     std::this_thread::sleep_for(wait_time);
+    thread_stat_->accumulated_idle_ns += wait_time.count();
   }
   return delayed;
 }

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -111,6 +111,7 @@ RequestRateWorker::SleepIfNecessary()
   if (wait_time.count() < 0) {
     delayed = true;
   } else {
+    thread_stat_->accumulated_idle_ns += wait_time.count();
     std::this_thread::sleep_for(wait_time);
   }
   return delayed;

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -183,6 +183,20 @@ class TestConcurrencyManager : public TestLoadManagerBase,
     watchdog.stop();
   }
 
+  void TestOverhead()
+  {
+    stats_->SetDelays({1});
+    ChangeConcurrencyLevel(params_.max_concurrency);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // During a run of 100 ms (100,000,000 ns), make sure that the idle time is
+    // at least 95% of that
+    //
+    auto idle_time_ns = GetIdleTime();
+    CHECK(idle_time_ns > 95000000);
+    CHECK(idle_time_ns < 100000000);
+    StopWorkerThreads();
+  }
+
   std::shared_ptr<ModelParser>& parser_{LoadManager::parser_};
   std::shared_ptr<DataLoader>& data_loader_{LoadManager::data_loader_};
   bool& using_json_data_{LoadManager::using_json_data_};
@@ -741,4 +755,37 @@ TEST_CASE("concurrency_deadlock")
 
   tcm.TestTimeouts();
 }
+
+TEST_CASE("concurrency_overhead")
+{
+  PerfAnalyzerParameters params{};
+  SUBCASE("sync, conc 1")
+  {
+    params.async = false;
+    params.max_concurrency = 1;
+  }
+  SUBCASE("sync, conc 4")
+  {
+    params.async = false;
+    params.max_concurrency = 4;
+  }
+  SUBCASE("async, conc 1")
+  {
+    params.async = true;
+    params.max_concurrency = 1;
+  }
+  SUBCASE("async, conc 1")
+  {
+    params.async = true;
+    params.max_concurrency = 4;
+  }
+  TestConcurrencyManager tcm(params, false);
+  tcm.InitManager(
+      params.string_length, params.string_data, params.zero_input,
+      params.user_data, params.start_sequence_id, params.sequence_id_range,
+      params.sequence_length);
+
+  tcm.TestOverhead();
+}
+
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -194,7 +194,6 @@ class TestConcurrencyManager : public TestLoadManagerBase,
     //
     auto idle_time_ns = GetIdleTime();
     CHECK(idle_time_ns > 95000000);
-    CHECK(idle_time_ns < 100000000);
     StopWorkerThreads();
   }
 

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -183,6 +183,7 @@ class TestConcurrencyManager : public TestLoadManagerBase,
     watchdog.stop();
   }
 
+  /// Test that idle time is tracked correctly
   void TestOverhead()
   {
     stats_->SetDelays({1});

--- a/src/c++/perf_analyzer/test_idle_timer.cc
+++ b/src/c++/perf_analyzer/test_idle_timer.cc
@@ -24,6 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <thread>
 #include "doctest.h"
 #include "idle_timer.h"
 
@@ -32,20 +33,21 @@ namespace triton { namespace perfanalyzer {
 TEST_CASE("idle_timer: basic usage")
 {
   IdleTimer timer;
-  CHECK(0 == timer.GetIdleTime());
+  CHECK(timer.GetIdleTime() == 0);
   timer.Start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
   timer.Stop();
-  CHECK(0 < timer.GetIdleTime());
+  CHECK(timer.GetIdleTime() > 0);
   timer.Reset();
-  CHECK(0 == timer.GetIdleTime());
+  CHECK(timer.GetIdleTime() == 0);
 }
 
 TEST_CASE("idle_timer: restart when inactive")
 {
   IdleTimer timer;
-  CHECK(0 == timer.GetIdleTime());
+  CHECK(timer.GetIdleTime() == 0);
   timer.Restart();
-  CHECK(0 == timer.GetIdleTime());
+  CHECK(timer.GetIdleTime() == 0);
   CHECK_NOTHROW(timer.Start());
 }
 
@@ -53,8 +55,9 @@ TEST_CASE("idle_timer: restart when active")
 {
   IdleTimer timer;
   timer.Start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
   timer.Restart();
-  CHECK(0 < timer.GetIdleTime());
+  CHECK(timer.GetIdleTime() > 0);
   CHECK_NOTHROW(timer.Stop());
 }
 
@@ -62,25 +65,29 @@ TEST_CASE("idle_timer: reset when active")
 {
   IdleTimer timer;
   timer.Start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
   timer.Stop();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
   timer.Start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
   timer.Reset();
-  CHECK(0 == timer.GetIdleTime());
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  CHECK(timer.GetIdleTime() == 0);
   CHECK_NOTHROW(timer.Stop());
-  CHECK(0 < timer.GetIdleTime());
+  CHECK(timer.GetIdleTime() > 0);
 }
 
 TEST_CASE("idle_timer: double start")
 {
   IdleTimer timer;
   timer.Start();
-  CHECK_THROWS_AS(timer.Start();, const std::exception&);
+  CHECK_THROWS_AS(timer.Start(), const std::exception&);
 }
 
 TEST_CASE("idle_timer: stop without start")
 {
   IdleTimer timer;
-  CHECK_THROWS_AS(timer.Stop();, const std::exception&);
+  CHECK_THROWS_AS(timer.Stop(), const std::exception&);
 }
 
 

--- a/src/c++/perf_analyzer/test_idle_timer.cc
+++ b/src/c++/perf_analyzer/test_idle_timer.cc
@@ -42,21 +42,22 @@ TEST_CASE("idle_timer: basic usage")
   CHECK(timer.GetIdleTime() == 0);
 }
 
-TEST_CASE("idle_timer: restart when inactive")
+TEST_CASE("idle_timer: GetIdleTime when inactive")
 {
   IdleTimer timer;
   CHECK(timer.GetIdleTime() == 0);
-  timer.Restart();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
   CHECK(timer.GetIdleTime() == 0);
   CHECK_NOTHROW(timer.Start());
 }
 
-TEST_CASE("idle_timer: restart when active")
+TEST_CASE("idle_timer: GetIdleTime when active")
 {
   IdleTimer timer;
   timer.Start();
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  timer.Restart();
+  CHECK(timer.GetIdleTime() > 0);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
   CHECK(timer.GetIdleTime() > 0);
   CHECK_NOTHROW(timer.Stop());
 }
@@ -72,8 +73,6 @@ TEST_CASE("idle_timer: reset when active")
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
   timer.Reset();
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  CHECK(timer.GetIdleTime() == 0);
-  CHECK_NOTHROW(timer.Stop());
   CHECK(timer.GetIdleTime() > 0);
 }
 

--- a/src/c++/perf_analyzer/test_inference_profiler.cc
+++ b/src/c++/perf_analyzer/test_inference_profiler.cc
@@ -674,8 +674,8 @@ TEST_CASE("InferenceProfiler: Test SummarizeOverhead")
   }
   SUBCASE("overflow")
   {
-    CHECK_THROWS_AS(
-        tip.SummarizeOverhead(100, 101, status), const std::exception&);
+    tip.SummarizeOverhead(100, 101, status);
+    CHECK(status.overhead_pct == doctest::Approx(0));
   }
 }
 

--- a/src/c++/perf_analyzer/test_inference_profiler.cc
+++ b/src/c++/perf_analyzer/test_inference_profiler.cc
@@ -129,6 +129,13 @@ class TestInferenceProfiler : public InferenceProfiler {
     InferenceProfiler::GetMetricFirstPerGPU<T>(
         input_metric_maps, output_metric_map);
   }
+
+  void SummarizeOverhead(
+      const uint64_t window_duration_ns, const uint64_t idle_ns,
+      PerfStatus& summary)
+  {
+    InferenceProfiler::SummarizeOverhead(window_duration_ns, idle_ns, summary);
+  }
 };
 
 TEST_CASE("testing the ValidLatencyMeasurement function")
@@ -648,6 +655,27 @@ TEST_CASE("test the ReportPrometheusMetrics function")
         captured_cout.str() ==
         "Too many GPUs on system to print out individual Prometheus metrics, "
         "use the CSV output feature to see metrics.\n");
+  }
+}
+
+TEST_CASE("InferenceProfiler: Test SummarizeOverhead")
+{
+  TestInferenceProfiler tip{};
+  PerfStatus status;
+  SUBCASE("normal")
+  {
+    tip.SummarizeOverhead(100, 63, status);
+    CHECK(status.overhead_pct == 37);
+  }
+  SUBCASE("normal 2")
+  {
+    tip.SummarizeOverhead(234, 56, status);
+    CHECK(status.overhead_pct == doctest::Approx(76.068));
+  }
+  SUBCASE("overflow")
+  {
+    tip.SummarizeOverhead(100, 101, status);
+    CHECK(status.overhead_pct == 0);
   }
 }
 

--- a/src/c++/perf_analyzer/test_inference_profiler.cc
+++ b/src/c++/perf_analyzer/test_inference_profiler.cc
@@ -665,7 +665,7 @@ TEST_CASE("InferenceProfiler: Test SummarizeOverhead")
   SUBCASE("normal")
   {
     tip.SummarizeOverhead(100, 63, status);
-    CHECK(status.overhead_pct == 37);
+    CHECK(status.overhead_pct == doctest::Approx(37));
   }
   SUBCASE("normal 2")
   {
@@ -674,8 +674,8 @@ TEST_CASE("InferenceProfiler: Test SummarizeOverhead")
   }
   SUBCASE("overflow")
   {
-    tip.SummarizeOverhead(100, 101, status);
-    CHECK(status.overhead_pct == 0);
+    CHECK_THROWS_AS(
+        tip.SummarizeOverhead(100, 101, status), const std::exception&);
   }
 }
 

--- a/src/c++/perf_analyzer/test_load_manager.cc
+++ b/src/c++/perf_analyzer/test_load_manager.cc
@@ -319,8 +319,8 @@ class TestLoadManager : public TestLoadManagerBase, public LoadManager {
     SUBCASE("All active")
     {
       // If multiple threads are active, their idle times are averaged
-      stat1->accumulated_idle_ns = 5;
-      stat2->accumulated_idle_ns = 7;
+      stat1->idle_timer.idle_ns_ = 5;
+      stat2->idle_timer.idle_ns_ = 7;
       CHECK(GetIdleTime() == 6);
       ResetIdleTime();
       CHECK(GetIdleTime() == 0);
@@ -330,8 +330,8 @@ class TestLoadManager : public TestLoadManagerBase, public LoadManager {
     {
       // If a thread has no idle time, it is considered inactive and not
       // factored in to the average
-      stat1->accumulated_idle_ns = 0;
-      stat2->accumulated_idle_ns = 7;
+      stat1->idle_timer.idle_ns_ = 0;
+      stat2->idle_timer.idle_ns_ = 7;
       CHECK(GetIdleTime() == 7);
       ResetIdleTime();
       CHECK(GetIdleTime() == 0);

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -307,7 +307,6 @@ class TestRequestRateManager : public TestLoadManagerBase,
     //
     auto idle_time_ns = GetIdleTime();
     CHECK(idle_time_ns > 95000000);
-    CHECK(idle_time_ns < 100000000);
     StopWorkerThreads();
   }
 

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -296,6 +296,21 @@ class TestRequestRateManager : public TestLoadManagerBase,
     watchdog.stop();
   }
 
+  /// Test that idle time is tracked correctly
+  void TestOverhead(uint request_rate)
+  {
+    stats_->SetDelays({1});
+    ChangeRequestRate(request_rate);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // During a run of 100 ms (100,000,000 ns), make sure that the idle time is
+    // at least 95% of that
+    //
+    auto idle_time_ns = GetIdleTime();
+    CHECK(idle_time_ns > 95000000);
+    CHECK(idle_time_ns < 100000000);
+    StopWorkerThreads();
+  }
+
   std::shared_ptr<ModelParser>& parser_{LoadManager::parser_};
   std::shared_ptr<DataLoader>& data_loader_{LoadManager::data_loader_};
   bool& using_json_data_{LoadManager::using_json_data_};
@@ -1071,4 +1086,38 @@ TEST_CASE("request_rate_deadlock")
 
   trrm.TestTimeouts();
 }
+
+TEST_CASE("request_rate_overhead")
+{
+  uint rate;
+  PerfAnalyzerParameters params{};
+  SUBCASE("sync, rate 10")
+  {
+    params.async = false;
+    rate = 10;
+  }
+  SUBCASE("sync, rate 100")
+  {
+    params.async = false;
+    rate = 100;
+  }
+  SUBCASE("async, rate 10")
+  {
+    params.async = true;
+    rate = 10;
+  }
+  SUBCASE("async, rate 100")
+  {
+    params.async = true;
+    rate = 100;
+  }
+  TestRequestRateManager trrm(params, false);
+  trrm.InitManager(
+      params.string_length, params.string_data, params.zero_input,
+      params.user_data, params.start_sequence_id, params.sequence_id_range,
+      params.sequence_length);
+
+  trrm.TestOverhead(rate);
+}
+
 }}  // namespace triton::perfanalyzer


### PR DESCRIPTION
Track overhead in perf analyzer. This is any time that PA is not calling a backend function and not sleeping/waiting until it is time to issue a new request.

new class IdleTimer with proper unit testing
add idle timing around backend function calls as well as worker wait/sleep periods
All time not idle is considered overhead
Add function in LoadManager to bubble up average worker idle time
Add function in InferenceProfiler to calculate and store per-window overhead percentage