### PR TITLE
Add support for json input and output content type

### DIFF
--- a/src/c++/library/common.cc
+++ b/src/c++/library/common.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -212,6 +212,13 @@ InferInput::SharedMemoryInfo(
 }
 
 Error
+InferInput::SetBinaryData(const bool binary_data)
+{
+  binary_data_ = binary_data;
+  return Error::Success;
+}
+
+Error
 InferInput::PrepareForRequest()
 {
   // Reset position so request sends entire input.
@@ -319,6 +326,13 @@ InferRequestedOutput::SharedMemoryInfo(
   *byte_size = shm_byte_size_;
   *offset = shm_offset_;
 
+  return Error::Success;
+}
+
+Error
+InferRequestedOutput::SetBinaryData(const bool binary_data)
+{
+  binary_data_ = binary_data;
   return Error::Success;
 }
 

--- a/src/c++/library/common.cc
+++ b/src/c++/library/common.cc
@@ -211,11 +211,10 @@ InferInput::SharedMemoryInfo(
   return Error::Success;
 }
 
-Error
+void
 InferInput::SetBinaryData(const bool binary_data)
 {
   binary_data_ = binary_data;
-  return Error::Success;
 }
 
 Error
@@ -329,11 +328,10 @@ InferRequestedOutput::SharedMemoryInfo(
   return Error::Success;
 }
 
-Error
+void
 InferRequestedOutput::SetBinaryData(const bool binary_data)
 {
   binary_data_ = binary_data;
-  return Error::Success;
 }
 
 //==============================================================================

--- a/src/c++/library/common.cc
+++ b/src/c++/library/common.cc
@@ -211,10 +211,11 @@ InferInput::SharedMemoryInfo(
   return Error::Success;
 }
 
-void
+Error
 InferInput::SetBinaryData(const bool binary_data)
 {
   binary_data_ = binary_data;
+  return Error::Success;
 }
 
 Error
@@ -328,10 +329,11 @@ InferRequestedOutput::SharedMemoryInfo(
   return Error::Success;
 }
 
-void
+Error
 InferRequestedOutput::SetBinaryData(const bool binary_data)
 {
   binary_data_ = binary_data;
+  return Error::Success;
 }
 
 //==============================================================================

--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -333,7 +333,8 @@ class InferInput {
   /// \return true if this input should be sent in binary format.
   bool BinaryData() const { return binary_data_; }
 
-  void SetBinaryData(const bool binary_data);
+  /// \return Error object indicating success or failure.
+  Error SetBinaryData(const bool binary_data);
 
  private:
 #ifdef TRITON_INFERENCE_SERVER_CLIENT_CLASS
@@ -436,7 +437,8 @@ class InferRequestedOutput {
   /// \return true if this output should be received in binary format.
   bool BinaryData() const { return binary_data_; }
 
-  void SetBinaryData(const bool binary_data);
+  /// \return Error object indicating success or failure.
+  Error SetBinaryData(const bool binary_data);
 
  private:
 #ifdef TRITON_INFERENCE_SERVER_CLIENT_CLASS

--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -333,8 +333,7 @@ class InferInput {
   /// \return true if this input should be sent in binary format.
   bool BinaryData() const { return binary_data_; }
 
-  /// \return Error object indicating success or failure.
-  Error SetBinaryData(const bool binary_data);
+  void SetBinaryData(const bool binary_data);
 
  private:
 #ifdef TRITON_INFERENCE_SERVER_CLIENT_CLASS
@@ -437,8 +436,7 @@ class InferRequestedOutput {
   /// \return true if this output should be received in binary format.
   bool BinaryData() const { return binary_data_; }
 
-  /// \return Error object indicating success or failure.
-  Error SetBinaryData(const bool binary_data);
+  void SetBinaryData(const bool binary_data);
 
  private:
 #ifdef TRITON_INFERENCE_SERVER_CLIENT_CLASS

--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -330,10 +330,17 @@ class InferInput {
   /// \return Error object indicating success or failure.
   Error ByteSize(size_t* byte_size) const;
 
+  /// \return true if this input should be sent in binary format.
+  bool BinaryData() const { return binary_data_; }
+
+  /// \return Error object indicating success or failure.
+  Error SetBinaryData(const bool binary_data);
+
  private:
 #ifdef TRITON_INFERENCE_SERVER_CLIENT_CLASS
   friend class TRITON_INFERENCE_SERVER_CLIENT_CLASS;
 #endif
+  friend class HttpInferRequest;
   InferInput(
       const std::string& name, const std::vector<int64_t>& dims,
       const std::string& datatype);
@@ -364,6 +371,8 @@ class InferInput {
   IOType io_type_;
   std::string shm_name_;
   size_t shm_offset_;
+
+  bool binary_data_{true};
 };
 
 //==============================================================================
@@ -425,6 +434,12 @@ class InferRequestedOutput {
   Error SharedMemoryInfo(
       std::string* name, size_t* byte_size, size_t* offset) const;
 
+  /// \return true if this output should be received in binary format.
+  bool BinaryData() const { return binary_data_; }
+
+  /// \return Error object indicating success or failure.
+  Error SetBinaryData(const bool binary_data);
+
  private:
 #ifdef TRITON_INFERENCE_SERVER_CLIENT_CLASS
   friend class TRITON_INFERENCE_SERVER_CLIENT_CLASS;
@@ -442,6 +457,8 @@ class InferRequestedOutput {
   std::string shm_name_;
   size_t shm_byte_size_;
   size_t shm_offset_;
+
+  bool binary_data_{true};
 };
 
 //==============================================================================

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -34,6 +34,8 @@
 #include <cstdint>
 #include <deque>
 #include <iostream>
+#include <string>
+#include <utility>
 #include "http_client.h"
 
 #ifdef TRITON_ENABLE_ZLIB
@@ -328,6 +330,13 @@ class HttpInferRequest : public InferRequest {
       const std::vector<const InferRequestedOutput*>& outputs,
       triton::common::TritonJson::Value* request_json);
 
+  Error ConvertBinaryInputsToJSON(
+      InferInput& input, triton::common::TritonJson::Value& data_json) const;
+
+  Error ConvertBinaryInputToJSON(
+      const uint8_t* buf, const size_t buf_size, const std::string& datatype,
+      triton::common::TritonJson::Value& data_json) const;
+
   // Pointer to the list of the HTTP request header, keep it such that it will
   // be valid during the transfer and can be freed once transfer is completed.
   struct curl_slist* header_list_;
@@ -475,7 +484,8 @@ HttpInferRequest::PrepareRequestJson(
         if (offset != 0) {
           ioparams_json.AddUInt("shared_memory_offset", offset);
         }
-      } else {
+        io_json.Add("parameters", std::move(ioparams_json));
+      } else if (io->BinaryData()) {
         size_t byte_size;
         Error err = io->ByteSize(&byte_size);
         if (!err.IsOk()) {
@@ -483,9 +493,19 @@ HttpInferRequest::PrepareRequestJson(
         }
 
         ioparams_json.AddUInt("binary_data_size", byte_size);
+        io_json.Add("parameters", std::move(ioparams_json));
+      } else {
+        triton::common::TritonJson::Value data_json(
+            *request_json, triton::common::TritonJson::ValueType::ARRAY);
+
+        Error err = ConvertBinaryInputsToJSON(*io, data_json);
+        if (!err.IsOk()) {
+          return err;
+        }
+
+        io_json.Add("data", std::move(data_json));
       }
 
-      io_json.Add("parameters", std::move(ioparams_json));
       inputs_json.Append(std::move(io_json));
     }
 
@@ -523,7 +543,7 @@ HttpInferRequest::PrepareRequestJson(
           ioparams_json.AddUInt("shared_memory_offset", offset);
         }
       } else {
-        ioparams_json.AddBool("binary_data", true);
+        ioparams_json.AddBool("binary_data", io->BinaryData());
       }
 
       io_json.Add("parameters", std::move(ioparams_json));
@@ -531,6 +551,106 @@ HttpInferRequest::PrepareRequestJson(
     }
 
     request_json->Add("outputs", std::move(outputs_json));
+  }
+
+  return Error::Success;
+}
+
+Error
+HttpInferRequest::ConvertBinaryInputsToJSON(
+    InferInput& input, triton::common::TritonJson::Value& data_json) const
+{
+  input.PrepareForRequest();
+  bool end_of_input{false};
+  while (!end_of_input) {
+    const uint8_t* buf{nullptr};
+    size_t buf_size{0};
+    input.GetNext(&buf, &buf_size, &end_of_input);
+    size_t element_count{1};
+    for (size_t i = 1; i < input.Shape().size(); i++) {
+      element_count *= input.Shape()[i];
+    }
+    if (buf != nullptr) {
+      Error err = ConvertBinaryInputToJSON(
+          buf, element_count, input.Datatype(), data_json);
+      if (!err.IsOk()) {
+        return err;
+      }
+    }
+  }
+
+  return Error::Success;
+}
+
+Error
+HttpInferRequest::ConvertBinaryInputToJSON(
+    const uint8_t* buf, const size_t element_count, const std::string& datatype,
+    triton::common::TritonJson::Value& data_json) const
+{
+  if (datatype == "BOOL") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendBool(reinterpret_cast<const bool*>(buf)[i]);
+    }
+  } else if (datatype == "UINT8") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendUInt(reinterpret_cast<const uint8_t*>(buf)[i]);
+    }
+  } else if (datatype == "UINT16") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendUInt(reinterpret_cast<const uint16_t*>(buf)[i]);
+    }
+  } else if (datatype == "UINT32") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendUInt(reinterpret_cast<const uint32_t*>(buf)[i]);
+    }
+  } else if (datatype == "UINT64") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendUInt(reinterpret_cast<const uint64_t*>(buf)[i]);
+    }
+  } else if (datatype == "INT8") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendInt(reinterpret_cast<const int8_t*>(buf)[i]);
+    }
+  } else if (datatype == "INT16") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendInt(reinterpret_cast<const int16_t*>(buf)[i]);
+    }
+  } else if (datatype == "INT32") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendInt(reinterpret_cast<const int32_t*>(buf)[i]);
+    }
+  } else if (datatype == "INT64") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendInt(reinterpret_cast<const int64_t*>(buf)[i]);
+    }
+  } else if (datatype == "FP16") {
+    return Error(
+        "datatype '" + datatype +
+        "' is not supported with JSON. Please use the binary data format");
+
+  } else if (datatype == "FP32") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendDouble(reinterpret_cast<const float*>(buf)[i]);
+    }
+  } else if (datatype == "FP64") {
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.AppendDouble(reinterpret_cast<const double*>(buf)[i]);
+    }
+  } else if (datatype == "BYTES") {
+    size_t offset{0};
+    for (size_t i = 0; i < element_count; i++) {
+      const size_t len{*reinterpret_cast<const uint32_t*>(buf + offset)};
+      data_json.AppendStringRef(
+          reinterpret_cast<const char*>(buf + offset + sizeof(const uint32_t)),
+          len);
+      offset += sizeof(const uint32_t) + len;
+    }
+  } else if (datatype == "BF16") {
+    return Error(
+        "datatype '" + datatype +
+        "' is not supported with JSON. Please use the binary data format");
+  } else {
+    return Error("datatype '" + datatype + "' is invalid");
   }
 
   return Error::Success;
