### PR TITLE
Add testing for ReadDataFromDir

### DIFF
--- a/src/c++/perf_analyzer/data_loader.cc
+++ b/src/c++/perf_analyzer/data_loader.cc
@@ -568,4 +568,56 @@ DataLoader::ReadTensorData(
   return cb::Error::Success;
 }
 
+
+cb::Error
+DataLoader::ReadFile(const std::string& path, std::vector<char>* contents)
+{
+  std::ifstream in(path, std::ios::in | std::ios::binary);
+  if (!in) {
+    return cb::Error("failed to open file '" + path + "'", pa::GENERIC_ERROR);
+  }
+
+  in.seekg(0, std::ios::end);
+
+  int file_size = in.tellg();
+  if (file_size > 0) {
+    contents->resize(file_size);
+    in.seekg(0, std::ios::beg);
+    in.read(&(*contents)[0], contents->size());
+  }
+
+  in.close();
+
+  // If size is invalid, report after ifstream is closed
+  if (file_size < 0) {
+    return cb::Error(
+        "failed to get size for file '" + path + "'", pa::GENERIC_ERROR);
+  } else if (file_size == 0) {
+    return cb::Error("file '" + path + "' is empty", pa::GENERIC_ERROR);
+  }
+
+  return cb::Error::Success;
+}
+
+cb::Error
+DataLoader::ReadTextFile(
+    const std::string& path, std::vector<std::string>* contents)
+{
+  std::ifstream in(path);
+  if (!in) {
+    return cb::Error("failed to open file '" + path + "'", pa::GENERIC_ERROR);
+  }
+
+  std::string current_string;
+  while (std::getline(in, current_string)) {
+    contents->push_back(current_string);
+  }
+  in.close();
+
+  if (contents->size() == 0) {
+    return cb::Error("file '" + path + "' is empty", pa::GENERIC_ERROR);
+  }
+  return cb::Error::Success;
+}
+
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/data_loader.cc
+++ b/src/c++/perf_analyzer/data_loader.cc
@@ -90,8 +90,8 @@ DataLoader::ReadDataFromDir(
       if (input_string_data.size() != batch1_num_strings) {
         return cb::Error(
             "provided data for input " + input.second.name_ + " has " +
-                std::to_string(it->second.size()) + " byte elements, expect " +
-                std::to_string(batch1_num_strings),
+                std::to_string(input_string_data.size()) +
+                " elements, expect " + std::to_string(batch1_num_strings),
             pa::GENERIC_ERROR);
       }
     }

--- a/src/c++/perf_analyzer/data_loader.h
+++ b/src/c++/perf_analyzer/data_loader.h
@@ -136,19 +136,19 @@ class DataLoader {
       const std::shared_ptr<ModelTensorMap>& outputs);
 
  private:
-  // Reads the data from file specified by path into vector of characters
-  // \param path The complete path to the file to be read
-  // \param contents The character vector that will contain the data read
-  // \return error status. Returns Non-Ok if an error is encountered during
-  //  read operation.
+  /// Reads the data from file specified by path into vector of characters
+  /// \param path The complete path to the file to be read
+  /// \param contents The character vector that will contain the data read
+  /// \return error status. Returns Non-Ok if an error is encountered during
+  ///  read operation.
   virtual cb::Error ReadFile(
       const std::string& path, std::vector<char>* contents);
 
-  // Reads the string from file specified by path into vector of strings
-  // \param path The complete path to the file to be read
-  // \param contents The string vector that will contain the data read
-  // \return error status. Returns Non-Ok if an error is encountered during
-  //  read operation.
+  /// Reads the string from file specified by path into vector of strings
+  /// \param path The complete path to the file to be read
+  /// \param contents The string vector that will contain the data read
+  /// \return error status. Returns Non-Ok if an error is encountered during
+  ///  read operation.
   virtual cb::Error ReadTextFile(
       const std::string& path, std::vector<std::string>* contents);
 

--- a/src/c++/perf_analyzer/data_loader.h
+++ b/src/c++/perf_analyzer/data_loader.h
@@ -136,6 +136,22 @@ class DataLoader {
       const std::shared_ptr<ModelTensorMap>& outputs);
 
  private:
+  // Reads the data from file specified by path into vector of characters
+  // \param path The complete path to the file to be read
+  // \param contents The character vector that will contain the data read
+  // \return error status. Returns Non-Ok if an error is encountered during
+  //  read operation.
+  virtual cb::Error ReadFile(
+      const std::string& path, std::vector<char>* contents);
+
+  // Reads the string from file specified by path into vector of strings
+  // \param path The complete path to the file to be read
+  // \param contents The string vector that will contain the data read
+  // \return error status. Returns Non-Ok if an error is encountered during
+  //  read operation.
+  virtual cb::Error ReadTextFile(
+      const std::string& path, std::vector<std::string>* contents);
+
   /// Helper function to read data for the specified input from json
   /// \param step the DOM for current step
   /// \param inputs The pointer to the map holding the information about

