### PR TITLE
update get ctxid

### DIFF
--- a/src/c++/perf_analyzer/concurrency_worker.cc
+++ b/src/c++/perf_analyzer/concurrency_worker.cc
@@ -159,16 +159,6 @@ ConcurrencyWorker::SendInferRequests()
   }
 }
 
-void
-ConcurrencyWorker::RestoreFreeCtxId(uint32_t ctx_id)
-{
-  if (!async_) {
-    {
-      std::lock_guard<std::mutex> lock(cb_mtx_);
-      free_ctx_ids_.push(ctx_id);
-    }
-  }
-}
 
 void
 ConcurrencyWorker::WaitForResponses()
@@ -233,22 +223,6 @@ uint32_t
 ConcurrencyWorker::GetSeqStatIndex(uint32_t ctx_id)
 {
   return (thread_config_->seq_stat_index_offset_ + ctx_id);
-}
-
-uint32_t
-ConcurrencyWorker::GetCtxId()
-{
-  uint32_t ctx_id;
-  // Find the next available context id to use for this request
-  std::lock_guard<std::mutex> lk(cb_mtx_);
-  {
-    if (free_ctx_ids_.size() < 1) {
-      throw std::runtime_error("free ctx id list is empty");
-    }
-    ctx_id = free_ctx_ids_.front();
-    free_ctx_ids_.pop();
-  }
-  return ctx_id;
 }
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/concurrency_worker.cc
+++ b/src/c++/perf_analyzer/concurrency_worker.cc
@@ -181,19 +181,6 @@ ConcurrencyWorker::WaitForResponses()
 }
 
 void
