### PR TITLE
Add request send rate detection

### DIFF
--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -106,10 +106,7 @@ InferContext::SendRequest(const uint64_t request_id, const bool delayed)
     return;
   }
 
-  {
-    std::lock_guard<std::mutex> lock(thread_stat_->mu_);
-    thread_stat_->num_sent_requests_++;
-  }
+  thread_stat_->num_sent_requests_++;
   if (async_) {
     infer_data_.options_->request_id_ = std::to_string(request_id);
     {

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -99,9 +99,14 @@ InferContext::CompleteOngoingSequence(uint32_t seq_stat_index)
   }
 }
 
+std::chrono::steady_clock::time_point origin{std::chrono::steady_clock::now()};
+
 void
 InferContext::SendRequest(const uint64_t request_id, const bool delayed)
 {
+  std::cout << (std::chrono::steady_clock::now() - origin).count() / 1000000.0
+            << "ms" << std::endl;
+
   if (!thread_stat_->status_.IsOk()) {
     return;
   }
@@ -118,6 +123,8 @@ InferContext::SendRequest(const uint64_t request_id, const bool delayed)
       it->second.start_time_ = std::chrono::system_clock::now();
       it->second.sequence_end_ = infer_data_.options_->sequence_end_;
       it->second.delayed_ = delayed;
+      thread_stat_->request_send_times_.push_back(
+          std::chrono::steady_clock::now());
     }
 
     thread_stat_->idle_timer.Start();
@@ -139,6 +146,11 @@ InferContext::SendRequest(const uint64_t request_id, const bool delayed)
     thread_stat_->idle_timer.Start();
     start_time_sync = std::chrono::system_clock::now();
     cb::InferResult* results = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(thread_stat_->mu_);