@@ -624,6 +744,12 @@ class InferResultHttp : public InferResult {
   InferResultHttp(std::shared_ptr<HttpInferRequest> infer_request);
   InferResultHttp(const Error err) : status_(err) {}
 
+  ~InferResultHttp();
+
+  Error ConvertJSONOutputToBinary(
+      triton::common::TritonJson::Value& data_json, const std::string& datatype,
+      const uint8_t** buf, size_t* buf_size) const;
+
   std::map<std::string, triton::common::TritonJson::Value>
       output_name_to_result_map_;
   std::map<std::string, std::pair<const uint8_t*, const size_t>>
@@ -632,6 +758,8 @@ class InferResultHttp : public InferResult {
   Error status_;
   triton::common::TritonJson::Value response_json_;
   std::shared_ptr<HttpInferRequest> infer_request_;
+
+  bool binary_data_{true};
 };
 
 void
@@ -920,7 +1048,7 @@ InferResultHttp::InferResultHttp(
 
           std::string output_name(name_str, name_strlen);
 
-          triton::common::TritonJson::Value param_json;
+          triton::common::TritonJson::Value param_json, data_json;
           if (output_json.Find("parameters", &param_json)) {
             uint64_t data_size = 0;
             status_ = param_json.MemberAsUInt("binary_data_size", &data_size);
@@ -936,6 +1064,25 @@ InferResultHttp::InferResultHttp(
                         offset,
                     data_size));
             offset += data_size;
+          } else if (output_json.Find("data", &data_json)) {
+            binary_data_ = false;
+            std::string datatype;
+            status_ = output_json.MemberAsString("datatype", &datatype);
+            if (!status_.IsOk()) {
+              break;
+            }
+
+            const uint8_t* buf{nullptr};
+            size_t buf_size{0};
+            status_ =
+                ConvertJSONOutputToBinary(data_json, datatype, &buf, &buf_size);
+            if (!status_.IsOk()) {
+              break;
+            }
+
+            output_name_to_buffer_map_.emplace(
+                output_name,
+                std::pair<const uint8_t*, const size_t>(buf, buf_size));
           }
 
           output_name_to_result_map_[output_name] = std::move(output_json);
@@ -943,6 +1090,146 @@ InferResultHttp::InferResultHttp(
       }
     }
   }