--- a/src/c++/perf_analyzer/mock_data_loader.h
+++ b/src/c++/perf_analyzer/mock_data_loader.h
@@ -47,10 +47,26 @@ class NaggyMockDataLoader : public DataLoader {
         .WillByDefault([this](size_t stream_id) -> size_t {
           return this->DataLoader::GetTotalSteps(stream_id);
         });
+    ON_CALL(*this, ReadFile(testing::_, testing::_))
+        .WillByDefault(
+            [this](
+                const std::string& path,
+                std::vector<char>* contents) -> cb::Error {
+              return this->DataLoader::ReadFile(path, contents);
+            });
+    ON_CALL(*this, ReadTextFile(testing::_, testing::_))
+        .WillByDefault(
+            [this](
+                const std::string& path,
+                std::vector<std::string>* contents) -> cb::Error {
+              return this->DataLoader::ReadTextFile(path, contents);
+            });
   }
 
   MOCK_METHOD(size_t, GetTotalSteps, (size_t), (override));
-
+  MOCK_METHOD(cb::Error, ReadFile, (const std::string&, std::vector<char>*));
+  MOCK_METHOD(
+      cb::Error, ReadTextFile, (const std::string&, std::vector<std::string>*));
 
   cb::Error ReadDataFromJSON(
       const std::shared_ptr<ModelTensorMap>& inputs,

--- a/src/c++/perf_analyzer/perf_utils.cc
+++ b/src/c++/perf_analyzer/perf_utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/perf_utils.cc
+++ b/src/c++/perf_analyzer/perf_utils.cc
@@ -88,56 +88,6 @@ ConvertDTypeFromTFS(const std::string& tf_dtype, std::string* datatype)
   return cb::Error::Success;
 }
 