+      thread_stat_->request_send_times_.push_back(
+          std::chrono::steady_clock::now());
+    }
     thread_stat_->status_ = infer_backend_->Infer(
         &results, *(infer_data_.options_), infer_data_.valid_inputs_,
         infer_data_.outputs_);

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -58,6 +58,8 @@ struct ThreadStat {
   TimestampVector request_timestamps_;
   // A lock to protect thread data
   std::mutex mu_;
+  // A vector of request send timestamps
+  std::vector<std::chrono::steady_clock::time_point> request_send_times_{};
 };
 
 /// The properties of an asynchronous request required in

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -59,7 +59,7 @@ struct ThreadStat {
   // A lock to protect thread data
   std::mutex mu_;
   // The number of sent requests by this thread.
-  size_t num_sent_requests_{0};
+  std::atomic<size_t> num_sent_requests_{0};
 };
 
 /// The properties of an asynchronous request required in

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -58,8 +58,8 @@ struct ThreadStat {
   TimestampVector request_timestamps_;
   // A lock to protect thread data
   std::mutex mu_;
-  // A vector of request send timestamps
-  std::vector<std::chrono::steady_clock::time_point> request_send_times_{};
+  // The number of sent requests by this thread.
+  size_t num_sent_requests_{0};
 };
 
 /// The properties of an asynchronous request required in

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -1173,6 +1173,8 @@ InferenceProfiler::Summarize(
 
   SummarizeOverhead(window_duration_ns, manager_->GetIdleTime(), summary);
 
+  SummarizeSendRequestRate(manager_->GetSendRequestRate(), summary);
+
   if (include_server_stats_) {
     RETURN_IF_ERROR(SummarizeServerStats(
         start_status, end_status, &(summary.server_stats)));
@@ -1335,6 +1337,13 @@ InferenceProfiler::SummarizeClientStat(
   }
 
   return cb::Error::Success;
+}
+
+void
+InferenceProfiler::SummarizeSendRequestRate(
+    const double send_request_rate, PerfStatus& summary)
+{
+  summary.send_request_rate = send_request_rate;
 }
 
 cb::Error

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1173,7 +1173,8 @@ InferenceProfiler::Summarize(
 
   SummarizeOverhead(window_duration_ns, manager_->GetIdleTime(), summary);
 
-  SummarizeSendRequestRate(manager_->GetSendRequestRate(), summary);
+  SummarizeSendRequestRate(
+      window_duration_ns, manager_->GetNumSentRequests(), summary);
 
   if (include_server_stats_) {
     RETURN_IF_ERROR(SummarizeServerStats(
@@ -1341,9 +1342,12 @@ InferenceProfiler::SummarizeClientStat(
 
 void
 InferenceProfiler::SummarizeSendRequestRate(
-    const double send_request_rate, PerfStatus& summary)
+    const uint64_t window_duration_ns, const size_t num_sent_requests,
+    PerfStatus& summary)
 {
-  summary.send_request_rate = send_request_rate;
+  summary.send_request_rate =
+      num_sent_requests /
+      (window_duration_ns / static_cast<double>(NANOS_PER_SECOND));
 }
 
 cb::Error

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -157,6 +157,7 @@ struct PerfStatus {
 
   // placeholder for the latency value that is used for conditional checking
   uint64_t stabilizing_latency_ns;
+  // Metric for requests sent per second
   double send_request_rate{0.0};
 };
 
@@ -468,12 +469,14 @@ class InferenceProfiler {
       PerfStatus& summary);
 
   /// Adds the send request rate metric to the summary object.
-  /// \param send_request_rate The send request rate metric to be added to the
-  /// summary object.
+  /// \param window_duration_ns The duration of the window.
+  /// \param num_sent_requests The number of requests sent during the last
+  /// window.
   /// \param summary The summary object to be updated with the send request rate
   /// metric.
   void SummarizeSendRequestRate(
-      const double send_request_rate, PerfStatus& summary);
+      const uint64_t window_duration_ns, const size_t num_sent_requests,
+      PerfStatus& summary);
 
   /// \param model_identifier A pair of model_name and model_version to identify
   /// a specific model.

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -469,13 +469,13 @@ class InferenceProfiler {
       PerfStatus& summary);
 
   /// Adds the send request rate metric to the summary object.
-  /// \param window_duration_ns The duration of the window.
+  /// \param window_duration_s The duration of the window in seconds.
   /// \param num_sent_requests The number of requests sent during the last
   /// window.
   /// \param summary The summary object to be updated with the send request rate
   /// metric.
   void SummarizeSendRequestRate(
-      const uint64_t window_duration_ns, const size_t num_sent_requests,
+      const double window_duration_s, const size_t num_sent_requests,
       PerfStatus& summary);
 
   /// \param model_identifier A pair of model_name and model_version to identify

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -157,6 +157,7 @@ struct PerfStatus {
 
   // placeholder for the latency value that is used for conditional checking
   uint64_t stabilizing_latency_ns;
+  double send_request_rate{0.0};
 };
 
 cb::Error ReportPrometheusMetrics(const Metrics& metrics);
@@ -465,6 +466,14 @@ class InferenceProfiler {
       const uint64_t duration_ns, const size_t valid_request_count,
       const size_t delayed_request_count, const size_t valid_sequence_count,
       PerfStatus& summary);
+
+  /// Adds the send request rate metric to the summary object.
+  /// \param send_request_rate The send request rate metric to be added to the
+  /// summary object.
+  /// \param summary The summary object to be updated with the send request rate
+  /// metric.
+  void SummarizeSendRequestRate(
+      const double send_request_rate, PerfStatus& summary);
 
   /// \param model_identifier A pair of model_name and model_version to identify
   /// a specific model.

--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -149,7 +149,6 @@ LoadManager::GetAndResetNumSentRequests()
   size_t num_sent_requests{0};
 
   for (auto& thread_stat : threads_stat_) {
-    std::lock_guard<std::mutex> lock(thread_stat->mu_);
     num_sent_requests += thread_stat->num_sent_requests_;
     thread_stat->num_sent_requests_ = 0;
   }

--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -144,7 +144,7 @@ LoadManager::ResetIdleTime()
 }
 
 const size_t
-LoadManager::GetNumSentRequests()
+LoadManager::GetAndResetNumSentRequests()
 {
   size_t num_sent_requests{0};
 

--- a/src/c++/perf_analyzer/load_manager.h
+++ b/src/c++/perf_analyzer/load_manager.h
@@ -87,9 +87,9 @@ class LoadManager {
   void ResetIdleTime();
 
   /// Calculates and returns the total number of sent requests across all
-  /// threads.
+  /// threads. Resets individual number of sent requests per thread.
   /// \return The total number of sent requests across all threads.
-  const size_t GetNumSentRequests();
+  const size_t GetAndResetNumSentRequests();
 
   /// \return the batch size used for the inference requests
   size_t BatchSize() const { return batch_size_; }

--- a/src/c++/perf_analyzer/load_manager.h
+++ b/src/c++/perf_analyzer/load_manager.h
@@ -86,6 +86,10 @@ class LoadManager {
   ///
   void ResetIdleTime();
 
+  /// Calculates and returns the combined send request rate from worker threads.
+  /// \return The combined send request rate from worker threads.
+  double GetSendRequestRate();
+
   /// \return the batch size used for the inference requests
   size_t BatchSize() const { return batch_size_; }
 

--- a/src/c++/perf_analyzer/load_manager.h
+++ b/src/c++/perf_analyzer/load_manager.h
@@ -86,9 +86,10 @@ class LoadManager {
   ///
   void ResetIdleTime();
 
-  /// Calculates and returns the combined send request rate from worker threads.
-  /// \return The combined send request rate from worker threads.
-  double GetSendRequestRate();
+  /// Calculates and returns the total number of sent requests across all
+  /// threads.
+  /// \return The total number of sent requests across all threads.
+  const size_t GetNumSentRequests();
 
   /// \return the batch size used for the inference requests
   size_t BatchSize() const { return batch_size_; }

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -812,7 +812,7 @@ TEST_CASE(
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   tcm.StopWorkerThreads();
 
-  const size_t num_sent_requests{tcm.GetNumSentRequests()};
+  const size_t num_sent_requests{tcm.GetAndResetNumSentRequests()};
 
   CHECK(num_sent_requests == doctest::Approx(40).epsilon(0.1));
 }

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -792,7 +792,7 @@ TEST_CASE("concurrency_overhead")
 
 TEST_CASE(
     "send_request_rate_concurrency_manager: testing logic around detecting "
-    "send request rate")
+    "send request count")
 {
   PerfAnalyzerParameters params{};
 
@@ -812,8 +812,9 @@ TEST_CASE(
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   tcm.StopWorkerThreads();
 
-  double send_request_rate{tcm.GetSendRequestRate()};
-  CHECK(send_request_rate == doctest::Approx(400).epsilon(0.1));
+  const size_t num_sent_requests{tcm.GetNumSentRequests()};
+
+  CHECK(num_sent_requests == doctest::Approx(40).epsilon(0.1));
 }
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -83,6 +83,8 @@ class TestConcurrencyManager : public TestLoadManagerBase,
     }
   }
 
+  void StopWorkerThreads() { LoadManager::StopWorkerThreads(); }
+
   /// Test that the correct Infer function is called in the backend
   ///
   void TestInferType()
@@ -786,6 +788,32 @@ TEST_CASE("concurrency_overhead")
       params.sequence_length);
 
   tcm.TestOverhead();
+}
+
+TEST_CASE(
+    "send_request_rate_concurrency_manager: testing logic around detecting "
+    "send request rate")
+{
+  PerfAnalyzerParameters params{};
+
+  SUBCASE("sync") { params.async = false; }
+  SUBCASE("async") { params.async = true; }
+
+  TestConcurrencyManager tcm(params);
+
+  tcm.stats_->SetDelays({10});
+
+  tcm.InitManager(
+      params.string_length, params.string_data, params.zero_input,
+      params.user_data, params.start_sequence_id, params.sequence_id_range,
+      params.sequence_length);
+
+  tcm.ChangeConcurrencyLevel(4);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  tcm.StopWorkerThreads();
+
+  double send_request_rate{tcm.GetSendRequestRate()};
+  CHECK(send_request_rate == doctest::Approx(400).epsilon(0.1));
 }
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_load_manager.cc
+++ b/src/c++/perf_analyzer/test_load_manager.cc
@@ -391,7 +391,7 @@ TEST_CASE("load_manager: Test public idle time functions")
 }
 
 TEST_CASE(
-    "send_request_rate_load_manager: testing the GetSendRequestRate function")
+    "send_request_rate_load_manager: testing the GetNumSentRequests function")
 {
   PerfAnalyzerParameters params{};
 
@@ -403,21 +403,17 @@ TEST_CASE(
   std::chrono::steady_clock::time_point start_time{
       std::chrono::steady_clock::time_point::min()};
 
-  thread_stat_1->request_send_times_ = {
-      start_time + std::chrono::milliseconds(0),
-      start_time + std::chrono::milliseconds(500),
-      start_time + std::chrono::milliseconds(1000)};
-  thread_stat_2->request_send_times_ = {
-      start_time + std::chrono::milliseconds(0),
-      start_time + std::chrono::milliseconds(500),
-      start_time + std::chrono::milliseconds(1000)};
+  thread_stat_1->num_sent_requests_ = 6;
+  thread_stat_2->num_sent_requests_ = 5;
 
   tlm.threads_stat_.push_back(thread_stat_1);
   tlm.threads_stat_.push_back(thread_stat_2);
 
-  double result{tlm.GetSendRequestRate()};
+  const size_t result{tlm.GetNumSentRequests()};
 
-  CHECK(result == doctest::Approx(6.0));
+  CHECK(result == 11);
+  CHECK(thread_stat_1->num_sent_requests_ == 0);
+  CHECK(thread_stat_2->num_sent_requests_ == 0);
 }
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_load_manager.cc
+++ b/src/c++/perf_analyzer/test_load_manager.cc
@@ -391,7 +391,8 @@ TEST_CASE("load_manager: Test public idle time functions")
 }
 
 TEST_CASE(
-    "send_request_rate_load_manager: testing the GetNumSentRequests function")
+    "send_request_rate_load_manager: testing the GetAndResetNumSentRequests "
+    "function")
 {
   PerfAnalyzerParameters params{};
 
@@ -406,14 +407,14 @@ TEST_CASE(
   thread_stat_1->num_sent_requests_ = 6;
   thread_stat_2->num_sent_requests_ = 5;
 
-  tlm.threads_stat_.push_back(thread_stat_1);
-  tlm.threads_stat_.push_back(thread_stat_2);
+  tlm.threads_stat_ = {thread_stat_1, thread_stat_2};
 
-  const size_t result{tlm.GetNumSentRequests()};
+  const size_t result{tlm.GetAndResetNumSentRequests()};
 
   CHECK(result == 11);
-  CHECK(thread_stat_1->num_sent_requests_ == 0);
-  CHECK(thread_stat_2->num_sent_requests_ == 0);
+  CHECK(tlm.threads_stat_.size() == 2);
+  CHECK(tlm.threads_stat_[0]->num_sent_requests_ == 0);
+  CHECK(tlm.threads_stat_[1]->num_sent_requests_ == 0);
 }
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_load_manager.cc
+++ b/src/c++/perf_analyzer/test_load_manager.cc
@@ -47,6 +47,9 @@ class TestLoadManager : public TestLoadManagerBase, public LoadManager {
   {
   }
 
+  std::vector<std::shared_ptr<ThreadStat>>& threads_stat_{
+      LoadManager::threads_stat_};
+
   /// Test the public function CheckHealth
   ///
   /// It will return a bad result if any of the thread stats
@@ -385,6 +388,36 @@ TEST_CASE("load_manager: Test public idle time functions")
   PerfAnalyzerParameters params;
   TestLoadManager tlm(params);
   tlm.TestIdle();
+}
+
+TEST_CASE(
+    "send_request_rate_load_manager: testing the GetSendRequestRate function")
+{
+  PerfAnalyzerParameters params{};
+
+  TestLoadManager tlm(params);
+
+  std::shared_ptr<ThreadStat> thread_stat_1{std::make_shared<ThreadStat>()};
+  std::shared_ptr<ThreadStat> thread_stat_2{std::make_shared<ThreadStat>()};
+
+  std::chrono::steady_clock::time_point start_time{
+      std::chrono::steady_clock::time_point::min()};
+
+  thread_stat_1->request_send_times_ = {
+      start_time + std::chrono::milliseconds(0),
+      start_time + std::chrono::milliseconds(500),
+      start_time + std::chrono::milliseconds(1000)};
+  thread_stat_2->request_send_times_ = {
+      start_time + std::chrono::milliseconds(0),
+      start_time + std::chrono::milliseconds(500),
+      start_time + std::chrono::milliseconds(1000)};
+
+  tlm.threads_stat_.push_back(thread_stat_1);
+  tlm.threads_stat_.push_back(thread_stat_2);
+
+  double result{tlm.GetSendRequestRate()};
+
+  CHECK(result == doctest::Approx(6.0));
 }
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -1143,7 +1143,7 @@ TEST_CASE(
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
   trrm.StopWorkerThreads();
 
-  const size_t num_sent_requests{trrm.GetNumSentRequests()};
+  const size_t num_sent_requests{trrm.GetAndResetNumSentRequests()};
 
   CHECK(num_sent_requests == doctest::Approx(50).epsilon(0.1));
 }

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -90,6 +90,8 @@ class TestRequestRateManager : public TestLoadManagerBase,
     }
   }
 