-ConcurrencyWorker::AsyncCallbackFinalize(uint32_t ctx_id)
-{
-  // avoid competition over 'cb_mtx_'
-  {
-    std::lock_guard<std::mutex> lk(cb_mtx_);
-    free_ctx_ids_.push(ctx_id);
-    notified_ = true;
-  }
-
-  cb_cv_.notify_all();
-}
-
-void
 ConcurrencyWorker::CompleteOngoingSequences()
 {
   if (on_sequence_model_) {

--- a/src/c++/perf_analyzer/concurrency_worker.h
+++ b/src/c++/perf_analyzer/concurrency_worker.h
@@ -102,8 +102,6 @@ class ConcurrencyWorker : public LoadWorker {
 
   std::shared_ptr<ThreadConfig> thread_config_;
 
-  void AsyncCallbackFinalize(uint32_t ctx_id);
-
   void CompleteOngoingSequences() override;
 
   // Reserve vector size for contexts

--- a/src/c++/perf_analyzer/concurrency_worker.h
+++ b/src/c++/perf_analyzer/concurrency_worker.h
@@ -25,9 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <atomic>
 #include <memory>
-#include <queue>
 #include <random>
 
 #include "load_worker.h"
@@ -102,14 +100,7 @@ class ConcurrencyWorker : public LoadWorker {
   // threads?
   size_t& active_threads_;
 
-  std::queue<int> free_ctx_ids_;
-
   std::shared_ptr<ThreadConfig> thread_config_;
-
-  // Variables used to signal async request completion
-  bool notified_ = false;
-  std::mutex cb_mtx_;
-  std::condition_variable cb_cv_;
 
   void AsyncCallbackFinalize(uint32_t ctx_id);
 
@@ -133,12 +124,9 @@ class ConcurrencyWorker : public LoadWorker {
 
   void WaitForResponses();
 
-  void RestoreFreeCtxId(uint32_t ctx_id);
   void ResetFreeCtxIds();
 
   uint32_t GetSeqStatIndex(uint32_t ctx_id) override;
-
-  uint32_t GetCtxId();
 
   void CreateContextFinalize(std::shared_ptr<InferContext> ctx) override
   {

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -78,4 +78,32 @@ LoadWorker::CreateContext()
   ctxs_.push_back(ctx);
 }
 
+uint32_t
+LoadWorker::GetCtxId()
+{
+  uint32_t ctx_id;
+  // Find the next available context id to use for this request
+  std::lock_guard<std::mutex> lk(cb_mtx_);
+  {
+    if (free_ctx_ids_.size() < 1) {
+      throw std::runtime_error("free ctx id list is empty");
+    }
+    ctx_id = free_ctx_ids_.front();
+    free_ctx_ids_.pop();
+  }
+  return ctx_id;
+}
+
+
+void
+LoadWorker::RestoreFreeCtxId(uint32_t ctx_id)
+{
+  if (!async_) {
+    {
+      std::lock_guard<std::mutex> lock(cb_mtx_);
+      free_ctx_ids_.push(ctx_id);
+    }
+  }
+}
+
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -86,7 +86,7 @@ LoadWorker::GetCtxId()
   std::lock_guard<std::mutex> lk(cb_mtx_);
   {
     if (free_ctx_ids_.size() < 1) {
-      throw std::runtime_error("free ctx id list is empty");
+      return 0;
     }
     ctx_id = free_ctx_ids_.front();
     free_ctx_ids_.pop();

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -106,4 +106,17 @@ LoadWorker::RestoreFreeCtxId(uint32_t ctx_id)
   }
 }
 
+void
+LoadWorker::AsyncCallbackFinalize(uint32_t ctx_id)
+{
+  // avoid competition over 'cb_mtx_'
+  {
+    std::lock_guard<std::mutex> lk(cb_mtx_);
+    free_ctx_ids_.push(ctx_id);
+    notified_ = true;
+  }
+
+  cb_cv_.notify_all();
+}
+
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/load_worker.h
+++ b/src/c++/perf_analyzer/load_worker.h
@@ -105,14 +105,14 @@ class LoadWorker : public IWorker {
   // Detect and handle the case where this thread needs to exit
   // Returns true if an exit condition was met
   bool HandleExitConditions();
+  virtual void CompleteOngoingSequences() = 0;
+  void WaitForOngoingRequests();
 
   virtual uint32_t GetSeqStatIndex(uint32_t ctx_id) = 0;
   uint32_t GetCtxId();
   void RestoreFreeCtxId(uint32_t ctx_id);
 
-  virtual void CompleteOngoingSequences() = 0;
-
-  void WaitForOngoingRequests();
+  void AsyncCallbackFinalize(uint32_t ctx_id);
 
   uint32_t id_;
 

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -38,8 +38,6 @@ void
 RequestRateWorker::Infer()
 {
   CreateContexts();
-  // FIXME -- join into new function once other story done
-  ResetFreeCtxIds();
 
   // run inferencing until receiving exit signal to maintain server load.
   do {
@@ -65,6 +63,8 @@ RequestRateWorker::CreateContexts()
   while (ctxs_.size() < active_ctx_cnt) {
     CreateContext();
   }
+
+  ResetFreeCtxIds();
 }
 
 void

--- a/src/c++/perf_analyzer/request_rate_worker.cc
+++ b/src/c++/perf_analyzer/request_rate_worker.cc
@@ -93,20 +93,6 @@ RequestRateWorker::ResetFreeCtxIds()
   }
 }
 
-
-void
-RequestRateWorker::AsyncCallbackFinalize(uint32_t ctx_id)
-{
-  // avoid competition over 'cb_mtx_'
-  {
-    std::lock_guard<std::mutex> lk(cb_mtx_);
-    free_ctx_ids_.push(ctx_id);
-    notified_ = true;
-  }
-
-  cb_cv_.notify_all();
-}
-
 void
 RequestRateWorker::SetSchedule(RateSchedulePtr_t schedule)
 {

--- a/src/c++/perf_analyzer/request_rate_worker.h
+++ b/src/c++/perf_analyzer/request_rate_worker.h
@@ -53,7 +53,7 @@ class RequestRateWorker : public LoadWorker, public IScheduler {
   struct ThreadConfig {
     ThreadConfig(uint32_t index, uint32_t stride)
         : id_(index), stride_(stride), seq_stat_index_offset_(0),
-          is_paused_(false)
+          is_paused_(false), num_sequences_(1)
     {
     }
 

--- a/src/c++/perf_analyzer/request_rate_worker.h
+++ b/src/c++/perf_analyzer/request_rate_worker.h
@@ -105,26 +105,28 @@ class RequestRateWorker : public LoadWorker, public IScheduler {
 
   std::chrono::nanoseconds GetNextTimestamp();
 
-  // Request Rate Worker only ever has a single context
-  uint32_t GetCtxId() { return 0; }
-
-  uint32_t GetSeqStatIndex(uint32_t ctx_id) override
-  {
-    return (thread_config_->seq_stat_index_offset_ + ctx_id);
-  }
+  uint32_t GetSeqStatIndex(uint32_t ctx_id) override;
 
   void CreateContexts();
 
   void CompleteOngoingSequences() override;
 
   void HandleExecuteOff();
+  void ResetFreeCtxIds();
 
   // Sleep until it is time for the next part of the schedule
   // Returns true if the request was delayed
   bool SleepIfNecessary();
 
+  // FIXME no longer needed?
+  void AsyncCallbackFinalize(uint32_t ctx_id);
+
   void CreateContextFinalize(std::shared_ptr<InferContext> ctx) override
   {
+    ctx->RegisterAsyncCallbackFinalize(std::bind(
+        &RequestRateWorker::AsyncCallbackFinalize, this,
+        std::placeholders::_1));
+
     ctx->SetNumActiveThreads(num_threads_);
   }
 

--- a/src/c++/perf_analyzer/request_rate_worker.h
+++ b/src/c++/perf_analyzer/request_rate_worker.h
@@ -118,6 +118,8 @@ class RequestRateWorker : public LoadWorker, public IScheduler {
   // Returns true if the request was delayed
   bool SleepIfNecessary();
 
+  void WaitForFreeCtx();
+
   void CreateContextFinalize(std::shared_ptr<InferContext> ctx) override
   {
     ctx->RegisterAsyncCallbackFinalize(std::bind(

--- a/src/c++/perf_analyzer/request_rate_worker.h
+++ b/src/c++/perf_analyzer/request_rate_worker.h
@@ -118,9 +118,6 @@ class RequestRateWorker : public LoadWorker, public IScheduler {
   // Returns true if the request was delayed
   bool SleepIfNecessary();
 
-  // FIXME no longer needed?
-  void AsyncCallbackFinalize(uint32_t ctx_id);
-
   void CreateContextFinalize(std::shared_ptr<InferContext> ctx) override
   {
     ctx->RegisterAsyncCallbackFinalize(std::bind(

--- a/src/c++/perf_analyzer/test_custom_load_manager.cc
+++ b/src/c++/perf_analyzer/test_custom_load_manager.cc
@@ -117,7 +117,7 @@ class TestCustomLoadManager : public TestLoadManagerBase,
 
 
   std::shared_ptr<ModelParser>& parser_{LoadManager::parser_};
-  std::shared_ptr<cb::ClientBackendFactory> factory_{
+  std::shared_ptr<cb::ClientBackendFactory>& factory_{
       TestLoadManagerBase::factory_};
 
   std::string& request_intervals_file_{

--- a/src/c++/perf_analyzer/test_custom_load_manager.cc
+++ b/src/c++/perf_analyzer/test_custom_load_manager.cc
@@ -106,6 +106,7 @@ class TestCustomLoadManager : public TestLoadManagerBase,
   }
 };
 
+// FIXME -- sometimes hanging??
 TEST_CASE("custom_load_schedule")
 {
   PerfAnalyzerParameters params;

--- a/src/c++/perf_analyzer/test_load_manager_base.h
+++ b/src/c++/perf_analyzer/test_load_manager_base.h
@@ -241,6 +241,7 @@ class TestLoadManagerBase {
       params.sequence_id_range = 8;
     }
     SUBCASE("num_of_sequences 1") { params.num_of_sequences = 1; }
+    SUBCASE("less threads than seq") { params.num_of_sequences = 12; }
     SUBCASE("num_of_sequences 8")
     {
       params.num_of_sequences = 8;

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -403,7 +403,7 @@ class TestRequestRateManager : public TestLoadManagerBase,
   size_t& max_threads_{LoadManager::max_threads_};
   bool& async_{LoadManager::async_};
   bool& streaming_{LoadManager::streaming_};
-  std::shared_ptr<cb::ClientBackendFactory> factory_{
+  std::shared_ptr<cb::ClientBackendFactory>& factory_{
       TestLoadManagerBase::factory_};
   std::shared_ptr<IInferDataManager>& infer_data_manager_{
       LoadManager::infer_data_manager_};

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -534,7 +534,7 @@ TEST_CASE("request_rate_schedule")
   params.max_trials = 10;
   bool is_sequence = false;
   bool is_decoupled = false;
-  bool use_mock_infer = false;
+  bool use_mock_infer = true;
   double rate;
 
 


### PR DESCRIPTION
Update GetCtxId for request_rate_worker to pick (approximately) round robin from all contexts instead of hardcoded to 0.

Moves the following functions up into LoadWorker to be shared:
- RestoreFreeCtxID 
- AsyncCallbackFinalize
- GetCtxId