+}
+
+InferResultHttp::~InferResultHttp()
+{
+  if (binary_data_) {
+    return;
+  }
+
+  for (auto& buf_pair : output_name_to_buffer_map_) {
+    const uint8_t* buf{buf_pair.second.first};
+    delete buf;
+  }
+}
+
+Error
+InferResultHttp::ConvertJSONOutputToBinary(
+    triton::common::TritonJson::Value& data_json, const std::string& datatype,
+    const uint8_t** buf, size_t* buf_size) const
+{
+  const size_t element_count{data_json.ArraySize()};
+
+  if (datatype == "BOOL") {
+    *buf = reinterpret_cast<const uint8_t*>(new bool[element_count]);
+    *buf_size = sizeof(bool) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      bool value{false};
+      data_json.IndexAsBool(i, &value);
+      const_cast<bool*>(reinterpret_cast<const bool*>(*buf))[i] = value;
+    }
+  } else if (datatype == "UINT8") {
+    *buf = reinterpret_cast<const uint8_t*>(new uint8_t[element_count]);
+    *buf_size = sizeof(uint8_t) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      uint64_t value{0};
+      data_json.IndexAsUInt(i, &value);
+      const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(*buf))[i] = value;
+    }
+  } else if (datatype == "UINT16") {
+    *buf = reinterpret_cast<const uint8_t*>(new uint16_t[element_count]);
+    *buf_size = sizeof(uint16_t) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      uint64_t value{0};
+      data_json.IndexAsUInt(i, &value);
+      const_cast<uint16_t*>(reinterpret_cast<const uint16_t*>(*buf))[i] = value;
+    }
+  } else if (datatype == "UINT32") {
+    *buf = reinterpret_cast<const uint8_t*>(new uint32_t[element_count]);
+    *buf_size = sizeof(uint32_t) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      uint64_t value{0};
+      data_json.IndexAsUInt(i, &value);
+      const_cast<uint32_t*>(reinterpret_cast<const uint32_t*>(*buf))[i] = value;
+    }
+  } else if (datatype == "UINT64") {
+    *buf = reinterpret_cast<const uint8_t*>(new uint64_t[element_count]);
+    *buf_size = sizeof(uint32_t) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      uint64_t value{0};
+      data_json.IndexAsUInt(i, &value);
+      const_cast<uint64_t*>(reinterpret_cast<const uint64_t*>(*buf))[i] = value;
+    }
+  } else if (datatype == "INT8") {
+    *buf = reinterpret_cast<const uint8_t*>(new int8_t[element_count]);
+    *buf_size = sizeof(int8_t) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      int64_t value{0};
+      data_json.IndexAsInt(i, &value);
+      const_cast<int8_t*>(reinterpret_cast<const int8_t*>(*buf))[i] = value;
+    }
+  } else if (datatype == "INT16") {
+    *buf = reinterpret_cast<const uint8_t*>(new int16_t[element_count]);
+    *buf_size = sizeof(int16_t) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      int64_t value{0};
+      data_json.IndexAsInt(i, &value);
+      const_cast<int16_t*>(reinterpret_cast<const int16_t*>(*buf))[i] = value;
+    }
+  } else if (datatype == "INT32") {
+    *buf = reinterpret_cast<const uint8_t*>(new int32_t[element_count]);
+    *buf_size = sizeof(int32_t) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      int64_t value{0};
+      data_json.IndexAsInt(i, &value);
+      const_cast<int32_t*>(reinterpret_cast<const int32_t*>(*buf))[i] = value;
+    }
+  } else if (datatype == "INT64") {
+    *buf = reinterpret_cast<const uint8_t*>(new int64_t[element_count]);
+    *buf_size = sizeof(int64_t) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      int64_t value{0};
+      data_json.IndexAsInt(i, &value);
+      const_cast<int64_t*>(reinterpret_cast<const int64_t*>(*buf))[i] = value;
+    }
+  } else if (datatype == "FP16") {
+    return Error("datatype '" + datatype + "' is not supported with JSON.");
+  } else if (datatype == "FP32") {
+    *buf = reinterpret_cast<const uint8_t*>(new float[element_count]);
+    *buf_size = sizeof(float) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      double value{0.0};
+      data_json.IndexAsDouble(i, &value);
+      const_cast<float*>(reinterpret_cast<const float*>(*buf))[i] = value;
+    }
+  } else if (datatype == "FP64") {
+    *buf = reinterpret_cast<const uint8_t*>(new float[element_count]);
+    *buf_size = sizeof(double) * element_count;
+    for (size_t i = 0; i < element_count; i++) {
+      double value{0.0};
+      data_json.IndexAsDouble(i, &value);
+      const_cast<double*>(reinterpret_cast<const double*>(*buf))[i] = value;
+    }
+  } else if (datatype == "BYTES") {
+    size_t total_buf_size{0};
+    std::vector<std::pair<const char*, size_t>> bytes_pairs{};
+    bytes_pairs.resize(element_count);
+    for (size_t i = 0; i < element_count; i++) {
+      data_json.IndexAsString(i, &bytes_pairs[i].first, &bytes_pairs[i].second);
+      total_buf_size += sizeof(const uint32_t) + bytes_pairs[i].second;
+    }
+    *buf = reinterpret_cast<const uint8_t*>(new uint8_t[total_buf_size]);
+    *buf_size = total_buf_size;
+    size_t offset{0};
+    for (const auto& bytes_pair : bytes_pairs) {
+      const char* bytes{bytes_pair.first};
+      size_t bytes_size{bytes_pair.second};
+      std::memcpy(
+          const_cast<uint8_t*>(*buf + offset), &bytes_size,
+          sizeof(const uint32_t));
+      std::memcpy(
+          const_cast<uint8_t*>(*buf + offset + sizeof(const uint32_t)), bytes,
+          bytes_size);
+      offset += sizeof(const uint32_t) + bytes_size;
+    }
+  } else if (datatype == "BF16") {
+    return Error("datatype '" + datatype + "' is not supported with JSON.");
+  } else {
+    return Error("datatype '" + datatype + "' is invalid");
+  }
+
+  return Error::Success;
 }
 
 //==============================================================================
