### PR TITLE
Close client in order to prevent file handle leak

### DIFF
--- a/src/java/README.md
+++ b/src/java/README.md
@@ -78,6 +78,7 @@ public class MinExample {
 
         InferenceServerClient client = new InferenceServerClient("0.0.0.0:8000", 5000, 5000);
         InferResult result = client.infer("roberta", inputs, outputs);
+        client.close();
         float[] logits = result.getOutputAsFloat("logits");
         System.out.println(Arrays.toString(logits));
     }

--- a/src/java/src/main/java/triton/client/examples/MemoryGrowthTest.java
+++ b/src/java/src/main/java/triton/client/examples/MemoryGrowthTest.java
@@ -57,6 +57,7 @@ public class MemoryGrowthTest {
 
       InferenceServerClient client = new InferenceServerClient("0.0.0.0:8000", 5000, 5000);
       InferResult result = client.infer("custom_identity_int32", inputs, outputs);
+      client.close();
 
       // Get the output arrays from the results and verify
       int[] output0 = result.getOutputAsInt("OUTPUT0");

--- a/src/java/src/main/java/triton/client/examples/SimpleInferClient.java
+++ b/src/java/src/main/java/triton/client/examples/SimpleInferClient.java
@@ -65,6 +65,7 @@ public class SimpleInferClient {
 
     InferenceServerClient client = new InferenceServerClient("0.0.0.0:8000", 5000, 5000);
     InferResult result = client.infer("simple", inputs, outputs);
+    client.close();
 
     // Get the output arrays from the results
     int[] op0 = result.getOutputAsInt("OUTPUT0");


### PR DESCRIPTION
When I was running the Java triton client without closing, then after approximately 300 requests I got a "too many open files" exception. Closing the client using client.close() prevent this problem