### PR TITLE
[Python] Handle non-JSON HTTP response errors

### DIFF
--- a/src/python/library/tritonclient/http/__init__.py
+++ b/src/python/library/tritonclient/http/__init__.py
@@ -49,8 +49,12 @@ def _get_error(response):
     indicates the error. If no error then return None
     """
     if response.status_code != 200:
-        error_response = json.loads(response.read())
-        return InferenceServerException(msg=error_response["error"])
+        body = response.read()
+        try:
+            error_response = json.loads(body)
+            return InferenceServerException(msg=error_response["error"], status=str(response.status_code))
+        except json.JSONDecodeError:
+            return InferenceServerException(msg=body, status=str(response.status_code))
     else:
         return None
 


### PR DESCRIPTION
`_get_error` in `tritonclient.http` will raise a `rapidjson.JSONDecodeError` if the response body is not JSON. However, the client is likely to receive non-200 HTTP bodies that are not parseable as JSON, for instance, if a proxy server returns plaintext.

This PR modifies `_get_error` to attempt decoding via JSON, but will fall back on placing the response body in `InferenceServerException.msg`. It also adds the HTTP status code (as a `str`) to the `status` field for clients to use. This behavior is similar to how the gRPC status is handled in the Triton gRPC client.