### PR TITLE
Fix uninitialized value bug

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -961,11 +961,11 @@ InferenceProfiler::MergePerfStatusReports(
     if (perf_status_reports[i].on_sequence_model !=
         perf_status.on_sequence_model) {
       return cb::Error(
-          "Incosistent sequence setting detected.", pa::GENERIC_ERROR);
+          "Inconsistent sequence setting detected.", pa::GENERIC_ERROR);
     }
 
     if (perf_status_reports[i].batch_size != perf_status.batch_size) {
-      return cb::Error("Incosistent batch size detected.", pa::GENERIC_ERROR);
+      return cb::Error("Inconsistent batch size detected.", pa::GENERIC_ERROR);
     }
 
     if (perf_status_reports[i].server_stats.composing_models_stat.size() !=
@@ -995,6 +995,8 @@ InferenceProfiler::MergePerfStatusReports(
   experiment_perf_status.client_stats.sequence_per_sec = 0;
   experiment_perf_status.client_stats.completed_count = 0;
   experiment_perf_status.stabilizing_latency_ns = 0;
+  experiment_perf_status.overhead_pct = 0;
+  experiment_perf_status.send_request_rate = 0.0;
 
   std::vector<ServerSideStats> server_side_stats;
   for (auto& perf_status : perf_status_reports) {


### PR DESCRIPTION
[Here](https://github.com/triton-inference-server/client/pull/324/files#diff-1d869f26de26a6908d10260f21bd433d63ab260cd58156aed650f563001547d1R1021) we are incrementing, but the value was never initialized to 0. The result is that any random overhead could be reported depending on where that variable ended up in memory.

Technically the send_request_rate was initialized to 0 in the struct so that change wasn't as necessary, but I added an explicit reset to 0 in case the object is reused.