@@ -1780,8 +2067,13 @@ InferenceServerHttpClient::PreRunProcessing(
   }
 
   // Add the buffers holding input tensor data
+  bool all_inputs_are_json{true};
   for (const auto this_input : inputs) {
-    if (!this_input->IsSharedMemory()) {
+    if (this_input->BinaryData()) {
+      all_inputs_are_json = false;
+    }
+
+    if (!this_input->IsSharedMemory() && this_input->BinaryData()) {
       this_input->PrepareForRequest();
       bool end_of_input = false;
       while (!end_of_input) {
@@ -1861,7 +2153,12 @@ InferenceServerHttpClient::PreRunProcessing(
                         std::to_string(http_request->request_json_.Size())};
   list = curl_slist_append(list, infer_hdr.c_str());
   list = curl_slist_append(list, "Expect:");
-  list = curl_slist_append(list, "Content-Type: application/octet-stream");
+  if (all_inputs_are_json) {
+    list = curl_slist_append(list, "Content-Type: application/json");
+  } else {
+    list = curl_slist_append(list, "Content-Type: application/octet-stream");
+  }
+
   for (const auto& pr : headers) {
     std::string hdr = pr.first + ": " + pr.second;
     list = curl_slist_append(list, hdr.c_str());

--- a/src/c++/perf_analyzer/client_backend/client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/client_backend.cc
@@ -119,14 +119,14 @@ ClientBackendFactory::Create(
     std::shared_ptr<Headers> http_headers,
     const std::string& triton_server_path,
     const std::string& model_repository_path, const bool verbose,
-    const std::string& metrics_url, const cb::ContentType input_content_type,
-    const cb::ContentType output_content_type,
+    const std::string& metrics_url, const cb::TensorFormat input_tensor_format,
+    const cb::TensorFormat output_tensor_format,
     std::shared_ptr<ClientBackendFactory>* factory)
 {
   factory->reset(new ClientBackendFactory(
       kind, url, protocol, ssl_options, trace_options, compression_algorithm,
       http_headers, triton_server_path, model_repository_path, verbose,
-      metrics_url, input_content_type, output_content_type));
+      metrics_url, input_tensor_format, output_tensor_format));
   return Error::Success;
 }
 
@@ -137,8 +137,8 @@ ClientBackendFactory::CreateClientBackend(
   RETURN_IF_CB_ERROR(ClientBackend::Create(
       kind_, url_, protocol_, ssl_options_, trace_options_,
       compression_algorithm_, http_headers_, verbose_, triton_server_path,
-      model_repository_path_, metrics_url_, input_content_type_,
-      output_content_type_, client_backend));
+      model_repository_path_, metrics_url_, input_tensor_format_,
+      output_tensor_format_, client_backend));
   return Error::Success;
 }
 
@@ -160,7 +160,8 @@ ClientBackend::Create(
     std::shared_ptr<Headers> http_headers, const bool verbose,
     const std::string& triton_server_path,
     const std::string& model_repository_path, const std::string& metrics_url,
-    const ContentType input_content_type, const ContentType output_content_type,
+    const TensorFormat input_tensor_format,
+    const TensorFormat output_tensor_format,
     std::unique_ptr<ClientBackend>* client_backend)
 {
   std::unique_ptr<ClientBackend> local_backend;
@@ -168,7 +169,8 @@ ClientBackend::Create(
     RETURN_IF_CB_ERROR(tritonremote::TritonClientBackend::Create(
         url, protocol, ssl_options, trace_options,
         BackendToGrpcType(compression_algorithm), http_headers, verbose,
-        metrics_url, input_content_type, output_content_type, &local_backend));
+        metrics_url, input_tensor_format, output_tensor_format,
+        &local_backend));
   }
 #ifdef TRITON_ENABLE_PERF_ANALYZER_TFS
   else if (kind == TENSORFLOW_SERVING) {

--- a/src/c++/perf_analyzer/client_backend/client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/client_backend.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -119,13 +119,14 @@ ClientBackendFactory::Create(
     std::shared_ptr<Headers> http_headers,
     const std::string& triton_server_path,
     const std::string& model_repository_path, const bool verbose,
-    const std::string& metrics_url,
+    const std::string& metrics_url, const cb::ContentType input_content_type,
+    const cb::ContentType output_content_type,
     std::shared_ptr<ClientBackendFactory>* factory)
 {
   factory->reset(new ClientBackendFactory(
       kind, url, protocol, ssl_options, trace_options, compression_algorithm,
       http_headers, triton_server_path, model_repository_path, verbose,
-      metrics_url));
+      metrics_url, input_content_type, output_content_type));
   return Error::Success;
 }
 
@@ -136,7 +137,8 @@ ClientBackendFactory::CreateClientBackend(
   RETURN_IF_CB_ERROR(ClientBackend::Create(
       kind_, url_, protocol_, ssl_options_, trace_options_,
       compression_algorithm_, http_headers_, verbose_, triton_server_path,
-      model_repository_path_, metrics_url_, client_backend));
+      model_repository_path_, metrics_url_, input_content_type_,
+      output_content_type_, client_backend));
   return Error::Success;
 }
 
