### PR TITLE
Set range of aiohttp (>=3.8.1,<4.0.0) to avoid installing error in Python 3.10

### DIFF
--- a/src/python/library/requirements/requirements_http.txt
+++ b/src/python/library/requirements/requirements_http.txt
@@ -25,6 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 geventhttpclient>=1.4.4,<=2.0.2
-aiohttp>=3.8.1
+aiohttp>=3.8.1,<4.0.0
 numpy>=1.19.1
 python-rapidjson>=0.9.1


### PR DESCRIPTION
Fix: [#5666](https://github.com/triton-inference-server/server/issues/5666)