### PR TITLE
improve delay reporting

### DIFF
--- a/src/c++/perf_analyzer/constants.h
+++ b/src/c++/perf_analyzer/constants.h
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -38,7 +38,7 @@ constexpr static const uint32_t OPTION_ERROR = 3;
 
 constexpr static const uint32_t GENERIC_ERROR = 99;
 
-const float DELAY_PCT_THRESHOLD{1.0};
+const double DELAY_PCT_THRESHOLD{1.0};
 
 /// Different measurement modes possible.
 enum MeasurementMode { TIME_WINDOWS = 0, COUNT_WINDOWS = 1 };

--- a/src/c++/perf_analyzer/constants.h
+++ b/src/c++/perf_analyzer/constants.h
@@ -38,6 +38,8 @@ constexpr static const uint32_t OPTION_ERROR = 3;
 
 constexpr static const uint32_t GENERIC_ERROR = 99;
 
+const float DELAY_PCT_THRESHOLD{1.0};
+
 /// Different measurement modes possible.
 enum MeasurementMode { TIME_WINDOWS = 0, COUNT_WINDOWS = 1 };
 

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -385,8 +385,8 @@ ReportClientSideStats(
                << std::setprecision(2) << send_request_rate << " infer/sec"
                << std::endl;
     delay_data << "    "
-               << "[WARNING] Perf Analyzer is not able to keep up with the "
-                  "desired load. ";
+               << "[WARNING] Perf Analyzer was not able to keep up with the "
+                  "desired request rate. ";
     float delay_pct =
         ((float)stats.delayed_request_count / stats.request_count) * 100;
     delay_data << delay_pct << "% of the requests were delayed. ";

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -377,8 +377,21 @@ ReportClientSideStats(
 
   std::cout << "    Request count: " << stats.request_count << std::endl;
   if (stats.delayed_request_count != 0) {
-    std::cout << "    Delayed Request Count: " << stats.delayed_request_count
-              << std::endl;
+    std::stringstream delay_data{""};
+    delay_data << "    Delayed Request Count: " << stats.delayed_request_count
+               << std::endl;
+    delay_data << "    "
+               << "Avg send request rate: " << std::fixed
+               << std::setprecision(2) << send_request_rate << " infer/sec"
+               << std::endl;
+    delay_data << "    "
+               << "[WARNING] Perf Analyzer is not able to keep up with the "
+                  "desired load. ";
+    float delay_pct =
+        ((float)stats.delayed_request_count / stats.request_count) * 100;
+    delay_data << delay_pct << "% of the requests were delayed. ";
+    delay_data << std::endl;
+    std::cout << delay_data.str();
   }
   if (on_sequence_model) {
     std::cout << "    Sequence count: " << stats.sequence_count << " ("
@@ -389,15 +402,10 @@ ReportClientSideStats(
 
   if (verbose) {
     std::stringstream client_overhead{""};
-    std::stringstream send_rate{""};
     client_overhead << "    "
                     << "Avg client overhead: " << std::fixed
                     << std::setprecision(2) << overhead_pct << "%";
-    send_rate << "    "
-              << "Avg send request rate: " << std::fixed << std::setprecision(2)
-              << send_request_rate << " infer/sec";
     std::cout << client_overhead.str() << std::endl;
-    std::cout << send_rate.str() << std::endl;
   }
 
   if (percentile == -1) {

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -35,6 +35,7 @@
 #include <sstream>
 #include <stdexcept>
 #include "client_backend/client_backend.h"
+#include "constants.h"
 #include "doctest.h"
 
 namespace triton { namespace perfanalyzer {
@@ -378,8 +379,7 @@ ReportClientSideStats(
   std::cout << "    Request count: " << stats.request_count << std::endl;
   float delay_pct =
       ((float)stats.delayed_request_count / stats.request_count) * 100;
-  float delay_pct_threshold = 1.0;
-  if (delay_pct > delay_pct_threshold) {
+  if (delay_pct > DELAY_PCT_THRESHOLD) {
     std::stringstream delay_data{""};
     delay_data << "    "
                << "Avg send request rate: " << std::fixed

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -377,20 +377,16 @@ ReportClientSideStats(
   }
 
   std::cout << "    Request count: " << stats.request_count << std::endl;
-  float delay_pct =
-      ((float)stats.delayed_request_count / stats.request_count) * 100;
+  double delay_pct =
+      ((double)stats.delayed_request_count / stats.request_count) * 100;
   if (delay_pct > DELAY_PCT_THRESHOLD) {
-    std::stringstream delay_data{""};
-    delay_data << "    "
-               << "Avg send request rate: " << std::fixed
-               << std::setprecision(2) << send_request_rate << " infer/sec"
-               << std::endl;
-    delay_data << "    "
-               << "[WARNING] Perf Analyzer was not able to keep up with the "
-                  "desired request rate. ";
-    delay_data << delay_pct << "% of the requests were delayed. ";
-    delay_data << std::endl;
-    std::cout << delay_data.str();
+    std::cout << "    "
+              << "Avg send request rate: " << std::fixed << std::setprecision(2)
+              << send_request_rate << " infer/sec" << std::endl;
+    std::cout << "    "
+              << "[WARNING] Perf Analyzer was not able to keep up with the "
+                 "desired request rate. ";
+    std::cout << delay_pct << "% of the requests were delayed. " << std::endl;
   }
   if (on_sequence_model) {
     std::cout << "    Sequence count: " << stats.sequence_count << " ("

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -376,10 +376,11 @@ ReportClientSideStats(
   }
 
   std::cout << "    Request count: " << stats.request_count << std::endl;
-  if (stats.delayed_request_count != 0) {
+  float delay_pct =
+      ((float)stats.delayed_request_count / stats.request_count) * 100;
+  float delay_pct_threshold = 1.0;
+  if (delay_pct > delay_pct_threshold) {
     std::stringstream delay_data{""};
-    delay_data << "    Delayed Request Count: " << stats.delayed_request_count
-               << std::endl;
     delay_data << "    "
                << "Avg send request rate: " << std::fixed
                << std::setprecision(2) << send_request_rate << " infer/sec"
@@ -387,8 +388,6 @@ ReportClientSideStats(
     delay_data << "    "
                << "[WARNING] Perf Analyzer was not able to keep up with the "
                   "desired request rate. ";
-    float delay_pct =
-        ((float)stats.delayed_request_count / stats.request_count) * 100;
     delay_data << delay_pct << "% of the requests were delayed. ";
     delay_data << std::endl;
     std::cout << delay_data.str();

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -657,6 +657,7 @@ class InferenceProfiler {
   bool extra_percentile_;
   size_t percentile_;
   uint64_t latency_threshold_ms_;
+  const float delay_pct_threshold_{1.0};
 
   cb::ProtocolType protocol_;
   std::string model_name_;

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -657,7 +657,6 @@ class InferenceProfiler {
   bool extra_percentile_;
   size_t percentile_;
   uint64_t latency_threshold_ms_;
-  const float delay_pct_threshold_{1.0};
 
   cb::ProtocolType protocol_;
   std::string model_name_;


### PR DESCRIPTION
Updated delayed reporting. 
Now whenever any requests are delayed, the Avg send request rate will be printed along with a warning that includes the percent of requests that were delayed. This should provide more context for users when PA is overloaded.