### PR TITLE
report overhead and request rate

### DIFF
--- a/src/c++/perf_analyzer/CMakeLists.txt
+++ b/src/c++/perf_analyzer/CMakeLists.txt
@@ -3,14 +3,14 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
-#  * Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-#  * Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-#  * Neither the name of NVIDIA CORPORATION nor the names of its
-#    contributors may be used to endorse or promote products derived
-#    from this software without specific prior written permission.
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# * Neither the name of NVIDIA CORPORATION nor the names of its
+# contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -24,189 +24,185 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION 3.18)
+cmake_minimum_required(VERSION 3.18)
 
 if(WIN32)
   message("perf_analyzer is not currently supported on Windows because "
-          "is requires functionalities that are UNIX specific.")
+    "is requires functionalities that are UNIX specific.")
 else()
+  add_subdirectory(client_backend)
 
-add_subdirectory(client_backend)
+  set(
+    PERF_ANALYZER_SRCS
+    command_line_parser.cc
+    perf_analyzer.cc
+    model_parser.cc
+    perf_utils.cc
+    load_manager.cc
+    data_loader.cc
+    concurrency_manager.cc
+    request_rate_manager.cc
+    load_worker.cc
+    concurrency_worker.cc
+    request_rate_worker.cc
+    custom_load_manager.cc
+    infer_context.cc
+    inference_profiler.cc
+    report_writer.cc
+    mpi_utils.cc
+    metrics_manager.cc
+    infer_data_manager_base.cc
+    infer_data_manager.cc
+    infer_data_manager_shm.cc
+    sequence_manager.cc
+  )
 
-set(
-  PERF_ANALYZER_SRCS
-  command_line_parser.cc
-  perf_analyzer.cc
-  model_parser.cc
-  perf_utils.cc
-  load_manager.cc
-  data_loader.cc
-  concurrency_manager.cc
-  request_rate_manager.cc
-  load_worker.cc
-  concurrency_worker.cc
-  request_rate_worker.cc
-  custom_load_manager.cc
-  infer_context.cc
-  inference_profiler.cc
-  report_writer.cc
-  mpi_utils.cc
-  metrics_manager.cc
-  infer_data_manager_base.cc
-  infer_data_manager.cc
-  infer_data_manager_shm.cc
-  sequence_manager.cc
-)
+  set(
+    PERF_ANALYZER_HDRS
+    command_line_parser.h
+    perf_analyzer.h
+    model_parser.h
+    perf_utils.h
+    load_manager.h
+    data_loader.h
+    concurrency_manager.h
+    request_rate_manager.h
+    custom_load_manager.h
+    iworker.h
+    load_worker.h
+    request_rate_worker.h
+    concurrency_worker.h
+    infer_context.h
+    inference_profiler.h
+    report_writer.h
+    mpi_utils.h
+    doctest.h
+    constants.h
+    metrics.h
+    metrics_manager.h
+    infer_data_manager_factory.h
+    iinfer_data_manager.h
+    infer_data_manager.h
+    infer_data_manager_shm.h
+    infer_data_manager_base.h
+    infer_data.h
+    sequence_manager.h
+    sequence_status.h
+  )
 