@@ -158,6 +160,7 @@ ClientBackend::Create(
     std::shared_ptr<Headers> http_headers, const bool verbose,
     const std::string& triton_server_path,
     const std::string& model_repository_path, const std::string& metrics_url,
+    const ContentType input_content_type, const ContentType output_content_type,
     std::unique_ptr<ClientBackend>* client_backend)
 {
   std::unique_ptr<ClientBackend> local_backend;
@@ -165,7 +168,7 @@ ClientBackend::Create(
     RETURN_IF_CB_ERROR(tritonremote::TritonClientBackend::Create(
         url, protocol, ssl_options, trace_options,
         BackendToGrpcType(compression_algorithm), http_headers, verbose,
-        metrics_url, &local_backend));
+        metrics_url, input_content_type, output_content_type, &local_backend));
   }
 #ifdef TRITON_ENABLE_PERF_ANALYZER_TFS
   else if (kind == TENSORFLOW_SERVING) {

--- a/src/c++/perf_analyzer/client_backend/client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/client_backend.h
@@ -143,7 +143,7 @@ enum GrpcCompressionAlgorithm {
   COMPRESS_DEFLATE = 1,
   COMPRESS_GZIP = 2
 };
-enum class ContentType { BINARY, JSON, UNKNOWN };
+enum class TensorFormat { BINARY, JSON, UNKNOWN };
 typedef std::map<std::string, std::string> Headers;
 
 using OnCompleteFn = std::function<void(InferResult*)>;
@@ -267,9 +267,10 @@ class ClientBackendFactory {
   /// repository which contains the desired model.
   /// \param verbose Enables the verbose mode.
   /// \param metrics_url The inference server metrics url and port.
-  /// \param input_content_type The Triton inference request input content type.
-  /// \param output_content_type The Triton inference response output content
-  /// type.
+  /// \param input_tensor_format The Triton inference request input tensor
+  /// format.
+  /// \param output_tensor_format The Triton inference response output tensor
+  /// format.
   /// \param factory Returns a new ClientBackend object.
   /// \return Error object indicating success or failure.
   static Error Create(
@@ -280,8 +281,8 @@ class ClientBackendFactory {
       std::shared_ptr<Headers> http_headers,
       const std::string& triton_server_path,
       const std::string& model_repository_path, const bool verbose,
-      const std::string& metrics_url, const ContentType input_content_type,
-      const ContentType output_content_type,
+      const std::string& metrics_url, const TensorFormat input_tensor_format,
+      const TensorFormat output_tensor_format,
       std::shared_ptr<ClientBackendFactory>* factory);
 
   const BackendKind& Kind();
@@ -299,15 +300,15 @@ class ClientBackendFactory {
       const std::shared_ptr<Headers> http_headers,
       const std::string& triton_server_path,
       const std::string& model_repository_path, const bool verbose,
-      const std::string& metrics_url, const ContentType input_content_type,
-      const ContentType output_content_type)
+      const std::string& metrics_url, const TensorFormat input_tensor_format,
+      const TensorFormat output_tensor_format)
       : kind_(kind), url_(url), protocol_(protocol), ssl_options_(ssl_options),
         trace_options_(trace_options),
         compression_algorithm_(compression_algorithm),
         http_headers_(http_headers), triton_server_path(triton_server_path),
         model_repository_path_(model_repository_path), verbose_(verbose),
-        metrics_url_(metrics_url), input_content_type_(input_content_type),
-        output_content_type_(output_content_type)
+        metrics_url_(metrics_url), input_tensor_format_(input_tensor_format),
+        output_tensor_format_(output_tensor_format)
   {
   }
 
@@ -322,8 +323,8 @@ class ClientBackendFactory {
   std::string model_repository_path_;
   const bool verbose_;
   const std::string metrics_url_{""};
-  const ContentType input_content_type_{ContentType::UNKNOWN};
-  const ContentType output_content_type_{ContentType::UNKNOWN};
+  const TensorFormat input_tensor_format_{TensorFormat::UNKNOWN};
+  const TensorFormat output_tensor_format_{TensorFormat::UNKNOWN};
 
 
 #ifndef DOCTEST_CONFIG_DISABLE
@@ -350,8 +351,8 @@ class ClientBackend {
       const GrpcCompressionAlgorithm compression_algorithm,
       std::shared_ptr<Headers> http_headers, const bool verbose,
       const std::string& library_directory, const std::string& model_repository,
-      const std::string& metrics_url, const ContentType input_content_type,
-      const ContentType output_content_type,
+      const std::string& metrics_url, const TensorFormat input_tensor_format,
+      const TensorFormat output_tensor_format,
       std::unique_ptr<ClientBackend>* client_backend);
 
   /// Destructor for the client backend object

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
@@ -93,14 +93,14 @@ TritonClientBackend::Create(
     const std::map<std::string, std::vector<std::string>> trace_options,
     const grpc_compression_algorithm compression_algorithm,
     std::shared_ptr<Headers> http_headers, const bool verbose,
-    const std::string& metrics_url, const ContentType input_content_type,
-    const ContentType output_content_type,
+    const std::string& metrics_url, const TensorFormat input_tensor_format,
+    const TensorFormat output_tensor_format,
     std::unique_ptr<ClientBackend>* client_backend)
 {
   std::unique_ptr<TritonClientBackend> triton_client_backend(
       new TritonClientBackend(
           protocol, compression_algorithm, http_headers, metrics_url,
-          input_content_type, output_content_type));
+          input_tensor_format, output_tensor_format));
   if (protocol == ProtocolType::HTTP) {
     triton::client::HttpSslOptions http_ssl_options =
         ParseHttpSslOptions(ssl_options);
@@ -553,7 +553,7 @@ TritonClientBackend::ParseInferInputToTriton(
 {
   for (const auto input : inputs) {
     tc::InferInput* triton_input{dynamic_cast<TritonInferInput*>(input)->Get()};
-    triton_input->SetBinaryData(input_content_type_ == ContentType::BINARY);
+    triton_input->SetBinaryData(input_tensor_format_ == TensorFormat::BINARY);
     triton_inputs->push_back(triton_input);
   }
 }
@@ -566,7 +566,7 @@ TritonClientBackend::ParseInferRequestedOutputToTriton(
   for (const auto output : outputs) {
     tc::InferRequestedOutput* triton_output{
         dynamic_cast<const TritonInferRequestedOutput*>(output)->Get()};
-    triton_output->SetBinaryData(input_content_type_ == ContentType::BINARY);
+    triton_output->SetBinaryData(input_tensor_format_ == TensorFormat::BINARY);
     triton_outputs->push_back(triton_output);
   }
 }

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -93,12 +93,14 @@ TritonClientBackend::Create(
     const std::map<std::string, std::vector<std::string>> trace_options,
     const grpc_compression_algorithm compression_algorithm,
     std::shared_ptr<Headers> http_headers, const bool verbose,
-    const std::string& metrics_url,
+    const std::string& metrics_url, const ContentType input_content_type,
+    const ContentType output_content_type,
     std::unique_ptr<ClientBackend>* client_backend)
 {
   std::unique_ptr<TritonClientBackend> triton_client_backend(
       new TritonClientBackend(
-          protocol, compression_algorithm, http_headers, metrics_url));
+          protocol, compression_algorithm, http_headers, metrics_url,
+          input_content_type, output_content_type));
   if (protocol == ProtocolType::HTTP) {
     triton::client::HttpSslOptions http_ssl_options =
         ParseHttpSslOptions(ssl_options);
@@ -550,7 +552,9 @@ TritonClientBackend::ParseInferInputToTriton(
     std::vector<tc::InferInput*>* triton_inputs)
 {
   for (const auto input : inputs) {
-    triton_inputs->push_back((dynamic_cast<TritonInferInput*>(input))->Get());
+    tc::InferInput* triton_input{dynamic_cast<TritonInferInput*>(input)->Get()};
+    triton_input->SetBinaryData(input_content_type_ == ContentType::BINARY);
+    triton_inputs->push_back(triton_input);
   }
 }
 
@@ -560,8 +564,10 @@ TritonClientBackend::ParseInferRequestedOutputToTriton(
     std::vector<const tc::InferRequestedOutput*>* triton_outputs)
 {
   for (const auto output : outputs) {
-    triton_outputs->push_back(
-        (dynamic_cast<const TritonInferRequestedOutput*>(output))->Get());
+    tc::InferRequestedOutput* triton_output{
+        dynamic_cast<const TritonInferRequestedOutput*>(output)->Get()};
+    triton_output->SetBinaryData(input_content_type_ == ContentType::BINARY);
+    triton_outputs->push_back(triton_output);
   }
 }
 

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -79,6 +79,9 @@ class TritonClientBackend : public ClientBackend {
   /// the header name/value.
   /// \param verbose Enables the verbose mode.
   /// \param metrics_url The inference server metrics url and port.
+  /// \param input_content_type The Triton inference request input content type.
+  /// \param output_content_type The Triton inference response output content
+  /// type.
   /// \param client_backend Returns a new TritonClientBackend object.
   /// \return Error object indicating success or failure.
   static Error Create(
@@ -87,7 +90,8 @@ class TritonClientBackend : public ClientBackend {
       const std::map<std::string, std::vector<std::string>> trace_options,
       const grpc_compression_algorithm compression_algorithm,
       std::shared_ptr<tc::Headers> http_headers, const bool verbose,
-      const std::string& metrics_url,
+      const std::string& metrics_url, const cb::ContentType input_content_type,
+      const cb::ContentType output_content_type,
       std::unique_ptr<ClientBackend>* client_backend);
 
   /// See ClientBackend::ServerExtensions()
@@ -169,10 +173,14 @@ class TritonClientBackend : public ClientBackend {
   TritonClientBackend(
       const ProtocolType protocol,
       const grpc_compression_algorithm compression_algorithm,
-      std::shared_ptr<tc::Headers> http_headers, const std::string& metrics_url)
+      std::shared_ptr<tc::Headers> http_headers, const std::string& metrics_url,
+      const cb::ContentType input_content_type,
+      const cb::ContentType output_content_type)
       : ClientBackend(BackendKind::TRITON), protocol_(protocol),
         compression_algorithm_(compression_algorithm),
-        http_headers_(http_headers), metrics_url_(metrics_url)
+        http_headers_(http_headers), metrics_url_(metrics_url),
+        input_content_type_(input_content_type),
+        output_content_type_(output_content_type)
   {
   }
 
@@ -239,6 +247,8 @@ class TritonClientBackend : public ClientBackend {
   const grpc_compression_algorithm compression_algorithm_{GRPC_COMPRESS_NONE};
   std::shared_ptr<tc::Headers> http_headers_;
   const std::string metrics_url_{""};
+  const cb::ContentType input_content_type_{cb::ContentType::UNKNOWN};
+  const cb::ContentType output_content_type_{cb::ContentType::UNKNOWN};
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend TestTritonClientBackend;

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -79,9 +79,10 @@ class TritonClientBackend : public ClientBackend {
   /// the header name/value.
   /// \param verbose Enables the verbose mode.
   /// \param metrics_url The inference server metrics url and port.
-  /// \param input_content_type The Triton inference request input content type.
-  /// \param output_content_type The Triton inference response output content
-  /// type.
+  /// \param input_tensor_format The Triton inference request input tensor
+  /// format.
+  /// \param output_tensor_format The Triton inference response output tensor
+  /// format.
   /// \param client_backend Returns a new TritonClientBackend object.
   /// \return Error object indicating success or failure.
   static Error Create(
@@ -90,8 +91,9 @@ class TritonClientBackend : public ClientBackend {
       const std::map<std::string, std::vector<std::string>> trace_options,
       const grpc_compression_algorithm compression_algorithm,
       std::shared_ptr<tc::Headers> http_headers, const bool verbose,
-      const std::string& metrics_url, const cb::ContentType input_content_type,
-      const cb::ContentType output_content_type,
+      const std::string& metrics_url,
+      const cb::TensorFormat input_tensor_format,
+      const cb::TensorFormat output_tensor_format,
       std::unique_ptr<ClientBackend>* client_backend);
 
   /// See ClientBackend::ServerExtensions()
@@ -174,13 +176,13 @@ class TritonClientBackend : public ClientBackend {
       const ProtocolType protocol,
       const grpc_compression_algorithm compression_algorithm,
       std::shared_ptr<tc::Headers> http_headers, const std::string& metrics_url,
-      const cb::ContentType input_content_type,
-      const cb::ContentType output_content_type)
+      const cb::TensorFormat input_tensor_format,
+      const cb::TensorFormat output_tensor_format)
       : ClientBackend(BackendKind::TRITON), protocol_(protocol),
         compression_algorithm_(compression_algorithm),
         http_headers_(http_headers), metrics_url_(metrics_url),
-        input_content_type_(input_content_type),
-        output_content_type_(output_content_type)
+        input_tensor_format_(input_tensor_format),
+        output_tensor_format_(output_tensor_format)
   {
   }
 
@@ -247,8 +249,8 @@ class TritonClientBackend : public ClientBackend {
   const grpc_compression_algorithm compression_algorithm_{GRPC_COMPRESS_NONE};
   std::shared_ptr<tc::Headers> http_headers_;
   const std::string metrics_url_{""};
-  const cb::ContentType input_content_type_{cb::ContentType::UNKNOWN};
-  const cb::ContentType output_content_type_{cb::ContentType::UNKNOWN};
+  const cb::TensorFormat input_tensor_format_{cb::TensorFormat::UNKNOWN};
+  const cb::TensorFormat output_tensor_format_{cb::TensorFormat::UNKNOWN};
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend TestTritonClientBackend;

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -77,6 +77,7 @@ CLParser::Usage(const std::string& msg)
             << std::endl;
   std::cerr << "\t-m <model name>" << std::endl;
   std::cerr << "\t-x <model version>" << std::endl;
+  std::cerr << "\t--bls-composing-models=<string>" << std::endl;
   std::cerr << "\t--model-signature-name <model signature name>" << std::endl;
   std::cerr << "\t-v" << std::endl;
   std::cerr << std::endl;
@@ -122,6 +123,8 @@ CLParser::Usage(const std::string& msg)
   std::cerr << "\t--sequence-id-range <start:end>" << std::endl;
   std::cerr << "\t--string-length <length>" << std::endl;
   std::cerr << "\t--string-data <string>" << std::endl;
+  std::cerr << "\t--input-content-type=[binary|json]" << std::endl;
+  std::cerr << "\t--output-content-type=[binary|json]" << std::endl;
   std::cerr << "\tDEPRECATED OPTIONS" << std::endl;
   std::cerr << "\t-z" << std::endl;
   std::cerr << "\t--data-directory <path>" << std::endl;
@@ -489,6 +492,18 @@ CLParser::Usage(const std::string& msg)
                    "option is ignored if --input-data points to a directory.",
                    18)
             << std::endl;
+  std::cerr << FormatMessage(
+                   " --input-content-type=[binary|json]: Specifies Triton "
+                   "inference request input content type. Only valid when HTTP "
+                   "protocol is used. Default is 'binary'.",
+                   18)
+            << std::endl;
+  std::cerr << FormatMessage(
+                   " --output-content-type=[binary|json]: Specifies Triton "
+                   "inference response output content type. Only valid when "
+                   "HTTP protocol is used. Default is 'binary'.",
+                   18)
+            << std::endl;
   std::cerr << std::endl;
   std::cerr << "III. SERVER DETAILS: " << std::endl;
   std::cerr << std::setw(38) << std::left << " -u: "
@@ -765,6 +780,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
       {"sequence-length-variation", required_argument, 0, 52},
       {"bls-composing-models", required_argument, 0, 53},
       {"serial-sequences", no_argument, 0, 54},
+      {"input-content-type", required_argument, 0, 55},
+      {"output-content-type", required_argument, 0, 56},
       {0, 0, 0, 0}};
 
   // Parse commandline...
@@ -1242,6 +1259,21 @@ CLParser::ParseCommandLine(int argc, char** argv)
       }
       case 54: {
         params_->serial_sequences = true;
+      }
+      case 55: {
+        cb::ContentType input_content_type{ParseContentType(optarg)};
+        if (input_content_type == cb::ContentType::UNKNOWN) {
+          Usage("--input-content-type must be 'binary' or 'json'");
+        }
+        params_->input_content_type = input_content_type;
+        break;
+      }
+      case 56: {
+        cb::ContentType output_content_type{ParseContentType(optarg)};
+        if (output_content_type == cb::ContentType::UNKNOWN) {
+          Usage("--output-content-type must be 'binary' or 'json'");
+        }
+        params_->output_content_type = output_content_type;
         break;
       }
       case 'v':

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -123,8 +123,8 @@ CLParser::Usage(const std::string& msg)
   std::cerr << "\t--sequence-id-range <start:end>" << std::endl;
   std::cerr << "\t--string-length <length>" << std::endl;
   std::cerr << "\t--string-data <string>" << std::endl;
-  std::cerr << "\t--input-content-type=[binary|json]" << std::endl;
-  std::cerr << "\t--output-content-type=[binary|json]" << std::endl;
+  std::cerr << "\t--input-tensor-format=[binary|json]" << std::endl;
+  std::cerr << "\t--output-tensor-format=[binary|json]" << std::endl;
   std::cerr << "\tDEPRECATED OPTIONS" << std::endl;
   std::cerr << "\t-z" << std::endl;
   std::cerr << "\t--data-directory <path>" << std::endl;
@@ -493,14 +493,14 @@ CLParser::Usage(const std::string& msg)
                    18)
             << std::endl;
   std::cerr << FormatMessage(
-                   " --input-content-type=[binary|json]: Specifies Triton "
-                   "inference request input content type. Only valid when HTTP "
-                   "protocol is used. Default is 'binary'.",
+                   " --input-tensor-format=[binary|json]: Specifies Triton "
+                   "inference request input tensor format. Only valid when "
+                   "HTTP protocol is used. Default is 'binary'.",
                    18)
             << std::endl;
   std::cerr << FormatMessage(
-                   " --output-content-type=[binary|json]: Specifies Triton "
-                   "inference response output content type. Only valid when "
+                   " --output-tensor-format=[binary|json]: Specifies Triton "
+                   "inference response output tensor format. Only valid when "
                    "HTTP protocol is used. Default is 'binary'.",
                    18)
             << std::endl;
@@ -780,8 +780,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
       {"sequence-length-variation", required_argument, 0, 52},
       {"bls-composing-models", required_argument, 0, 53},
       {"serial-sequences", no_argument, 0, 54},
-      {"input-content-type", required_argument, 0, 55},
-      {"output-content-type", required_argument, 0, 56},
+      {"input-tensor-format", required_argument, 0, 55},
+      {"output-tensor-format", required_argument, 0, 56},
       {0, 0, 0, 0}};
 
   // Parse commandline...
@@ -1261,19 +1261,19 @@ CLParser::ParseCommandLine(int argc, char** argv)
         params_->serial_sequences = true;
       }
       case 55: {
-        cb::ContentType input_content_type{ParseContentType(optarg)};
-        if (input_content_type == cb::ContentType::UNKNOWN) {
-          Usage("--input-content-type must be 'binary' or 'json'");
+        cb::TensorFormat input_tensor_format{ParseTensorFormat(optarg)};
+        if (input_tensor_format == cb::TensorFormat::UNKNOWN) {
+          Usage("--input-tensor-format must be 'binary' or 'json'");
         }
-        params_->input_content_type = input_content_type;
+        params_->input_tensor_format = input_tensor_format;
         break;
       }
       case 56: {
-        cb::ContentType output_content_type{ParseContentType(optarg)};
-        if (output_content_type == cb::ContentType::UNKNOWN) {
-          Usage("--output-content-type must be 'binary' or 'json'");
+        cb::TensorFormat output_tensor_format{ParseTensorFormat(optarg)};
+        if (output_tensor_format == cb::TensorFormat::UNKNOWN) {
+          Usage("--output-tensor-format must be 'binary' or 'json'");
         }
-        params_->output_content_type = output_content_type;
+        params_->output_tensor_format = output_tensor_format;
         break;
       }
       case 'v':

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -138,6 +138,12 @@ struct PerfAnalyzerParameters {
   // percentage exceeds the threshold, a warning is displayed.
   //
   double overhead_pct_threshold{50.0};
+
+  // Triton inference request input content type.
+  cb::ContentType input_content_type{cb::ContentType::BINARY};
+
+  // Triton inference response output content type.
+  cb::ContentType output_content_type{cb::ContentType::BINARY};
 };
 
 using PAParamsPtr = std::shared_ptr<PerfAnalyzerParameters>;

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -139,11 +139,11 @@ struct PerfAnalyzerParameters {
   //
   double overhead_pct_threshold{50.0};
 
-  // Triton inference request input content type.
-  cb::ContentType input_content_type{cb::ContentType::BINARY};
+  // Triton inference request input tensor format.
+  cb::TensorFormat input_tensor_format{cb::TensorFormat::BINARY};
 
-  // Triton inference response output content type.
-  cb::ContentType output_content_type{cb::ContentType::BINARY};
+  // Triton inference response output tensor format.
+  cb::TensorFormat output_tensor_format{cb::TensorFormat::BINARY};
 };
 
 using PAParamsPtr = std::shared_ptr<PerfAnalyzerParameters>;

--- a/src/c++/perf_analyzer/docs/cli.md
+++ b/src/c++/perf_analyzer/docs/cli.md
@@ -364,16 +364,16 @@ output_shared_memory_size * number_of_outputs * batch_size.
          
 Default is `102400` (100 KB).
 
-#### `--input-content-type=[binary|json]`
+#### `--input-tensor-format=[binary|json]`
 
-Specifies the Triton inference request input content type. Only valid when HTTP
+Specifies the Triton inference request input tensor format. Only valid when HTTP
 protocol is used.
 
 Default is `binary`.
 
-#### `--output-content-type=[binary|json]`
+#### `--output-tensor-format=[binary|json]`
 
-Specifies the Triton inference response output content type. Only valid when
+Specifies the Triton inference response output tensor format. Only valid when
 HTTP protocol is used.
 
 Default is `binary`.

--- a/src/c++/perf_analyzer/docs/cli.md
+++ b/src/c++/perf_analyzer/docs/cli.md
@@ -364,6 +364,20 @@ output_shared_memory_size * number_of_outputs * batch_size.
          
 Default is `102400` (100 KB).
 
+#### `--input-content-type=[binary|json]`
+
+Specifies the Triton inference request input content type. Only valid when HTTP
+protocol is used.
+
+Default is `binary`.
+
+#### `--output-content-type=[binary|json]`
+
+Specifies the Triton inference response output content type. Only valid when
+HTTP protocol is used.
+
+Default is `binary`.
+
 ## Request Options
 
 #### `-i [http|grpc]`

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -79,8 +79,8 @@ PerfAnalyzer::CreateAnalyzerObjects()
           params_->trace_options, params_->compression_algorithm,
           params_->http_headers, params_->triton_server_path,
           params_->model_repository_path, params_->extra_verbose,
-          params_->metrics_url, params_->input_content_type,
-          params_->output_content_type, &factory),
+          params_->metrics_url, params_->input_tensor_format,
+          params_->output_tensor_format, &factory),
       "failed to create client factory");
 
   FAIL_IF_ERR(

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -79,7 +79,8 @@ PerfAnalyzer::CreateAnalyzerObjects()
           params_->trace_options, params_->compression_algorithm,
           params_->http_headers, params_->triton_server_path,
           params_->model_repository_path, params_->extra_verbose,
-          params_->metrics_url, &factory),
+          params_->metrics_url, params_->input_content_type,
+          params_->output_content_type, &factory),
       "failed to create client factory");
 
   FAIL_IF_ERR(

--- a/src/c++/perf_analyzer/perf_utils.cc
+++ b/src/c++/perf_analyzer/perf_utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #include <algorithm>
+#include <cctype>
 #include <iostream>
 #include <string>
 #include "client_backend/client_backend.h"
@@ -432,6 +433,23 @@ ScheduleDistribution<Distribution::CONSTANT>(const double request_rate)
       std::chrono::duration_cast<std::chrono::nanoseconds>(
           std::chrono::duration<double>(1.0 / request_rate));
   return [period](std::mt19937& /*gen*/) { return period; };
+}
+
+cb::ContentType
+ParseContentType(const std::string& content_type_str)
+{
+  std::string content_type_str_lowercase{content_type_str};
+  std::transform(
+      content_type_str.cbegin(), content_type_str.cend(),
+      content_type_str_lowercase.begin(),
+      [](unsigned char c) { return std::tolower(c); });
+  if (content_type_str_lowercase == "binary") {
+    return cb::ContentType::BINARY;
+  } else if (content_type_str_lowercase == "json") {
+    return cb::ContentType::JSON;
+  } else {
+    return cb::ContentType::UNKNOWN;
+  }
 }
 
 TEST_CASE("testing the ParseProtocol function")

