### PR TITLE
Enable ppc64le builds

### DIFF
--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -198,6 +198,8 @@ if __name__ == '__main__':
     if FLAGS.linux:
         if os.uname().machine == "aarch64":
             platform_name = "manylinux2014_aarch64"
+        elif os.uname().machine == "ppc64le":
+            platform_name = "manylinux2014_ppc64le" 
         else:
             platform_name = "manylinux1_x86_64"
         args = [


### PR DESCRIPTION
Minimal patch to enable ppc64le builds.
Currently it defaults to "manylinux1_x86_64" on Power (although the binaries are still ppc64le if build on Power) however pip fails to install that.

There should be no impact for existing builds (x86_64 and aarch64)