-set(
-  PERF_ANALYZER_HDRS
-  command_line_parser.h
-  perf_analyzer.h
-  model_parser.h
-  perf_utils.h
-  load_manager.h
-  data_loader.h
-  concurrency_manager.h
-  request_rate_manager.h
-  custom_load_manager.h
-  iworker.h
-  load_worker.h
-  request_rate_worker.h
-  concurrency_worker.h
-  infer_context.h
-  inference_profiler.h
-  report_writer.h
-  mpi_utils.h
-  doctest.h
-  constants.h
-  metrics.h
-  metrics_manager.h
-  infer_data_manager_factory.h
-  iinfer_data_manager.h
-  infer_data_manager.h
-  infer_data_manager_shm.h
-  infer_data_manager_base.h
-  infer_data.h
-  sequence_manager.h
-  sequence_status.h
-)
-
-add_executable(
-  perf_analyzer
-  main.cc
-  ${PERF_ANALYZER_SRCS}
-  ${PERF_ANALYZER_HDRS}
-  $<TARGET_OBJECTS:json-utils-library>
-)
-target_link_libraries(
-  perf_analyzer
-  PRIVATE
+  add_executable(
+    perf_analyzer
+    main.cc
+    ${PERF_ANALYZER_SRCS}
+    ${PERF_ANALYZER_HDRS}
+    $<TARGET_OBJECTS:json-utils-library>
+  )
+  target_link_libraries(
+    perf_analyzer
+    PRIVATE
     client-backend-library
     -lb64
     ${CMAKE_DL_LIBS}
-)
-
-# If gpu is enabled then compile with CUDA dependencies
-if(TRITON_ENABLE_GPU)
-  target_compile_definitions(
-    perf_analyzer
-    PUBLIC TRITON_ENABLE_GPU=1
   )
+
+  # If gpu is enabled then compile with CUDA dependencies
+  if(TRITON_ENABLE_GPU)
+    target_compile_definitions(
+      perf_analyzer
+      PUBLIC TRITON_ENABLE_GPU=1
+    )
+
+    target_link_libraries(
+      perf_analyzer
+      PRIVATE CUDA::cudart
+    )
+  endif()
+
+  if(TRITON_ENABLE_PERF_ANALYZER_C_API)
+    target_compile_definitions(
+      client-backend-library
+      PUBLIC TRITON_ENABLE_PERF_ANALYZER_C_API=1
+    )
+  endif()
+
+  if(TRITON_ENABLE_PERF_ANALYZER_TFS)
+    target_compile_definitions(
+      client-backend-library
+      PUBLIC TRITON_ENABLE_PERF_ANALYZER_TFS=1
+    )
+  endif()
+
+  if(TRITON_ENABLE_PERF_ANALYZER_TS)
+    target_compile_definitions(
+      client-backend-library
+      PUBLIC TRITON_ENABLE_PERF_ANALYZER_TS=1
+    )
+  endif()
+
+  install(
+    TARGETS perf_analyzer
+    RUNTIME DESTINATION bin
+  )
+
+  target_compile_definitions(perf_analyzer PUBLIC DOCTEST_CONFIG_DISABLE)
+
+  # Creating perf_client link to perf_analyzer binary for backwards compatibility.
+  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ./perf_analyzer perf_client
+  WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/)")
+  install(CODE "message(\"-- Created symlink: perf_client -> ./perf_analyzer\")")
+
+  set(PERF_ANALYZER_UNIT_TESTS_SRCS ${PERF_ANALYZER_SRCS})
+  list(PREPEND PERF_ANALYZER_UNIT_TESTS_SRCS perf_analyzer_unit_tests.cc)
+  set(PERF_ANALYZER_UNIT_TESTS_HDRS ${PERF_ANALYZER_HDRS})
+
+  add_executable(
+    perf_analyzer_unit_tests
+    ${PERF_ANALYZER_UNIT_TESTS_SRCS}
+    ${PERF_ANALYZER_UNIT_TESTS_HDRS}
+    mock_inference_profiler.h
+    mock_model_parser.h
+    test_utils.h
+    client_backend/mock_client_backend.h
+    mock_data_loader.h
+    test_inference_profiler.cc
+    test_command_line_parser.cc
+    test_idle_timer.cc
+    test_load_manager_base.h
+    test_load_manager.cc
+    test_model_parser.cc
+    test_metrics_manager.cc
+    test_perf_utils.cc
+    test_report_writer.cc
+    client_backend/triton/test_triton_client_backend.cc
+    test_request_rate_manager.cc
+    test_concurrency_manager.cc
+    test_custom_load_manager.cc
+    test_sequence_manager.cc
+    $<TARGET_OBJECTS:json-utils-library>
+  )
+
+  # -Wno-write-strings is needed for the unit tests in order to statically create
+  # input argv cases in the CommandLineParser unit test
+  #
+  set_target_properties(perf_analyzer_unit_tests
+    PROPERTIES COMPILE_FLAGS "-Wno-write-strings")
 
   target_link_libraries(
-    perf_analyzer
-    PRIVATE CUDA::cudart
-  )
-endif()
-
-if(TRITON_ENABLE_PERF_ANALYZER_C_API)
-  target_compile_definitions(
-    client-backend-library
-    PUBLIC TRITON_ENABLE_PERF_ANALYZER_C_API=1
-  )
-endif()
-
-if(TRITON_ENABLE_PERF_ANALYZER_TFS)
-  target_compile_definitions(
-    client-backend-library
-    PUBLIC TRITON_ENABLE_PERF_ANALYZER_TFS=1
-  )
-endif()
-
-if(TRITON_ENABLE_PERF_ANALYZER_TS)
-  target_compile_definitions(
-    client-backend-library
-    PUBLIC TRITON_ENABLE_PERF_ANALYZER_TS=1
-  )
-endif()
-
-install(
-  TARGETS perf_analyzer
-  RUNTIME DESTINATION bin
-)
-
-target_compile_definitions(perf_analyzer PUBLIC DOCTEST_CONFIG_DISABLE)
-
-# Creating perf_client link to perf_analyzer binary for backwards compatibility.
-install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ./perf_analyzer perf_client
-  WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/)")
-install(CODE "message(\"-- Created symlink: perf_client -> ./perf_analyzer\")")
-
-
-
-set(PERF_ANALYZER_UNIT_TESTS_SRCS ${PERF_ANALYZER_SRCS})
-list(PREPEND PERF_ANALYZER_UNIT_TESTS_SRCS perf_analyzer_unit_tests.cc)
-set(PERF_ANALYZER_UNIT_TESTS_HDRS ${PERF_ANALYZER_HDRS})
-
-add_executable(
-  perf_analyzer_unit_tests
-  ${PERF_ANALYZER_UNIT_TESTS_SRCS}
-  ${PERF_ANALYZER_UNIT_TESTS_HDRS}
-  mock_inference_profiler.h
-  mock_model_parser.h
-  test_utils.h
-  client_backend/mock_client_backend.h  
-  mock_data_loader.h
-  test_inference_profiler.cc
-  test_command_line_parser.cc
-  test_idle_timer.cc
-  test_load_manager_base.h
-  test_load_manager.cc
-  test_model_parser.cc
-  test_metrics_manager.cc
-  test_perf_utils.cc
-  test_report_writer.cc
-  client_backend/triton/test_triton_client_backend.cc
-  test_request_rate_manager.cc
-  test_concurrency_manager.cc
-  test_custom_load_manager.cc
-  test_sequence_manager.cc
-  $<TARGET_OBJECTS:json-utils-library>
-)
-
-# -Wno-write-strings is needed for the unit tests in order to statically create
-# input argv cases in the CommandLineParser unit test
-#
-set_target_properties(perf_analyzer_unit_tests 
-  PROPERTIES COMPILE_FLAGS "-Wno-write-strings")
-
-target_link_libraries(
-  perf_analyzer_unit_tests
-  PRIVATE
+    perf_analyzer_unit_tests
+    PRIVATE
     gmock
     client-backend-library
     -lb64
-)
+  )
 
-target_include_directories(
-  perf_analyzer_unit_tests
-  PRIVATE
+  target_include_directories(
+    perf_analyzer_unit_tests
+    PRIVATE
     client_backend
-)
+  )
 
-install(
-  TARGETS perf_analyzer_unit_tests
-  RUNTIME DESTINATION bin
-)
-
+  install(
+    TARGETS perf_analyzer_unit_tests
+    RUNTIME DESTINATION bin
+  )
 endif()

--- a/src/c++/perf_analyzer/CMakeLists.txt
+++ b/src/c++/perf_analyzer/CMakeLists.txt
@@ -3,14 +3,14 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
-# * Redistributions of source code must retain the above copyright
-# notice, this list of conditions and the following disclaimer.
-# * Redistributions in binary form must reproduce the above copyright
-# notice, this list of conditions and the following disclaimer in the
-# documentation and/or other materials provided with the distribution.
-# * Neither the name of NVIDIA CORPORATION nor the names of its
-# contributors may be used to endorse or promote products derived
-# from this software without specific prior written permission.
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -24,185 +24,189 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required (VERSION 3.18)
 
 if(WIN32)
   message("perf_analyzer is not currently supported on Windows because "
-    "is requires functionalities that are UNIX specific.")
+          "is requires functionalities that are UNIX specific.")
 else()
-  add_subdirectory(client_backend)
 