+  void StopWorkerThreads() { LoadManager::StopWorkerThreads(); }
+
   void TestSchedule(double rate, PerfAnalyzerParameters params)
   {
     PauseWorkers();
@@ -1117,6 +1119,32 @@ TEST_CASE("request_rate_overhead")
       params.sequence_length);
 
   trrm.TestOverhead(rate);
+}
+
+std::chrono::steady_clock::time_point mk_start{};
+
+TEST_CASE(
+    "send_request_rate_request_rate_manager: testing logic around detecting "
+    "send request rate")
+{
+  PerfAnalyzerParameters params{};
+
+  SUBCASE("sync") { params.async = false; }
+  SUBCASE("async") { params.async = true; }
+
+  TestRequestRateManager trrm(params);
+
+  trrm.InitManager(
+      params.string_length, params.string_data, params.zero_input,
+      params.user_data, params.start_sequence_id, params.sequence_id_range,
+      params.sequence_length);
+
+  trrm.ChangeRequestRate(1000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  trrm.StopWorkerThreads();
+
+  double send_request_rate{trrm.GetSendRequestRate()};
+  CHECK(send_request_rate == doctest::Approx(1000).epsilon(0.1));
 }
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -1125,7 +1125,7 @@ std::chrono::steady_clock::time_point mk_start{};
 
 TEST_CASE(
     "send_request_rate_request_rate_manager: testing logic around detecting "
-    "send request rate")
+    "send request count")
 {
   PerfAnalyzerParameters params{};
 
@@ -1143,8 +1143,9 @@ TEST_CASE(
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
   trrm.StopWorkerThreads();
 
-  double send_request_rate{trrm.GetSendRequestRate()};
-  CHECK(send_request_rate == doctest::Approx(1000).epsilon(0.1));
+  const size_t num_sent_requests{trrm.GetNumSentRequests()};
+
+  CHECK(num_sent_requests == doctest::Approx(50).epsilon(0.1));
 }
 
 }}  // namespace triton::perfanalyzer


### PR DESCRIPTION
* Each thread in load manager now increments a counter when a request is sent
* These counters are summed up by the InferenceProfiler once per window to calculate send request rate
* The send request rate metric is stored in the PerfStatus object in InferenceProfiler