-cb::Error
-ReadFile(const std::string& path, std::vector<char>* contents)
-{
-  std::ifstream in(path, std::ios::in | std::ios::binary);
-  if (!in) {
-    return cb::Error("failed to open file '" + path + "'", pa::GENERIC_ERROR);
-  }
-
-  in.seekg(0, std::ios::end);
-
-  int file_size = in.tellg();
-  if (file_size > 0) {
-    contents->resize(file_size);
-    in.seekg(0, std::ios::beg);
-    in.read(&(*contents)[0], contents->size());
-  }
-
-  in.close();
-
-  // If size is invalid, report after ifstream is closed
-  if (file_size < 0) {
-    return cb::Error(
-        "failed to get size for file '" + path + "'", pa::GENERIC_ERROR);
-  } else if (file_size == 0) {
-    return cb::Error("file '" + path + "' is empty", pa::GENERIC_ERROR);
-  }
-
-  return cb::Error::Success;
-}
-
-cb::Error
-ReadTextFile(const std::string& path, std::vector<std::string>* contents)
-{
-  std::ifstream in(path);
-  if (!in) {
-    return cb::Error("failed to open file '" + path + "'", pa::GENERIC_ERROR);
-  }
-
-  std::string current_string;
-  while (std::getline(in, current_string)) {
-    contents->push_back(current_string);
-  }
-  in.close();
-
-  if (contents->size() == 0) {
-    return cb::Error("file '" + path + "' is empty", pa::GENERIC_ERROR);
-  }
-  return cb::Error::Success;
-}
-
 bool
 IsDirectory(const std::string& path)
 {

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -97,21 +97,6 @@ cb::Error ConvertDTypeFromTFS(
 // Parse the communication protocol type
 cb::ProtocolType ParseProtocol(const std::string& str);
 
-// Reads the data from file specified by path into vector of characters
-// \param path The complete path to the file to be read
-// \param contents The character vector that will contain the data read
-// \return error status. Returns Non-Ok if an error is encountered during
-//  read operation.
-cb::Error ReadFile(const std::string& path, std::vector<char>* contents);
-
-// Reads the string from file specified by path into vector of strings
-// \param path The complete path to the file to be read
-// \param contents The string vector that will contain the data read
-// \return error status. Returns Non-Ok if an error is encountered during
-//  read operation.
-cb::Error ReadTextFile(
-    const std::string& path, std::vector<std::string>* contents);
-
 // To check whether the path points to a valid system directory
 bool IsDirectory(const std::string& path);
 

--- a/src/c++/perf_analyzer/test_dataloader.cc
+++ b/src/c++/perf_analyzer/test_dataloader.cc
@@ -126,7 +126,7 @@ TEST_CASE("dataloader: ParseData: Bad Json")
 
 TEST_CASE(
     "dataloader: ParseData: No Data" *
-    doctest::description("If there is no field called data in the json, an "
+    doctest::description("When there is no field called data in the json, an "
                          "error should be thrown"))
 {
   std::string json_str{R"({ "notdata" : 5})"};
@@ -144,8 +144,8 @@ TEST_CASE(
 // TEST_CASE(
 //    "dataloader: ParseData: Mismatch Shape" *
 //    doctest::description(
-//        "If the size of the provided Input is not in line with the Tensor's "
-//        "shape, then an error should be thrown"))
+//        "When the size of the provided Input is not in line with the Tensor's
+//        " "shape, then an error should be thrown"))
 //{
 //  std::string json_str{R"({"data": [{ "INPUT1": [1,2] }]})"};
 //
@@ -168,7 +168,7 @@ TEST_CASE(
 TEST_CASE(
     "dataloader: ParseData: Mismatch Input and Output" *
     doctest::description(
-        "If the size of the provided Input and validation Output data are "
+        "When the size of the provided Input and validation Output data are "
         "different, then an error should be thrown"))
 {
   std::string json_str{R"({
@@ -368,9 +368,9 @@ TEST_CASE("dataloader: ParseData: Multiple Streams Valid")
 TEST_CASE(
     "dataloader: ParseData: Missing Shape" *
     doctest::description(
-        "If a tensor's shape is dynamic (-1), then it needs to be provided via "
-        "--shape option (which is not visable to this testing), or via a shape "
-        "option in the json. If not, an error is thrown"))
+        "When a tensor's shape is dynamic (-1), then it needs to be provided "
+        "via --shape option (which is not visable to this testing), or via a "
+        "shape option in the json. If not, an error is thrown"))
 {
   std::string json_str{R"({"data": [{ "INPUT1": [1,2,3] } ]})"};
 
@@ -675,7 +675,7 @@ TEST_CASE(
 TEST_CASE(
     "dataloader: ReadDataFromDir: Error reading input file" *
     doctest::description(
-        "If error reading input data file, an error reading the file should "
+        "When there is an error reading an input data file, the error should "
         "bubble up to the return value of ReadDataFromDir"))
 {
   MockDataLoader dataloader;
@@ -698,8 +698,9 @@ TEST_CASE(
 TEST_CASE(
     "dataloader: ReadDataFromDir: Error reading output file" *
     doctest::description(
-        "If error reading output data file, an error is NOT raised, and "
-        "instead GetOutputData will return nullptr with a batch1_size of 0"))
+        "When there is an error reading an output data file, an error is NOT "
+        "raised from ReadDataFromDir, and instead GetOutputData will return "
+        "nullptr with a batch1_size of 0"))
 {
   MockDataLoader dataloader;
 

--- a/src/c++/perf_analyzer/test_dataloader.cc
+++ b/src/c++/perf_analyzer/test_dataloader.cc
@@ -673,4 +673,145 @@ TEST_CASE(
   }
 }
 
+
+TEST_CASE(
+    "dataloader: ReadDataFromDir: Error reading input file" *
+    doctest::description(
+        "If error reading input data file, an error reading the file should "
+        "bubble up to the return value of ReadDataFromDir"))
+{
+  MockDataLoader dataloader;
+
+  std::shared_ptr<ModelTensorMap> inputs = std::make_shared<ModelTensorMap>();
+  std::shared_ptr<ModelTensorMap> outputs = std::make_shared<ModelTensorMap>();
+
+  ModelTensor input1 = TestDataLoader::CreateTensor("INPUT1");
+
+  std::string dir{"fake/path"};
+
+  SUBCASE("BYTES (string) data") { input1.datatype_ = "BYTES"; }
+  SUBCASE("Raw Binary data") { input1.datatype_ = "INT32"; }
+
+  inputs->insert(std::make_pair(input1.name_, input1));
+  cb::Error status = dataloader.ReadDataFromDir(inputs, outputs, dir);
+  CHECK(status.IsOk() == false);
+}
+
+TEST_CASE(
+    "dataloader: ReadDataFromDir: Error reading output file" *
+    doctest::description(
+        "If error reading output data file, an error is NOT raised, and "
+        "instead GetOutputData will return nullptr with a batch1_size of 0"))
+{
+  MockDataLoader dataloader;
+
+  std::shared_ptr<ModelTensorMap> inputs = std::make_shared<ModelTensorMap>();
+  std::shared_ptr<ModelTensorMap> outputs = std::make_shared<ModelTensorMap>();
+
+  ModelTensor output1 = TestDataLoader::CreateTensor("OUTPUT1");
+
+  std::string dir{"fake/path"};
+
+  SUBCASE("BYTES (string) data") { output1.datatype_ = "BYTES"; }
+  SUBCASE("Raw Binary data") { output1.datatype_ = "INT32"; }
+
+  outputs->insert(std::make_pair(output1.name_, output1));
+  cb::Error status = dataloader.ReadDataFromDir(inputs, outputs, dir);
+  CHECK(status.IsOk() == true);
+
+  const uint8_t* data_ptr{nullptr};
+  size_t batch1_size;
+
+  dataloader.GetOutputData("OUTPUT1", 0, 0, &data_ptr, &batch1_size);
+  CHECK(data_ptr == nullptr);
+  CHECK(batch1_size == 0);
+}
+
+TEST_CASE(
+    "dataloader: ReadDataFromDir: Valid Data" *
+    doctest::description("Successfully reading files will always result in a "
+                         "single stream with a single step"))
+{
+  MockDataLoader dataloader;
+
+  std::string datatype;
+
+  std::shared_ptr<ModelTensorMap> inputs = std::make_shared<ModelTensorMap>();
+  std::shared_ptr<ModelTensorMap> outputs = std::make_shared<ModelTensorMap>();
+
+  ModelTensor input1 = TestDataLoader::CreateTensor("INPUT1");
+  ModelTensor output1 = TestDataLoader::CreateTensor("OUTPUT1");
+
+  std::string dir{"mocked_out"};
+
+  std::vector<char> input_char_data{'0', '0', '0', '7'};
+  std::vector<char> output_char_data{'0', '0', '0', '3'};
+
+  std::vector<std::string> input_string_data{"InStr"};
+  std::vector<std::string> output_string_data{"OutStr"};
+
+  std::vector<char> expected_input;
+  std::vector<char> expected_output;
+
+  SUBCASE("BYTES (string) data")
+  {
+    datatype = "BYTES";
+
+    expected_input = {'\5', '\0', '\0', '\0', 'I', 'n', 'S', 't', 'r'};
+    expected_output = {'\6', '\0', '\0', '\0', 'O', 'u', 't', 'S', 't', 'r'};
+
+    EXPECT_CALL(dataloader, ReadTextFile(testing::_, testing::_))
+        .WillOnce(testing::DoAll(
+            testing::SetArgPointee<1>(input_string_data),
+            testing::Return(cb::Error::Success)))
+        .WillOnce(testing::DoAll(
+            testing::SetArgPointee<1>(output_string_data),
+            testing::Return(cb::Error::Success)));
+  }
+  SUBCASE("Raw Binary data")
+  {
+    datatype = "INT32";
+
+    expected_input = input_char_data;
+    expected_output = output_char_data;
+
+    EXPECT_CALL(dataloader, ReadFile(testing::_, testing::_))
+        .WillOnce(testing::DoAll(
+            testing::SetArgPointee<1>(input_char_data),
+            testing::Return(cb::Error::Success)))
+        .WillOnce(testing::DoAll(
+            testing::SetArgPointee<1>(output_char_data),
+            testing::Return(cb::Error::Success)));
+  }
+
+  input1.datatype_ = datatype;
+  output1.datatype_ = datatype;
+
+  inputs->insert(std::make_pair(input1.name_, input1));
+  outputs->insert(std::make_pair(output1.name_, output1));
+
+  cb::Error status = dataloader.ReadDataFromDir(inputs, outputs, dir);
+  REQUIRE(status.IsOk() == true);
+  CHECK_EQ(dataloader.GetDataStreamsCount(), 1);
+  CHECK_EQ(dataloader.GetTotalSteps(0), 1);
+
+  // Validate input and output data
+  const uint8_t* data_ptr{nullptr};
+  size_t batch1_size;
+
+  dataloader.GetInputData(input1, 0, 0, &data_ptr, &batch1_size);
+  const char* input_data = reinterpret_cast<const char*>(data_ptr);
+  REQUIRE(batch1_size == expected_input.size());
+  for (size_t i = 0; i < batch1_size; i++) {
+    CHECK(input_data[i] == expected_input[i]);
+  }
+
+  dataloader.GetOutputData("OUTPUT1", 0, 0, &data_ptr, &batch1_size);
+  const char* output_data = reinterpret_cast<const char*>(data_ptr);
+  REQUIRE(batch1_size == expected_output.size());
+  for (size_t i = 0; i < batch1_size; i++) {
+    CHECK(output_data[i] == expected_output[i]);
+  }
+}
+
 }}  // namespace triton::perfanalyzer


### PR DESCRIPTION
Add testing for DataLoader::ReadDataFromDir
This also moves ReadFile and ReadTextFile from perf_utils into the DataLoader class

Coverage up to 73% despite adding not-unit-testable file system code to the file.