-  set(
-    PERF_ANALYZER_SRCS
-    command_line_parser.cc
-    perf_analyzer.cc
-    model_parser.cc
-    perf_utils.cc
-    load_manager.cc
-    data_loader.cc
-    concurrency_manager.cc
-    request_rate_manager.cc
-    load_worker.cc
-    concurrency_worker.cc
-    request_rate_worker.cc
-    custom_load_manager.cc
-    infer_context.cc
-    inference_profiler.cc
-    report_writer.cc
-    mpi_utils.cc
-    metrics_manager.cc
-    infer_data_manager_base.cc
-    infer_data_manager.cc
-    infer_data_manager_shm.cc
-    sequence_manager.cc
-  )
+add_subdirectory(client_backend)
 
-  set(
-    PERF_ANALYZER_HDRS
-    command_line_parser.h
-    perf_analyzer.h
-    model_parser.h
-    perf_utils.h
-    load_manager.h
-    data_loader.h
-    concurrency_manager.h
-    request_rate_manager.h
-    custom_load_manager.h
-    iworker.h
-    load_worker.h
-    request_rate_worker.h
-    concurrency_worker.h
-    infer_context.h
-    inference_profiler.h
-    report_writer.h
-    mpi_utils.h
-    doctest.h
-    constants.h
-    metrics.h
-    metrics_manager.h
-    infer_data_manager_factory.h
-    iinfer_data_manager.h
-    infer_data_manager.h
-    infer_data_manager_shm.h
-    infer_data_manager_base.h
-    infer_data.h
-    sequence_manager.h
-    sequence_status.h
-  )
+set(
+  PERF_ANALYZER_SRCS
+  command_line_parser.cc
+  perf_analyzer.cc
+  model_parser.cc
+  perf_utils.cc
+  load_manager.cc
+  data_loader.cc
+  concurrency_manager.cc
+  request_rate_manager.cc
+  load_worker.cc
+  concurrency_worker.cc
+  request_rate_worker.cc
+  custom_load_manager.cc
+  infer_context.cc
+  inference_profiler.cc
+  report_writer.cc
+  mpi_utils.cc
+  metrics_manager.cc
+  infer_data_manager_base.cc
+  infer_data_manager.cc
+  infer_data_manager_shm.cc
+  sequence_manager.cc
+)
 
-  add_executable(
-    perf_analyzer
-    main.cc
-    ${PERF_ANALYZER_SRCS}
-    ${PERF_ANALYZER_HDRS}
-    $<TARGET_OBJECTS:json-utils-library>
-  )
-  target_link_libraries(
-    perf_analyzer
-    PRIVATE
+set(
+  PERF_ANALYZER_HDRS
+  command_line_parser.h
+  perf_analyzer.h
+  model_parser.h
+  perf_utils.h
+  load_manager.h
+  data_loader.h
+  concurrency_manager.h
+  request_rate_manager.h
+  custom_load_manager.h
+  iworker.h
+  load_worker.h
+  request_rate_worker.h
+  concurrency_worker.h
+  infer_context.h
+  inference_profiler.h
+  report_writer.h
+  mpi_utils.h
+  doctest.h
+  constants.h
+  metrics.h
+  metrics_manager.h
+  infer_data_manager_factory.h
+  iinfer_data_manager.h
+  infer_data_manager.h
+  infer_data_manager_shm.h
+  infer_data_manager_base.h
+  infer_data.h
+  sequence_manager.h
+  sequence_status.h
+)
+
+add_executable(
+  perf_analyzer
+  main.cc
+  ${PERF_ANALYZER_SRCS}
+  ${PERF_ANALYZER_HDRS}
+  $<TARGET_OBJECTS:json-utils-library>
+)
+target_link_libraries(
+  perf_analyzer
+  PRIVATE
     client-backend-library
     -lb64
     ${CMAKE_DL_LIBS}
+)
+
+# If gpu is enabled then compile with CUDA dependencies
+if(TRITON_ENABLE_GPU)
+  target_compile_definitions(
+    perf_analyzer
+    PUBLIC TRITON_ENABLE_GPU=1
   )
-
-  # If gpu is enabled then compile with CUDA dependencies
-  if(TRITON_ENABLE_GPU)
-    target_compile_definitions(
-      perf_analyzer
-      PUBLIC TRITON_ENABLE_GPU=1
-    )
-
-    target_link_libraries(
-      perf_analyzer
-      PRIVATE CUDA::cudart
-    )
-  endif()
-
-  if(TRITON_ENABLE_PERF_ANALYZER_C_API)
-    target_compile_definitions(
-      client-backend-library
-      PUBLIC TRITON_ENABLE_PERF_ANALYZER_C_API=1
-    )
-  endif()
-
-  if(TRITON_ENABLE_PERF_ANALYZER_TFS)
-    target_compile_definitions(
-      client-backend-library
-      PUBLIC TRITON_ENABLE_PERF_ANALYZER_TFS=1
-    )
-  endif()
-
-  if(TRITON_ENABLE_PERF_ANALYZER_TS)
-    target_compile_definitions(
-      client-backend-library
-      PUBLIC TRITON_ENABLE_PERF_ANALYZER_TS=1
-    )
-  endif()
-
-  install(
-    TARGETS perf_analyzer
-    RUNTIME DESTINATION bin
-  )
-
-  target_compile_definitions(perf_analyzer PUBLIC DOCTEST_CONFIG_DISABLE)
-
-  # Creating perf_client link to perf_analyzer binary for backwards compatibility.
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ./perf_analyzer perf_client
-  WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/)")
-  install(CODE "message(\"-- Created symlink: perf_client -> ./perf_analyzer\")")
-
-  set(PERF_ANALYZER_UNIT_TESTS_SRCS ${PERF_ANALYZER_SRCS})
-  list(PREPEND PERF_ANALYZER_UNIT_TESTS_SRCS perf_analyzer_unit_tests.cc)
-  set(PERF_ANALYZER_UNIT_TESTS_HDRS ${PERF_ANALYZER_HDRS})
-
-  add_executable(
-    perf_analyzer_unit_tests
-    ${PERF_ANALYZER_UNIT_TESTS_SRCS}
-    ${PERF_ANALYZER_UNIT_TESTS_HDRS}
-    mock_inference_profiler.h
-    mock_model_parser.h
-    test_utils.h
-    client_backend/mock_client_backend.h
-    mock_data_loader.h
-    test_inference_profiler.cc
-    test_command_line_parser.cc
-    test_idle_timer.cc
-    test_load_manager_base.h
-    test_load_manager.cc
-    test_model_parser.cc
-    test_metrics_manager.cc
-    test_perf_utils.cc
-    test_report_writer.cc
-    client_backend/triton/test_triton_client_backend.cc
-    test_request_rate_manager.cc
-    test_concurrency_manager.cc
-    test_custom_load_manager.cc
-    test_sequence_manager.cc
-    $<TARGET_OBJECTS:json-utils-library>
-  )
-
-  # -Wno-write-strings is needed for the unit tests in order to statically create
-  # input argv cases in the CommandLineParser unit test
-  #
-  set_target_properties(perf_analyzer_unit_tests
-    PROPERTIES COMPILE_FLAGS "-Wno-write-strings")
 
   target_link_libraries(
-    perf_analyzer_unit_tests
-    PRIVATE
+    perf_analyzer
+    PRIVATE CUDA::cudart
+  )
+endif()
+
+if(TRITON_ENABLE_PERF_ANALYZER_C_API)
+  target_compile_definitions(
+    client-backend-library
+    PUBLIC TRITON_ENABLE_PERF_ANALYZER_C_API=1
+  )
+endif()
+
+if(TRITON_ENABLE_PERF_ANALYZER_TFS)
+  target_compile_definitions(
+    client-backend-library
+    PUBLIC TRITON_ENABLE_PERF_ANALYZER_TFS=1
+  )
+endif()
+
+if(TRITON_ENABLE_PERF_ANALYZER_TS)
+  target_compile_definitions(
+    client-backend-library
+    PUBLIC TRITON_ENABLE_PERF_ANALYZER_TS=1
+  )
+endif()
+
+install(
+  TARGETS perf_analyzer
+  RUNTIME DESTINATION bin
+)
+
+target_compile_definitions(perf_analyzer PUBLIC DOCTEST_CONFIG_DISABLE)
+
+# Creating perf_client link to perf_analyzer binary for backwards compatibility.
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ./perf_analyzer perf_client
+  WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/)")
+install(CODE "message(\"-- Created symlink: perf_client -> ./perf_analyzer\")")
+
+
+
+set(PERF_ANALYZER_UNIT_TESTS_SRCS ${PERF_ANALYZER_SRCS})
+list(PREPEND PERF_ANALYZER_UNIT_TESTS_SRCS perf_analyzer_unit_tests.cc)
+set(PERF_ANALYZER_UNIT_TESTS_HDRS ${PERF_ANALYZER_HDRS})
+
+add_executable(
+  perf_analyzer_unit_tests
+  ${PERF_ANALYZER_UNIT_TESTS_SRCS}
+  ${PERF_ANALYZER_UNIT_TESTS_HDRS}
+  mock_inference_profiler.h
+  mock_model_parser.h
+  test_utils.h
+  client_backend/mock_client_backend.h  
+  mock_data_loader.h
+  test_inference_profiler.cc
+  test_command_line_parser.cc
+  test_idle_timer.cc
+  test_load_manager_base.h
+  test_load_manager.cc
+  test_model_parser.cc
+  test_metrics_manager.cc
+  test_perf_utils.cc
+  test_report_writer.cc
+  client_backend/triton/test_triton_client_backend.cc
+  test_request_rate_manager.cc
+  test_concurrency_manager.cc
+  test_custom_load_manager.cc
+  test_sequence_manager.cc
+  $<TARGET_OBJECTS:json-utils-library>
+)
+
+# -Wno-write-strings is needed for the unit tests in order to statically create
+# input argv cases in the CommandLineParser unit test
+#
+set_target_properties(perf_analyzer_unit_tests 
+  PROPERTIES COMPILE_FLAGS "-Wno-write-strings")
+
+target_link_libraries(
+  perf_analyzer_unit_tests
+  PRIVATE
     gmock
     client-backend-library
     -lb64
-  )
+)
 
