### PR TITLE
Update grpcio requirement for python client

### DIFF
--- a/src/python/library/requirements/requirements_grpc.txt
+++ b/src/python/library/requirements/requirements_grpc.txt
@@ -28,10 +28,7 @@
 # (see https://github.com/protocolbuffers/protobuf/issues/10051)
 # TODO: Update to be compatible with 4.0 release (DLIS-3809)
 protobuf>=3.5.0,<4
-# There is memory leak in later Python GRPC (1.43.0 to be specific),
-# use known working version until the memory leak is resolved in the future
-# (see https://github.com/grpc/grpc/issues/28513)
-grpcio>=1.41.0
+grpcio>=1.51.1
 packaging>=14.1
 numpy>=1.19.1
 python-rapidjson>=0.9.1


### PR DESCRIPTION
As memory-leak reported to be resolved in grpcio>=1.51.1