### PR TITLE
Fix various things in docs

### DIFF
--- a/src/c++/perf_analyzer/README.md
+++ b/src/c++/perf_analyzer/README.md
@@ -36,17 +36,17 @@ changes in performance as you experiment with different optimization strategies.
 
 # Features
 
-### Request Sending Modes
+### Inference Load Modes
 
 - [Concurrency Mode](docs/request_sending_modes.md#concurrency-mode) simlulates
-  traffic by maintaining a specific concurrency of outgoing requests to the
+  load by maintaining a specific concurrency of outgoing requests to the
   server
 
 - [Request Rate Mode](docs/request_sending_modes.md#request-rate-mode) simulates
-  traffic by sending consecutive requests at a specific rate to the server
+  load by sending consecutive requests at a specific rate to the server
 
 - [Custom Interval Mode](docs/request_sending_modes.md#custom-interval-mode)
-  simulates traffic by sending consecutive requests at specific intervals to the
+  simulates load by sending consecutive requests at specific intervals to the
   server
 
 ### Performance Measurement Modes
@@ -168,7 +168,7 @@ have 1 outgoing request at all times.
 
 - [Installation](docs/install.md)
 - [Perf Analyzer CLI](docs/cli.md)
-- [Request Sending Modes](docs/request_sending_modes.md)
+- [Inference Load Modes](docs/inference_load_modes.md)
 - [Input Data](docs/input_data.md)
 - [Measurements & Metrics](docs/measurements_metrics.md)
 - [Benchmarking](docs/benchmarking.md)

--- a/src/c++/perf_analyzer/README.md
+++ b/src/c++/perf_analyzer/README.md
@@ -38,33 +38,40 @@ changes in performance as you experiment with different optimization strategies.
 
 ### Request Sending Modes
 
-- [Concurrency Mode]() simlulates traffic by maintaining a specific concurrency
-  of outgoing requests to the server
+- [Concurrency Mode](docs/request_sending_modes.md#concurrency-mode) simlulates
+  traffic by maintaining a specific concurrency of outgoing requests to the
+  server
 
-- [Request Rate Mode]() simulates traffic by sending consecutive requests at a
-  specific rate to the server
+- [Request Rate Mode](docs/request_sending_modes.md#request-rate-mode) simulates
+  traffic by sending consecutive requests at a specific rate to the server
 
-- [Custom Interval Mode]() simulates traffic by sending consecutive requests at
-  specific intervals to the server
+- [Custom Interval Mode](docs/request_sending_modes.md#custom-interval-mode)
+  simulates traffic by sending consecutive requests at specific intervals to the
+  server
 
 ### Performance Measurement Modes
 
-- [Time Windows Mode]() measures model performance repeatedly over a specific time
-  interval until performance has stabilized
+- [Time Windows Mode](docs/measurements_metrics.md#time-windows) measures model
+  performance repeatedly over a specific time interval until performance has
+  stabilized
 
-- [Count Windows Mode]() measures model performance repeatedly over a specific
-  number of requests until performance has stabilized
+- [Count Windows Mode](docs/measurements_metrics.md#count-windows) measures
+  model performance repeatedly over a specific number of requests until
+  performance has stabilized
 
 ### Other Features
 
-- [Sequence Models]() and [Ensemble Models]() can be profiled in addition to
-  standard/stateless models
+- [Sequence Models](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/architecture.md#stateful-models)
+  and
+  [Ensemble Models](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/architecture.md#ensemble-models)
+  can be profiled in addition to standard/stateless models
 
-- [Input Data]() to model inferences can be auto-generated or specified as well
-  as verifying output
+- [Input Data](docs/input_data.md) to model inferences can be auto-generated or
+  specified as well as verifying output
 
-- [TensorFlow Serving]() and [TorchServe]() can be used as the inference server
-  in addition to the default [Triton]() server
+- [TensorFlow Serving](docs/benchmarking.md#benchmarking-tensorflow-serving) and
+  [TorchServe](docs/benchmarking.md#benchmarking-torchserve) can be used as the
+  inference server in addition to the default Triton server
 
 <br>
 
@@ -161,6 +168,10 @@ have 1 outgoing request at all times.
 
 - [Installation](docs/install.md)
 - [Perf Analyzer CLI](docs/cli.md)
+- [Request Sending Modes](docs/request_sending_modes.md)
+- [Input Data](docs/input_data.md)
+- [Measurements & Metrics](docs/measurements_metrics.md)
+- [Benchmarking](docs/benchmarking.md)
 
 <br>
 

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -168,8 +168,8 @@ CLParser::Usage(const std::string& msg)
              "{\"data\" : [{\"TORCHSERVE_INPUT\" : [\"<complete path to the "
              "content file>\"]}, {...}...]}. The type of file here will depend "
              "on the model. In order to use \"triton_c_api\" you must specify "
-             "the Triton server install path and the model repository "
-             "path via the --library-name and --model-repo flags",
+             "the Triton server install path and the model repository path via "
+             "the --triton-server-directory and --model-repository flags",
              18)
       << std::endl;
 

--- a/src/c++/perf_analyzer/docs/README.md
+++ b/src/c++/perf_analyzer/docs/README.md
@@ -48,7 +48,7 @@ model input data, the performance measurement modes, the performance metrics and
 outputs, how to benchmark different servers, and more.
 
 - [Perf Analyzer CLI](cli.md)
-- [Request Sending Modes](request_sending_modes.md)
+- [Inference Load Modes](inference_load_modes.md)
 - [Input Data](input_data.md)
 - [Measurements & Metrics](measurements_metrics.md)
 - [Benchmarking](benchmarking.md)

--- a/src/c++/perf_analyzer/docs/inference_load_modes.md
+++ b/src/c++/perf_analyzer/docs/inference_load_modes.md
@@ -26,9 +26,9 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-# Request Sending Modes
+# Inference Load Modes
 
-Perf Analyzer has several modes for generating inference request traffic for a
+Perf Analyzer has several modes for generating inference request load for a
 model.
 
 ## Concurrency Mode

--- a/src/c++/perf_analyzer/docs/input_data.md
+++ b/src/c++/perf_analyzer/docs/input_data.md
@@ -31,7 +31,8 @@ data options. By default perf_analyzer sends random data to all the
 inputs of your model. You can select a different input data mode with
 the [`--input-data`](cli.md#--input-datazerorandompath) option:
 
-- _random_: (default) Send random data for each input.
+- _random_: (default) Send random data for each input. Note: Perf Analyzer only
+  generates random data once per input and reuses that for all inferences
 - _zero_: Send zeros for each input.
 - directory path: A path to a directory containing a binary file for each input, named the same as the input. Each binary file must contain the data required for that input for a batch-1 request. Each file should contain the raw binary representation of the input in row-major order.
 - file path: A path to a JSON file containing data to be used with every inference request. See the "Real Input Data" section for further details. --input-data can be provided multiple times with different file paths to specific multiple JSON files.

--- a/src/c++/perf_analyzer/docs/measurements_metrics.md
+++ b/src/c++/perf_analyzer/docs/measurements_metrics.md
@@ -69,6 +69,9 @@ broken-down into the following components:
   request waiting for an instance of the model to become available.
 - _compute_: The average time spent performing the actual inference,
   including any time needed to copy data to/from the GPU.
+- _overhead_: The average time spent in the endpoint that cannot be correctly
+  captured in the send/receive time with the way the GRPC and HTTP libraries are
+  structured
 
 The client latency time is broken-down further for HTTP and GRPC as
 follows:

--- a/src/c++/perf_analyzer/docs/request_sending_modes.md
+++ b/src/c++/perf_analyzer/docs/request_sending_modes.md
@@ -26,29 +26,41 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-# **Perf Analyzer Documentation**
+# Request Sending Modes
 
-| [Installation](README.md#installation) | [Getting Started](README.md#getting-started) | [User Guide](README.md#user-guide) |
-| -------------------------------------- | -------------------------------------------- | ---------------------------------- |
+Perf Analyzer has several modes for generating inference request traffic for a
+model.
 
-## **Installation**
+## Concurrency Mode
 
-See the [Installation Guide](install.md) for details on how to install Perf
-Analyzer.
+In concurrency mode, Perf Analyzer attempts to send inference requests to the
+server such that N requests are always outstanding during profiling. For
+example, when using
+[`--concurrency-range=4`](cli.md#--concurrency-rangestartendstep), Perf Analyzer
+will to attempt to have 4 outgoing inference requests at all times during
+profiling.
 
-## **Getting Started**
+## Request Rate Mode
 
-The [Quick Start Guide](../README.md#quick-start) will show you how to use Perf
-Analyzer to profile a simple PyTorch model.
+In request rate mode, Perf Analyzer attempts to send N inference requests per
+second to the server during profiling. For example, when using
+[`--request-rate-range=20](cli.md#--request-rate-rangestartendstep), Perf
+Analyzer will attempt to send 20 requests per second during profiling.
 
-## **User Guide**
+## Custom Interval Mode
 
-The User Guide describes the Perf Analyzer command line options, how to specify
-model input data, the performance measurement modes, the performance metrics and
-outputs, how to benchmark different servers, and more.
+In custom interval mode, Perf Analyzer attempts to send inference requests
+according to intervals (between requests, looping if necessary) provided by the
+user in the form of a text file with one time interval (in microseconds) per
+line. For example, when using
+[`--request-intervals=my_intervals.txt`](cli.md#--request-intervalspath),
+where `my_intervals.txt` contains:
 
-- [Perf Analyzer CLI](cli.md)
-- [Request Sending Modes](request_sending_modes.md)
-- [Input Data](input_data.md)
-- [Measurements & Metrics](measurements_metrics.md)
-- [Benchmarking](benchmarking.md)
+```
+100000
+200000
+500000
+```
+
+Perf Analyzer will attempt to send requests at the following times: 0.1s, 0.3s,
+0.8s, 0.9s, 1.1s, 1.6s, and so on, during profiling.


### PR DESCRIPTION
* Add request sending modes doc (concurrency/request rate/custom interval)
* Fix top-level readme links
* Add note about random data generation to input data doc
* Add note about latency overhead category to measurements doc
* Fix triton C API help message outdated options