-  target_include_directories(
-    perf_analyzer_unit_tests
-    PRIVATE
+target_include_directories(
+  perf_analyzer_unit_tests
+  PRIVATE
     client_backend
-  )
+)
 
-  install(
-    TARGETS perf_analyzer_unit_tests
-    RUNTIME DESTINATION bin
-  )
+install(
+  TARGETS perf_analyzer_unit_tests
+  RUNTIME DESTINATION bin
+)
+
 endif()

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -128,7 +128,12 @@ struct PerfAnalyzerParameters {
         !(using_request_rate_range || using_custom_intervals));
   }
 
-  double overhead_pct_threshold{10.0};
+  // Sets the threshold for PA client overhead.
+  // Overhead is defined as the percentage of time when PA is doing work and
+  // requests are not outstanding to the triton server. If the overhead
+  // percentage exceeds the threshold, a warning is displayed.
+  //
+  double overhead_pct_threshold{50.0};
 };
 
 using PAParamsPtr = std::shared_ptr<PerfAnalyzerParameters>;

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -127,6 +127,8 @@ struct PerfAnalyzerParameters {
         using_concurrency_range || using_old_options ||
         !(using_request_rate_range || using_custom_intervals));
   }
+
+  double overhead_pct_threshold{10.0};
 };
 
 using PAParamsPtr = std::shared_ptr<PerfAnalyzerParameters>;

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -391,11 +391,11 @@ ReportClientSideStats(
     std::stringstream client_overhead{""};
     std::stringstream send_rate{""};
     client_overhead << "    "
-                    << "Client overhead: " << std::fixed << std::setprecision(2)
-                    << overhead_pct << "%";
+                    << "Avg client overhead: " << std::fixed
+                    << std::setprecision(2) << overhead_pct << "%";
     send_rate << "    "
-              << "Send request rate: " << std::fixed << std::setprecision(2)
-              << send_request_rate << "";
+              << "Avg send request rate: " << std::fixed << std::setprecision(2)
+              << send_request_rate << " infer/sec";
     std::cout << client_overhead.str() << std::endl;
     std::cout << send_rate.str() << std::endl;
   }
@@ -1013,12 +1013,15 @@ InferenceProfiler::MergePerfStatusReports(
         experiment_perf_status.client_stats.latencies.end(),
         perf_status.client_stats.latencies.begin(),
         perf_status.client_stats.latencies.end());
-    // Accumulate the overhead percentage here to remove extra traversals
+    // Accumulate the overhead percentage and send rate here to remove extra
+    // traversals
     experiment_perf_status.overhead_pct += perf_status.overhead_pct;
