### PR TITLE
Fix various tfserve bugs

### DIFF
--- a/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h
+++ b/src/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -65,7 +65,7 @@ class TFServeInferInput : public InferInput {
       const std::string& datatype);
 
   std::vector<int64_t> shape_;
-  size_t byte_size_;
+  size_t byte_size_{0};
 
   size_t bufs_idx_, buf_pos_;
   std::vector<const uint8_t*> bufs_;

--- a/src/c++/perf_analyzer/data_loader.cc
+++ b/src/c++/perf_analyzer/data_loader.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -233,7 +233,8 @@ DataLoader::ParseData(
     }
   }
 
-  max_non_sequence_step_id_ = std::max(1, (int)(step_num_[0] / batch_size_));
+  max_non_sequence_step_id_ =
+      std::max(1, (int)(step_num_[0] / (batch_size_ != 0 ? batch_size_ : 1)));
 
   return cb::Error::Success;
 }


### PR DESCRIPTION
I have tested these changes locally to confirm that they remove the crashes seen by the user who reported the issue.

I do not have explicit testing in place to catch these, yet.
* The class data member not being initialized to zero is a symptom of assuming the compiler would do so. A repo-wide stylistic change to initialize all data members (and variables in general) would be an appropriate fix. Also more unit testing of the class for the data member. All stuff I would prefer to do in future, not now for a quick bug fix.
* The division by zero is also a symptom of the data loader class not having unit testing. I'd prefer to do that later in a dedicated story.