### PR TITLE
Fix composing model csv file

### DIFF
--- a/src/c++/perf_analyzer/report_writer.cc
+++ b/src/c++/perf_analyzer/report_writer.cc
@@ -260,7 +260,7 @@ ReportWriter::GenerateReport()
             ofs << "Server Cache Hit,";
             ofs << "Server Cache Miss,";
           }
-          ofs << "Client Recv";
+          ofs << "Client Recv" << std::endl;
 
           for (pa::PerfStatus& status : summary_) {
             auto it = status.server_stats.composing_models_stat.find(


### PR DESCRIPTION
Old code was missing an endline after the header, resulting in the first results being in the same row