### PR TITLE
Enable ppc64le builds for Python wheels

### DIFF
--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -198,6 +198,8 @@ if __name__ == '__main__':
     if FLAGS.linux:
         if os.uname().machine == "aarch64":
             platform_name = "manylinux2014_aarch64"
+        elif os.uname().machine == "ppc64le":
+            platform_name = "manylinux2014_ppc64le" 
         else:
             platform_name = "manylinux1_x86_64"
         args = [


### PR DESCRIPTION
This is a clone of https://github.com/triton-inference-server/client/pull/263.
