### PR TITLE
Improve L0_client_memory_growth test

### DIFF
--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -209,13 +209,15 @@ struct InferOptions {
   /// https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#dynamic-batcher
   uint64_t server_timeout_;
   // The maximum end-to-end time, in microseconds, the request is allowed
-  // to take. Note the HTTP library only offer the precision upto
-  // milliseconds. The client will abort request when the specified time
-  // elapses. The request will return error with message "Deadline Exceeded".
+  // to take. The client will abort request when the specified time elapses.
+  // The request will return error with message "Deadline Exceeded".
   // The default value is 0 which means client will wait for the
   // response from the server. This option is not supported for streaming
   // requests. Instead see 'stream_timeout' argument in
   // InferenceServerGrpcClient::StartStream().
+  // NOTE: the HTTP client library only offers millisecond precision, so a
+  // timeout < 1000 microseconds will be rounded down to 0 milliseconds and have
+  // no effect.
   uint64_t client_timeout_;
 };
 

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -1466,15 +1466,15 @@ InferenceServerHttpClient::Infer(
   // RECV_END will be set.
   auto curl_status = curl_easy_perform(easy_handle_);
   if (curl_status == CURLE_OPERATION_TIMEDOUT) {
-    sync_request->http_code_ = 499;
-  } else if (curl_status != CURLE_OK) {
-    if (verbose_) {
-      std::cout << "Curl failed with return code: " << curl_status << std::endl;
-    }
+    std::cerr << "Curl failed with return code: " << curl_status << std::endl;
     return Error(
-        "HTTP client failed [400]: " +
+        "HTTP client failed (Deadline Exceeded): " +
         std::string(curl_easy_strerror(curl_status)));
-  } else {
+  } else if (curl_status != CURLE_OK) {
+    std::cerr << "Curl failed with return code: " << curl_status << std::endl;
+    return Error(
+        "HTTP client failed: " + std::string(curl_easy_strerror(curl_status)));
+  } else {  // Success
     curl_easy_getinfo(
         easy_handle_, CURLINFO_RESPONSE_CODE, &sync_request->http_code_);
   }

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -1466,12 +1466,10 @@ InferenceServerHttpClient::Infer(
   // RECV_END will be set.
   auto curl_status = curl_easy_perform(easy_handle_);
   if (curl_status == CURLE_OPERATION_TIMEDOUT) {
-    std::cerr << "Curl failed with return code: " << curl_status << std::endl;
     return Error(
         "HTTP client failed (Deadline Exceeded): " +
         std::string(curl_easy_strerror(curl_status)));
   } else if (curl_status != CURLE_OK) {
-    std::cerr << "Curl failed with return code: " << curl_status << std::endl;
     return Error(
         "HTTP client failed: " + std::string(curl_easy_strerror(curl_status)));
   } else {  // Success

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -1468,7 +1468,12 @@ InferenceServerHttpClient::Infer(
   if (curl_status == CURLE_OPERATION_TIMEDOUT) {
     sync_request->http_code_ = 499;
   } else if (curl_status != CURLE_OK) {
-    sync_request->http_code_ = 400;
+    if (verbose_) {
+      std::cout << "Curl failed with return code: " << curl_status << std::endl;
+    }
+    return Error(
+        "HTTP client failed [400]: " +
+        std::string(curl_easy_strerror(curl_status)));
   } else {
     curl_easy_getinfo(
         easy_handle_, CURLINFO_RESPONSE_CODE, &sync_request->http_code_);
@@ -1487,7 +1492,6 @@ InferenceServerHttpClient::Infer(
 
   return err;
 }
-
 
 Error
 InferenceServerHttpClient::AsyncInfer(

--- a/src/c++/tests/memory_leak_test.cc
+++ b/src/c++/tests/memory_leak_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/tests/memory_leak_test.cc
+++ b/src/c++/tests/memory_leak_test.cc
@@ -76,7 +76,7 @@ ValidateShapeAndDatatype(
 void
 ValidateResult(
     const std::shared_ptr<tc::InferResult> result,
-    std::vector<int32_t>& input0_data)
+    const std::vector<int32_t>& input0_data)
 {
   // Validate the results...
   ValidateShapeAndDatatype("OUTPUT0", result);
@@ -105,70 +105,91 @@ ValidateResult(
   std::cout << result->DebugString() << std::endl;
 }
 
-
 void
-RunSynchronousInference(
+ValidateResponse(
+    std::shared_ptr<tc::InferResult> results_ptr,
+    const std::vector<int32_t>& input0_data)
+{
+  // Validate results
+  if (results_ptr->RequestStatus().IsOk()) {
+    ValidateResult(results_ptr, input0_data);
+  } else {
+    std::cerr << "error: Inference failed: " << results_ptr->RequestStatus()
+              << std::endl;
+    exit(1);
+  }
+}
+
+template <typename T>
+void
+InferWithRetries(
+    const std::unique_ptr<T>& client, tc::InferResult** results,
+    tc::InferOptions& options, std::vector<tc::InferInput*>& inputs,
+    std::vector<const tc::InferRequestedOutput*>& outputs)
+{
+  // Exit early if we succeed first try
+  auto err = client->Infer(results, options, inputs, outputs);
+  if (err.IsOk()) {
+    return;
+  }
+
+  // If the host runs out of available sockets due to TIME_WAIT, sleep and
+  // retry on failure to give time for sockets to become available.
+  int max_retries = 5;
+  int sleep_secs = 60;
+  bool success = false;
+  for (int i = 0; i < max_retries; i++) {
+    std::cerr << "Error: " << err << std::endl;
+    std::cerr << "Sleeping for " << sleep_secs
+              << " seconds and retrying. [Attempt: " << i + 1 << "/"
+              << max_retries << "]" << std::endl;
+    sleep(sleep_secs);
+
+    err = client->Infer(results, options, inputs, outputs);
+    if (err.IsOk()) {
+      success = true;
+      break;
+    }
+  }
+
+  if (!success) {
+    std::cerr << "error: Exceeded max tries [" << max_retries
+              << "] on inference without success" << std::endl;
+    exit(1);
+  }
+}
+
+// T should be tc::InferenceServerHttpClient or tc::InferenceServerGrpcClient
+template <typename T>
+void
+RunSyncInfer(
     std::vector<tc::InferInput*>& inputs,
     std::vector<const tc::InferRequestedOutput*>& outputs,
     tc::InferOptions& options, std::vector<int32_t>& input0_data, bool reuse,
-    std::string url, bool verbose, std::string protocol, uint32_t repetitions)
+    std::string url, bool verbose, uint32_t repetitions)
 {
   // If re-use is enabled then use these client objects else use new objects for
   // each inference request.
-  std::unique_ptr<tc::InferenceServerGrpcClient> grpc_client_reuse;
-  std::unique_ptr<tc::InferenceServerHttpClient> http_client_reuse;
+  std::unique_ptr<T> client_reuse;
+  if (reuse) {
+    FAIL_IF_ERR(
+        T::Create(&client_reuse, url, verbose), "unable to create client");
+  }
 
   for (size_t i = 0; i < repetitions; ++i) {
     tc::InferResult* results;
-    if (!reuse) {
-      if (protocol == "grpc") {
-        std::unique_ptr<tc::InferenceServerGrpcClient> grpc_client;
-        FAIL_IF_ERR(
-            tc::InferenceServerGrpcClient::Create(&grpc_client, url, verbose),
-            "unable to create grpc client");
-        FAIL_IF_ERR(
-            grpc_client->Infer(&results, options, inputs, outputs),
-            "unable to run model");
-      } else {
-        std::unique_ptr<tc::InferenceServerHttpClient> http_client;
-        FAIL_IF_ERR(
-            tc::InferenceServerHttpClient::Create(&http_client, url, verbose),
-            "unable to create http client");
-        FAIL_IF_ERR(
-            http_client->Infer(&results, options, inputs, outputs),
-            "unable to run model");
-      }
+    if (reuse) {
+      FAIL_IF_ERR(
+          client_reuse->Infer(&results, options, inputs, outputs),
+          "unable to run model");
     } else {
-      if (protocol == "grpc") {
-        FAIL_IF_ERR(
-            tc::InferenceServerGrpcClient::Create(
-                &grpc_client_reuse, url, verbose),
-            "unable to create grpc client");
-        FAIL_IF_ERR(
-            grpc_client_reuse->Infer(&results, options, inputs, outputs),
-            "unable to run model");
-      } else {
-        FAIL_IF_ERR(
-            tc::InferenceServerHttpClient::Create(
-                &http_client_reuse, url, verbose),
-            "unable to create http client");
-        FAIL_IF_ERR(
-            http_client_reuse->Infer(&results, options, inputs, outputs),
-            "unable to run model");
-      }
+      std::unique_ptr<T> client;
+      FAIL_IF_ERR(T::Create(&client, url, verbose), "unable to create client");
+      InferWithRetries<T>(client, &results, options, inputs, outputs);
     }
 
-    std::shared_ptr<tc::InferResult> results_ptr;
-    results_ptr.reset(results);
-
-    // Validate results
-    if (results_ptr->RequestStatus().IsOk()) {
-      ValidateResult(results_ptr, input0_data);
-    } else {
-      std::cerr << "error: Inference failed: " << results_ptr->RequestStatus()
-                << std::endl;
-      exit(1);
-    }
+    std::shared_ptr<tc::InferResult> results_ptr(results);
+    ValidateResponse(results_ptr, input0_data);
   }
 }
 
@@ -186,6 +207,10 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-t <client timeout in microseconds>" << std::endl;
   std::cerr << "\t-r <number of repetitions for inference> default is 100."
             << std::endl;
+  std::cerr
+      << "\t-R Re-use the same client for each repetition. Without "
+         "this flag, the default is to create a new client on each repetition."
+      << std::endl;
   std::cerr << std::endl;
 
   exit(1);
@@ -293,9 +318,18 @@ main(int argc, char** argv)
   std::vector<const tc::InferRequestedOutput*> outputs = {output0_ptr.get()};
 
   // Send 'repetitions' number of inference requests to the inference server.
-  RunSynchronousInference(
-      inputs, outputs, options, input0_data, reuse, url, verbose, protocol,
-      repetitions);
+  if (protocol == "http") {
+    RunSyncInfer<tc::InferenceServerHttpClient>(
+        inputs, outputs, options, input0_data, reuse, url, verbose,
+        repetitions);
+  } else if (protocol == "grpc") {
+    RunSyncInfer<tc::InferenceServerGrpcClient>(
+        inputs, outputs, options, input0_data, reuse, url, verbose,
+        repetitions);
+  } else {
+    std::cerr << "Invalid protocol: " << protocol << std::endl;
+    return 1;
+  }
 
   return 0;
 }


### PR DESCRIPTION
1. Refactor memory_leak_test.cc
    - Fix behavior of -R (reuse) flag to actually reuse client/connection. Previously subsequent calls to `client::Create(reuse_client.  ...)` would just create new client objects under the hood.
    - Template helper functions since HTTP and GRPC APIs used are identical in this test

2. Update C++ HTTP client to correctly propogate errors on client-side curl failures. Now the behavior matches other API call failures, rather than reporting an obscure Timer and Json parsing issue. See the before/after examples below:

Before:
```
root@rmccormick-dt:/workspace# memory_leak_test
Failed to update context stat: Timer not set correctly. Send time from 1682559474332558400 to 0.
error: unable to run model: failed to parse the request JSON buffer: The document is empty. at 0

root@rmccormick-dt:/workspace# simple_http_infer_client
Failed to update context stat: Timer not set correctly. Send time from 1682559478689285651 to 0.
error: unable to run model: failed to parse the request JSON buffer: The document is empty. at 0

root@rmccormick-dt:/workspace# simple_http_health_metadata
error: unable to get server liveness: HTTP client failed: Couldn't connect to server

root@rmccormick-dt:/workspace# simple_http_model_control
error: Failed to get repository index: HTTP client failed: Couldn't connect to server
```

After:
```
root@rmccormick-dt:/mnt/triton/jira/4524-client-growth/client/build# ./install/bin/memory_leak_test
error: HTTP client failed [400]: Couldn't connect to server

root@rmccormick-dt:/mnt/triton/jira/4524-client-growth/client/build# ./install/bin/simple_http_infer_client
error: unable to run model: HTTP client failed [400]: Couldn't connect to server

root@rmccormick-dt:/mnt/triton/jira/4524-client-growth/client/build# ./install/bin/simple_http_health_metadata
error: unable to get server liveness: HTTP client failed: Couldn't connect to server

root@rmccormick-dt:/mnt/triton/jira/4524-client-growth/client/build# ./install/bin/simple_http_model_control
error: Failed to get repository index: HTTP client failed: Couldn't connect to server
```

The root cause of the connection errors above in CI was running out of ephemeral ports on the system. Sockets were being opened too quickly / too many hanging sockets were being left in WAIT state, causing an inability to assign a port to new connections.

For future reference, this can be observed by running `watch ss -s` in a separate shell while running this script. If you set the `-R` flag to re-use the same client connection, you will see a consistent flat usage of sockets. 

If you omit this flag and create new connections on each request, you will see a consistent rise / high value in sockets stuck in `timewait`:
```
$ ss -s

Total: 2031
TCP:   14135 (estab 47, closed 14068, orphaned 0, timewait 14065)
```

---

Possible Future Improvements:
- Test AsyncInfer
- Separate test to explicitly reuse client connection
- Expose `--max-retries` rather than hard-coded value
- Only retry on specific error messages like "couldn't connect to server"

---

Corresponding server PR that just adds notes about these findings to help future debuggers: https://github.com/triton-inference-server/server/pull/5710