### PR TITLE
Add check for invalid --shared-memory arg

### DIFF
--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -940,10 +940,13 @@ CLParser::ParseCommandLine(int argc, char** argv)
 #else
           Usage("cuda shared memory is not supported when TRITON_ENABLE_GPU=0");
 #endif  // TRITON_ENABLE_GPU
+        } else if (arg.compare("none") == 0) {
+          params_->shared_memory_type = SharedMemoryType::NO_SHARED_MEMORY;
         } else {
           Usage(
               "unsupported --shared-memory type provided: '" +
-              std::string(optarg) + "'. Choices are 'system' or 'cuda'.");
+              std::string(optarg) +
+              "'. Choices are 'system', 'cuda', or 'none'.");
         }
         break;
       }

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -940,6 +940,10 @@ CLParser::ParseCommandLine(int argc, char** argv)
 #else
           Usage("cuda shared memory is not supported when TRITON_ENABLE_GPU=0");
 #endif  // TRITON_ENABLE_GPU
+        } else {
+          Usage(
+              "unsupported --shared-memory type provided: '" +
+              std::string(optarg) + "'. Choices are 'system' or 'cuda'.");
         }
         break;
       }


### PR DESCRIPTION
Accidentally set `--shared-memory host` instead of `--shared-memory system` and noticed no error was raised, so it silently didn't use shared memory. This should fix that.