--- a/src/c++/perf_analyzer/perf_utils.cc
+++ b/src/c++/perf_analyzer/perf_utils.cc
@@ -435,8 +435,8 @@ ScheduleDistribution<Distribution::CONSTANT>(const double request_rate)
   return [period](std::mt19937& /*gen*/) { return period; };
 }
 
-cb::ContentType
-ParseContentType(const std::string& content_type_str)
+cb::TensorFormat
+ParseTensorFormat(const std::string& content_type_str)
 {
   std::string content_type_str_lowercase{content_type_str};
   std::transform(
@@ -444,11 +444,11 @@ ParseContentType(const std::string& content_type_str)
       content_type_str_lowercase.begin(),
       [](unsigned char c) { return std::tolower(c); });
   if (content_type_str_lowercase == "binary") {
-    return cb::ContentType::BINARY;
+    return cb::TensorFormat::BINARY;
   } else if (content_type_str_lowercase == "json") {
-    return cb::ContentType::JSON;
+    return cb::TensorFormat::JSON;
   } else {
-    return cb::ContentType::UNKNOWN;
+    return cb::TensorFormat::UNKNOWN;
   }
 }
 

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -155,7 +155,7 @@ template <Distribution distribution>
 std::function<std::chrono::nanoseconds(std::mt19937&)> ScheduleDistribution(
     const double request_rate);
 
-// Parse the HTTP content type
-cb::ContentType ParseContentType(const std::string& content_type_str);
+// Parse the HTTP tensor format
+cb::TensorFormat ParseTensorFormat(const std::string& tensor_format_str);
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -154,5 +154,8 @@ std::string TensorToRegionName(std::string name);
 template <Distribution distribution>
 std::function<std::chrono::nanoseconds(std::mt19937&)> ScheduleDistribution(
     const double request_rate);
+
+// Parse the HTTP content type
+cb::ContentType ParseContentType(const std::string& content_type_str);
 
 }}  // namespace triton::perfanalyzer


### PR DESCRIPTION
* implements ability to use json content type (in addition to binary) for inputs in inference request in c++ client
* implements ability to use json content type (in addition to binary) for outputs in inference response in c++ client
* implements two new PA options (`--json-input-data` and `--json-output-data`, which propagate down this preference to c++ client for inference requests/response input/output data formats)
* adds documentation for new PA option