+    experiment_perf_status.send_request_rate += perf_status.send_request_rate;
   }
 
   // Calculate the average overhead_pct for the experiment.
   experiment_perf_status.overhead_pct /= perf_status_reports.size();
+  experiment_perf_status.send_request_rate /= perf_status_reports.size();
 
   if (include_lib_stats_) {
     for (auto& perf_status : perf_status_reports) {

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -716,15 +716,9 @@ InferenceProfiler::ProfileHelper(
                     << (measurement_perf_status.client_stats.avg_latency_ns /
                         1000)
                     << " usec (std "
-                    << measurement_perf_status.client_stats.std_us
-                    << " usec). ";
-          // << std::endl;
+                    << measurement_perf_status.client_stats.std_us << " usec). "
+                    << std::endl;
         }
-        std::stringstream overhead_pct_ss;
-        overhead_pct_ss << "Client overhead: " << std::fixed
-                        << std::setprecision(2)
-                        << measurement_perf_status.overhead_pct << "%";
-        std::cout << overhead_pct_ss.str() << std::endl;
       } else {
         std::cout << "  Pass [" << (completed_trials + 1)
                   << "] cb::Error: " << error.back().Message() << std::endl;

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1507,12 +1507,12 @@ InferenceProfiler::SummarizeOverhead(
   // it as 0% overhead (100% idle) in that case
   //
   if (idle_ns > window_duration_ns) {
-    summary.overhead_pct = 0;
-  } else {
-    uint64_t overhead_ns = window_duration_ns - idle_ns;
-    double overhead_pct = double(overhead_ns) / window_duration_ns * 100;
-    summary.overhead_pct = overhead_pct;
+    throw std::runtime_error("Idle time can't be larger than window");
   }
+
+  uint64_t overhead_ns = window_duration_ns - idle_ns;
+  double overhead_pct = double(overhead_ns) / window_duration_ns * 100;
+  summary.overhead_pct = overhead_pct;
 }
 
 bool

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -378,8 +378,8 @@ ReportClientSideStats(
   std::stringstream client_overhead{""};
   if (verbose) {
     client_overhead << "    "
-                    << "Overhead percentage: " << std::fixed
-                    << std::setprecision(2) << overhead_pct << "%\n";
+                    << "Client overhead: " << std::fixed << std::setprecision(2)
+                    << overhead_pct << "%\n";
   }
 
   std::cout << "    Request count: " << stats.request_count << std::endl;
@@ -716,9 +716,15 @@ InferenceProfiler::ProfileHelper(
                     << (measurement_perf_status.client_stats.avg_latency_ns /
                         1000)
                     << " usec (std "
-                    << measurement_perf_status.client_stats.std_us << " usec)"
-                    << std::endl;
+                    << measurement_perf_status.client_stats.std_us
+                    << " usec). ";
+          // << std::endl;
         }
+        std::stringstream overhead_pct_ss;
+        overhead_pct_ss << "Client overhead: " << std::fixed
+                        << std::setprecision(2)
+                        << measurement_perf_status.overhead_pct << "%";
+        std::cout << overhead_pct_ss.str() << std::endl;
       } else {
         std::cout << "  Pass [" << (completed_trials + 1)
                   << "] cb::Error: " << error.back().Message() << std::endl;

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -327,7 +327,7 @@ ReportClientSideStats(
     const ClientSideStats& stats, const int64_t percentile,
     const cb::ProtocolType protocol, const bool verbose,
     const bool on_sequence_model, const bool include_lib_stats,
-    const double overhead_pct)
+    const double overhead_pct, const double send_request_rate)
 {
   const uint64_t avg_latency_us = stats.avg_latency_ns / 1000;
   const uint64_t std_us = stats.std_us;
@@ -376,10 +376,14 @@ ReportClientSideStats(
   }
 
   std::stringstream client_overhead{""};
+  std::stringstream send_rate{""};
   if (verbose) {
     client_overhead << "    "
                     << "Client overhead: " << std::fixed << std::setprecision(2)
                     << overhead_pct << "%\n";
+    send_rate << "    "
+              << "Send request rate: " << std::fixed << std::setprecision(2)
+              << send_request_rate << "\n";
   }
 
   std::cout << "    Request count: " << stats.request_count << std::endl;
@@ -394,6 +398,8 @@ ReportClientSideStats(
   std::cout << "    Throughput: " << stats.infer_per_sec << " infer/sec"
             << std::endl;
   std::cout << client_overhead.str();
+  std::cout << send_rate.str();
+
   if (percentile == -1) {
     std::cout << "    Avg latency: " << avg_latency_us << " usec"
               << " (standard deviation " << std_us << " usec)" << std::endl;
@@ -420,7 +426,8 @@ Report(
   std::cout << "  Client: " << std::endl;
   ReportClientSideStats(
       summary.client_stats, percentile, protocol, verbose,
-      summary.on_sequence_model, include_lib_stats, summary.overhead_pct);
+      summary.on_sequence_model, include_lib_stats, summary.overhead_pct,
+      summary.send_request_rate);
 
   if (include_server_stats) {
     std::cout << "  Server: " << std::endl;

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1507,12 +1507,12 @@ InferenceProfiler::SummarizeOverhead(
   // it as 0% overhead (100% idle) in that case
   //
   if (idle_ns > window_duration_ns) {
-    throw std::runtime_error("Idle time can't be larger than window");
+    summary.overhead_pct = 0;
+  } else {
+    uint64_t overhead_ns = window_duration_ns - idle_ns;
+    double overhead_pct = double(overhead_ns) / window_duration_ns * 100;
+    summary.overhead_pct = overhead_pct;
   }
-
-  uint64_t overhead_ns = window_duration_ns - idle_ns;
-  double overhead_pct = double(overhead_ns) / window_duration_ns * 100;
-  summary.overhead_pct = overhead_pct;
 }
 
 bool

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -241,19 +241,20 @@ class InferenceProfiler {
   template <typename T>
   cb::Error Profile(
       const T start, const T end, const T step, const SearchMode search_mode,
-      std::vector<PerfStatus>& summary_list)
+      std::vector<PerfStatus>& perf_status_vec)
   {
     cb::Error err;
     bool meets_threshold, is_stable;
     if (search_mode == SearchMode::NONE) {
-      err = Profile(summary_list, meets_threshold, is_stable);
+      err = Profile(perf_status_vec, meets_threshold, is_stable);
       if (!err.IsOk()) {
         return err;
       }
     } else if (search_mode == SearchMode::LINEAR) {
       T current_value = start;
       do {
-        err = Profile(current_value, summary_list, meets_threshold, is_stable);
+        err =
+            Profile(current_value, perf_status_vec, meets_threshold, is_stable);
         if (!err.IsOk()) {
           return err;
         }
@@ -267,11 +268,11 @@ class InferenceProfiler {
             "Failed to obtain stable measurement.", pa::STABILITY_ERROR);
       }
     } else {
-      err = Profile(start, summary_list, meets_threshold, is_stable);
+      err = Profile(start, perf_status_vec, meets_threshold, is_stable);
       if (!err.IsOk() || (!meets_threshold)) {
         return err;
       }
-      err = Profile(end, summary_list, meets_threshold, is_stable);
+      err = Profile(end, perf_status_vec, meets_threshold, is_stable);
       if (!err.IsOk() || (meets_threshold)) {
         return err;
       }
@@ -280,7 +281,8 @@ class InferenceProfiler {
       T this_end = end;
       while ((this_end - this_start) > step) {
         T current_value = (this_end + this_start) / 2;
-        err = Profile(current_value, summary_list, meets_threshold, is_stable);
+        err =
+            Profile(current_value, perf_status_vec, meets_threshold, is_stable);
         if (!err.IsOk()) {
           return err;
         }
@@ -317,36 +319,36 @@ class InferenceProfiler {
   /// measures (we can't get the exact server status right before the first
   /// request and right after the last request in the measurement window).
   /// \param concurrent_request_count The concurrency level for the measurement.
-  /// \param summary_list Appends the measurements summary at the end of this
+  /// \param perf_status_vec Appends the measurements summary at the end of this
   /// list. \param meets_threshold Returns whether the setting meets the
   /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
       const size_t concurrent_request_count,
-      std::vector<PerfStatus>& summary_list, bool& meets_threshold,
+      std::vector<PerfStatus>& perf_status_vec, bool& meets_threshold,
       bool& is_stable);
 
   /// Similar to above function, but instead of setting the concurrency, it
   /// sets the specified request rate for measurements.
   /// \param request_rate The request rate for inferences.
-  /// \param summary_list Appends the measurements summary at the end of this
+  /// \param perf_status_vec Appends the measurements summary at the end of this
   /// list. \param meets_threshold Returns whether the setting meets the
   /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
-      const double request_rate, std::vector<PerfStatus>& summary_list,
+      const double request_rate, std::vector<PerfStatus>& perf_status_vec,
       bool& meets_threshold, bool& is_stable);
 
   /// Measures throughput and latencies for custom load without controling
   /// request rate nor concurrency. Requires load manager to be loaded with
   /// a file specifying the time intervals.
-  /// \param summary_list Appends the measurements summary at the end of this
+  /// \param perf_status_vec Appends the measurements summary at the end of this
   /// list. \param meets_threshold Returns whether the measurement met the
   /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success
   /// or failure.
   cb::Error Profile(
-      std::vector<PerfStatus>& summary_list, bool& meets_threshold,
+      std::vector<PerfStatus>& perf_status_vec, bool& meets_threshold,
       bool& is_stable);
 
   /// A helper function for profiling functions.

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -243,20 +243,19 @@ class InferenceProfiler {
   template <typename T>
   cb::Error Profile(
       const T start, const T end, const T step, const SearchMode search_mode,
-      std::vector<PerfStatus>& perf_status_vec)
+      std::vector<PerfStatus>& perf_statuses)
   {
     cb::Error err;
     bool meets_threshold, is_stable;
     if (search_mode == SearchMode::NONE) {
-      err = Profile(perf_status_vec, meets_threshold, is_stable);
+      err = Profile(perf_statuses, meets_threshold, is_stable);
       if (!err.IsOk()) {
         return err;
       }
     } else if (search_mode == SearchMode::LINEAR) {
       T current_value = start;
       do {
-        err =
-            Profile(current_value, perf_status_vec, meets_threshold, is_stable);
+        err = Profile(current_value, perf_statuses, meets_threshold, is_stable);
         if (!err.IsOk()) {
           return err;
         }
@@ -270,11 +269,11 @@ class InferenceProfiler {
             "Failed to obtain stable measurement.", pa::STABILITY_ERROR);
       }
     } else {
-      err = Profile(start, perf_status_vec, meets_threshold, is_stable);
+      err = Profile(start, perf_statuses, meets_threshold, is_stable);
       if (!err.IsOk() || (!meets_threshold)) {
         return err;
       }
-      err = Profile(end, perf_status_vec, meets_threshold, is_stable);
+      err = Profile(end, perf_statuses, meets_threshold, is_stable);
       if (!err.IsOk() || (meets_threshold)) {
         return err;
       }
@@ -283,8 +282,7 @@ class InferenceProfiler {
       T this_end = end;
       while ((this_end - this_start) > step) {
         T current_value = (this_end + this_start) / 2;
-        err =
-            Profile(current_value, perf_status_vec, meets_threshold, is_stable);
+        err = Profile(current_value, perf_statuses, meets_threshold, is_stable);
         if (!err.IsOk()) {
           return err;
         }
@@ -322,36 +320,37 @@ class InferenceProfiler {
   /// measures (we can't get the exact server status right before the first
   /// request and right after the last request in the measurement window).
   /// \param concurrent_request_count The concurrency level for the measurement.
-  /// \param perf_status_vec Appends the measurements summary at the end of this
+  /// \param perf_statuses Appends the measurements summary at the end of this
   /// list. \param meets_threshold Returns whether the setting meets the
-  /// threshold. \param is_stable Returns whether the measurement is stable.
+  /// threshold.
+  /// \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
       const size_t concurrent_request_count,
-      std::vector<PerfStatus>& perf_status_vec, bool& meets_threshold,
+      std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
       bool& is_stable);
 
   /// Similar to above function, but instead of setting the concurrency, it
   /// sets the specified request rate for measurements.
   /// \param request_rate The request rate for inferences.
-  /// \param perf_status_vec Appends the measurements summary at the end of this
+  /// \param perf_statuses Appends the measurements summary at the end of this
   /// list. \param meets_threshold Returns whether the setting meets the
   /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
-      const double request_rate, std::vector<PerfStatus>& perf_status_vec,
+      const double request_rate, std::vector<PerfStatus>& perf_statuses,
       bool& meets_threshold, bool& is_stable);
 
   /// Measures throughput and latencies for custom load without controling
   /// request rate nor concurrency. Requires load manager to be loaded with
   /// a file specifying the time intervals.
-  /// \param perf_status_vec Appends the measurements summary at the end of this
+  /// \param perf_statuses Appends the measurements summary at the end of this
   /// list. \param meets_threshold Returns whether the measurement met the
   /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success
   /// or failure.
   cb::Error Profile(
-      std::vector<PerfStatus>& perf_status_vec, bool& meets_threshold,
+      std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
       bool& is_stable);
 
   /// A helper function for profiling functions.

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -214,6 +214,8 @@ class InferenceProfiler {
   /// \param metrics_interval_ms The interval at which the server-side metrics
   /// \param should_collect_metrics Whether server-side inference server metrics
   /// should be collected.
+  /// \param overhead_pct_threshold User set threshold above which the PA
+  /// overhead is too significant to provide useable results.
   /// \return cb::Error object indicating success or failure.
   static cb::Error Create(
       const bool verbose, const double stability_threshold,
@@ -225,7 +227,7 @@ class InferenceProfiler {
       std::unique_ptr<InferenceProfiler>* profiler,
       uint64_t measurement_request_count, MeasurementMode measurement_mode,
       std::shared_ptr<MPIDriver> mpi_driver, const uint64_t metrics_interval_ms,
-      const bool should_collect_metrics);
+      const bool should_collect_metrics, const double overhead_pct_threshold);
 
   /// Performs the profiling on the given range with the given search algorithm.
   /// For profiling using request rate invoke template with double, otherwise
@@ -308,7 +310,8 @@ class InferenceProfiler {
       std::shared_ptr<cb::ClientBackend> profile_backend,
       std::unique_ptr<LoadManager> manager, uint64_t measurement_request_count,
       MeasurementMode measurement_mode, std::shared_ptr<MPIDriver> mpi_driver,
-      const uint64_t metrics_interval_ms, const bool should_collect_metrics);
+      const uint64_t metrics_interval_ms, const bool should_collect_metrics,
+      const double overhead_pct_threshold);
 
   /// Actively measure throughput in every 'measurement_window' msec until the
   /// throughput is stable. Once the throughput is stable, it adds the
@@ -672,6 +675,10 @@ class InferenceProfiler {
 
   /// Whether server-side inference server metrics should be collected.
   bool should_collect_metrics_{false};
+
+  /// User set threshold above which the PA overhead is too significant to
+  /// provide useable results.
+  const double overhead_pct_threshold_{0.0};
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend TestInferenceProfiler;

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -241,19 +241,19 @@ class InferenceProfiler {
   template <typename T>
   cb::Error Profile(
       const T start, const T end, const T step, const SearchMode search_mode,
-      std::vector<PerfStatus>& summary)
+      std::vector<PerfStatus>& summary_list)
   {
     cb::Error err;
     bool meets_threshold, is_stable;
     if (search_mode == SearchMode::NONE) {
-      err = Profile(summary, meets_threshold, is_stable);
+      err = Profile(summary_list, meets_threshold, is_stable);
       if (!err.IsOk()) {
         return err;
       }
     } else if (search_mode == SearchMode::LINEAR) {
       T current_value = start;
       do {
-        err = Profile(current_value, summary, meets_threshold, is_stable);
+        err = Profile(current_value, summary_list, meets_threshold, is_stable);
         if (!err.IsOk()) {
           return err;
         }
@@ -267,11 +267,11 @@ class InferenceProfiler {
             "Failed to obtain stable measurement.", pa::STABILITY_ERROR);
       }
     } else {
-      err = Profile(start, summary, meets_threshold, is_stable);
+      err = Profile(start, summary_list, meets_threshold, is_stable);
       if (!err.IsOk() || (!meets_threshold)) {
         return err;
       }
-      err = Profile(end, summary, meets_threshold, is_stable);
+      err = Profile(end, summary_list, meets_threshold, is_stable);
       if (!err.IsOk() || (meets_threshold)) {
         return err;
       }
@@ -280,7 +280,7 @@ class InferenceProfiler {
       T this_end = end;
       while ((this_end - this_start) > step) {
         T current_value = (this_end + this_start) / 2;
-        err = Profile(current_value, summary, meets_threshold, is_stable);
+        err = Profile(current_value, summary_list, meets_threshold, is_stable);
         if (!err.IsOk()) {
           return err;
         }
@@ -317,35 +317,37 @@ class InferenceProfiler {
   /// measures (we can't get the exact server status right before the first
   /// request and right after the last request in the measurement window).
   /// \param concurrent_request_count The concurrency level for the measurement.
-  /// \param summary Appends the measurements summary at the end of this list.
-  /// \param meets_threshold Returns whether the setting meets the threshold.
-  /// \param is_stable Returns whether the measurement is stable.
+  /// \param summary_list Appends the measurements summary at the end of this
+  /// list. \param meets_threshold Returns whether the setting meets the
+  /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
-      const size_t concurrent_request_count, std::vector<PerfStatus>& summary,
-      bool& meets_threshold, bool& is_stable);
+      const size_t concurrent_request_count,
+      std::vector<PerfStatus>& summary_list, bool& meets_threshold,
+      bool& is_stable);
 
   /// Similar to above function, but instead of setting the concurrency, it
   /// sets the specified request rate for measurements.
   /// \param request_rate The request rate for inferences.
-  /// \param summary Appends the measurements summary at the end of this list.
-  /// \param meets_threshold Returns whether the setting meets the threshold.
-  /// \param is_stable Returns whether the measurement is stable.
+  /// \param summary_list Appends the measurements summary at the end of this
+  /// list. \param meets_threshold Returns whether the setting meets the
+  /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
-      const double request_rate, std::vector<PerfStatus>& summary,
+      const double request_rate, std::vector<PerfStatus>& summary_list,
       bool& meets_threshold, bool& is_stable);
 
   /// Measures throughput and latencies for custom load without controling
   /// request rate nor concurrency. Requires load manager to be loaded with
   /// a file specifying the time intervals.
-  /// \param summary Appends the measurements summary at the end of this list.
-  /// \param meets_threshold Returns whether the measurement met the threshold.
-  /// \param is_stable Returns whether the measurement is stable.
+  /// \param summary_list Appends the measurements summary at the end of this
+  /// list. \param meets_threshold Returns whether the measurement met the
+  /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success
   /// or failure.
   cb::Error Profile(
-      std::vector<PerfStatus>& summary, bool& meets_threshold, bool& is_stable);
+      std::vector<PerfStatus>& summary_list, bool& meets_threshold,
+      bool& is_stable);
 
   /// A helper function for profiling functions.
   /// \param status_summary Returns the summary of the measurement.

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -256,7 +256,7 @@ PerfAnalyzer::CreateAnalyzerObjects()
           parser_, std::move(backend_), std::move(manager), &profiler_,
           params_->measurement_request_count, params_->measurement_mode,
           params_->mpi_driver, params_->metrics_interval_ms,
-          params_->should_collect_metrics),
+          params_->should_collect_metrics, params_->overhead_pct_threshold),
       "failed to create profiler");
 }
 

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -354,14 +354,13 @@ PerfAnalyzer::Profile()
   if (params_->targeting_concurrency()) {
     err = profiler_->Profile<size_t>(
         params_->concurrency_range.start, params_->concurrency_range.end,
-        params_->concurrency_range.step, params_->search_mode,
-        perf_status_vec_);
+        params_->concurrency_range.step, params_->search_mode, perf_statuses_);
   } else {
     err = profiler_->Profile<double>(
         params_->request_rate_range[pa::SEARCH_RANGE::kSTART],
         params_->request_rate_range[pa::SEARCH_RANGE::kEND],
         params_->request_rate_range[pa::SEARCH_RANGE::kSTEP],
-        params_->search_mode, perf_status_vec_);
+        params_->search_mode, perf_statuses_);
   }
 
   params_->mpi_driver->MPIBarrierWorld();
@@ -379,7 +378,7 @@ PerfAnalyzer::Profile()
 void
 PerfAnalyzer::WriteReport()
 {
-  if (!perf_status_vec_.size()) {
+  if (!perf_statuses_.size()) {
     return;
   }
 
@@ -391,7 +390,7 @@ PerfAnalyzer::WriteReport()
     std::cout << "p" << params_->percentile << " Batch Latency" << std::endl;
   }
 
-  for (pa::PerfStatus& status : perf_status_vec_) {
+  for (pa::PerfStatus& status : perf_statuses_) {
     if (params_->targeting_concurrency()) {
       std::cout << "Concurrency: " << status.concurrency << ", ";
     } else {
@@ -409,7 +408,7 @@ PerfAnalyzer::WriteReport()
 
   FAIL_IF_ERR(
       pa::ReportWriter::Create(
-          params_->filename, params_->targeting_concurrency(), perf_status_vec_,
+          params_->filename, params_->targeting_concurrency(), perf_statuses_,
           params_->verbose_csv, profiler_->IncludeServerStats(),
           params_->percentile, parser_, &writer, should_output_metrics),
       "failed to create report writer");

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -354,13 +354,14 @@ PerfAnalyzer::Profile()
   if (params_->targeting_concurrency()) {
     err = profiler_->Profile<size_t>(
         params_->concurrency_range.start, params_->concurrency_range.end,
-        params_->concurrency_range.step, params_->search_mode, summary_);
+        params_->concurrency_range.step, params_->search_mode,
+        perf_status_vec_);
   } else {
     err = profiler_->Profile<double>(
         params_->request_rate_range[pa::SEARCH_RANGE::kSTART],
         params_->request_rate_range[pa::SEARCH_RANGE::kEND],
         params_->request_rate_range[pa::SEARCH_RANGE::kSTEP],
-        params_->search_mode, summary_);
+        params_->search_mode, perf_status_vec_);
   }
 
   params_->mpi_driver->MPIBarrierWorld();
@@ -378,7 +379,7 @@ PerfAnalyzer::Profile()
 void
 PerfAnalyzer::WriteReport()
 {
-  if (!summary_.size()) {
+  if (!perf_status_vec_.size()) {
     return;
   }
 
@@ -390,7 +391,7 @@ PerfAnalyzer::WriteReport()
     std::cout << "p" << params_->percentile << " Batch Latency" << std::endl;
   }
 
-  for (pa::PerfStatus& status : summary_) {
+  for (pa::PerfStatus& status : perf_status_vec_) {
     if (params_->targeting_concurrency()) {
       std::cout << "Concurrency: " << status.concurrency << ", ";
     } else {
@@ -408,7 +409,7 @@ PerfAnalyzer::WriteReport()
 
   FAIL_IF_ERR(
       pa::ReportWriter::Create(
-          params_->filename, params_->targeting_concurrency(), summary_,
+          params_->filename, params_->targeting_concurrency(), perf_status_vec_,
           params_->verbose_csv, profiler_->IncludeServerStats(),
           params_->percentile, parser_, &writer, should_output_metrics),
       "failed to create report writer");

--- a/src/c++/perf_analyzer/perf_analyzer.h
+++ b/src/c++/perf_analyzer/perf_analyzer.h
@@ -179,7 +179,7 @@ class PerfAnalyzer {
   std::unique_ptr<pa::InferenceProfiler> profiler_;
   std::unique_ptr<cb::ClientBackend> backend_;
   std::shared_ptr<pa::ModelParser> parser_;
-  std::vector<pa::PerfStatus> perf_status_vec_;
+  std::vector<pa::PerfStatus> perf_statuses_;
 
   //
   // Helper methods

--- a/src/c++/perf_analyzer/perf_analyzer.h
+++ b/src/c++/perf_analyzer/perf_analyzer.h
@@ -179,7 +179,7 @@ class PerfAnalyzer {
   std::unique_ptr<pa::InferenceProfiler> profiler_;
   std::unique_ptr<cb::ClientBackend> backend_;
   std::shared_ptr<pa::ModelParser> parser_;
-  std::vector<pa::PerfStatus> summary_;
+  std::vector<pa::PerfStatus> perf_status_vec_;
 
   //
   // Helper methods


### PR DESCRIPTION
Something was funky on main that caused the commits from Tim. The commits are still there but my work should be clean compared to main now and should only show my changes in the diff.

Updated:
- Report the overhead percentage and the request rate (only in verbose mode)
- Warn when overhead exceeds 10%. 10% is hardcoded for now and will be adjustable in the future.
- Renamed all of the perf status variables in the code base. It was not clear what each was referencing before the name changes