### PR TITLE
Add testing for json tensor format

### DIFF
--- a/src/c++/CMakeLists.txt
+++ b/src/c++/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -88,6 +88,12 @@ if(TRITON_ENABLE_TESTS OR TRITON_ENABLE_PERF_ANALYZER)
   FetchContent_MakeAvailable(googletest)
 endif()
 FetchContent_MakeAvailable(repo-common)
+
+if(TRITON_ENABLE_TESTS)
+  include_directories(
+    ${repo-common_SOURCE_DIR}/include
+  )
+endif() # TRITON_ENABLE_TESTS
 
 #
 # CUDA

--- a/src/c++/examples/simple_http_string_infer_client.cc
+++ b/src/c++/examples/simple_http_string_infer_client.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -24,6 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <getopt.h>
 #include <unistd.h>
 #include <iostream>
 #include <string>
@@ -75,6 +76,8 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-v" << std::endl;
   std::cerr << "\t-u <URL for inference service>" << std::endl;
   std::cerr << "\t-H <HTTP header>" << std::endl;
+  std::cerr << "\t--json-input-data" << std::endl;
+  std::cerr << "\t--json-output-data" << std::endl;
   std::cerr << std::endl;
   std::cerr
       << "For -H, header must be 'Header:Value'. May be given multiple times."
@@ -91,11 +94,24 @@ main(int argc, char** argv)
   bool verbose = false;
   std::string url("localhost:8000");
   tc::Headers http_headers;
+  bool json_input_data{false};
+  bool json_output_data{false};
+
+  // {name, has_arg, *flag, val}
+  static struct option long_options[] = {{"json-input-data", 0, 0, 0},
+                                         {"json-output-data", 0, 0, 1},
+                                         {0, 0, 0, 0}};
 
   // Parse commandline...
   int opt;
-  while ((opt = getopt(argc, argv, "vu:H:")) != -1) {
+  while ((opt = getopt_long(argc, argv, "vu:H:", long_options, NULL)) != -1) {
     switch (opt) {
+      case 0:
+        json_input_data = true;
+        break;
+      case 1:
+        json_output_data = true;
+        break;
       case 'v':
         verbose = true;
         break;
@@ -154,11 +170,13 @@ main(int argc, char** argv)
       "unable to get INPUT0");
   std::shared_ptr<tc::InferInput> input0_ptr;
   input0_ptr.reset(input0);
+  input0_ptr->SetBinaryData(!json_input_data);
   FAIL_IF_ERR(
       tc::InferInput::Create(&input1, "INPUT1", shape, "BYTES"),
       "unable to get INPUT1");
   std::shared_ptr<tc::InferInput> input1_ptr;
   input1_ptr.reset(input1);
+  input1_ptr->SetBinaryData(!json_input_data);
 
   FAIL_IF_ERR(
       input0_ptr->AppendFromString(input0_data),
@@ -176,11 +194,13 @@ main(int argc, char** argv)
       "unable to get OUTPUT0");
   std::shared_ptr<tc::InferRequestedOutput> output0_ptr;
   output0_ptr.reset(output0);
+  output0_ptr->SetBinaryData(!json_output_data);
   FAIL_IF_ERR(
       tc::InferRequestedOutput::Create(&output1, "OUTPUT1"),
       "unable to get OUTPUT1");
   std::shared_ptr<tc::InferRequestedOutput> output1_ptr;
   output1_ptr.reset(output1);
+  output1_ptr->SetBinaryData(!json_output_data);
 
 
   // The inference settings. Will be using default for now.

--- a/src/c++/library/CMakeLists.txt
+++ b/src/c++/library/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -295,7 +295,7 @@ if(TRITON_ENABLE_CC_HTTP OR TRITON_ENABLE_PERF_ANALYZER)
   target_link_libraries(
       httpclient_static
       PRIVATE triton-common-json
-      PRIVATE CURL::libcurl
+      PUBLIC CURL::libcurl
       PUBLIC Threads::Threads
   )
 
@@ -327,7 +327,7 @@ if(TRITON_ENABLE_CC_HTTP OR TRITON_ENABLE_PERF_ANALYZER)
   target_link_libraries(
       httpclient
       PRIVATE triton-common-json
-      PRIVATE CURL::libcurl
+      PUBLIC CURL::libcurl
       PUBLIC Threads::Threads
   )
 
@@ -351,9 +351,9 @@ if(TRITON_ENABLE_CC_HTTP OR TRITON_ENABLE_PERF_ANALYZER)
       PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<TARGET_PROPERTY:CURL::libcurl,INTERFACE_INCLUDE_DIRECTORIES>
       PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
-        $<TARGET_PROPERTY:CURL::libcurl,INTERFACE_INCLUDE_DIRECTORIES>
     )
 
     target_compile_definitions(

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -26,10 +26,9 @@
 
 // Include this first to make sure we are a friend of common classes.
 #define TRITON_INFERENCE_SERVER_CLIENT_CLASS InferenceServerHttpClient
-#include "http_client.h"
+#include "common.h"
 
 #include <curl/curl.h>
-
 #include <atomic>
 #include <climits>
 #include <cstdint>
@@ -37,8 +36,7 @@
 #include <iostream>
 #include <string>
 #include <utility>
-
-#include "common.h"
+#include "http_client.h"
 
 #ifdef TRITON_ENABLE_ZLIB
 #include <zlib.h>
@@ -2155,9 +2153,9 @@ InferenceServerHttpClient::PreRunProcessing(
 
   struct curl_slist* list = nullptr;
 
-  std::string infer_hdr{
-      std::string(kInferHeaderContentLengthHTTPHeader) + ": " +
-      std::to_string(http_request->request_json_.Size())};
+  std::string infer_hdr{std::string(kInferHeaderContentLengthHTTPHeader) +
+                        ": " +
+                        std::to_string(http_request->request_json_.Size())};
   list = curl_slist_append(list, infer_hdr.c_str());
   list = curl_slist_append(list, "Expect:");
   if (all_inputs_are_json) {

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1259,6 +1259,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
       }
       case 54: {
         params_->serial_sequences = true;
+        break;
       }
       case 55: {
         cb::TensorFormat input_tensor_format{ParseTensorFormat(optarg)};

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -700,6 +700,44 @@ TEST_CASE("Testing Command Line Parser")
   }
 
 
+  SUBCASE("Option : --input-tensor-format")
+  {
+    SUBCASE("binary")
+    {
+      int argc = 5;
+      char* argv[argc] = {
+          app_name, "-m", model_name, "--input-tensor-format", "binary"};
+
+      REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
+      CHECK(!parser.UsageCalled());
+
+      exp->input_tensor_format = cb::TensorFormat::BINARY;
+    }
+    SUBCASE("json")
+    {
+      int argc = 5;
+      char* argv[argc] = {
+          app_name, "-m", model_name, "--input-tensor-format", "json"};
+
+      REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
+      CHECK(!parser.UsageCalled());
+
+      exp->input_tensor_format = cb::TensorFormat::JSON;
+    }
+    SUBCASE("invalid")
+    {
+      int argc = 5;
+      char* argv[argc] = {
+          app_name, "-m", model_name, "--input-tensor-format", "invalid"};
+
+      REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
+      CHECK(parser.UsageCalled());
+
+      exp->input_tensor_format = cb::TensorFormat::UNKNOWN;
+    }
+  }
+
+
   SUBCASE("Option : --shape")
   {
     SUBCASE("expected input, single shape")

--- a/src/c++/perf_analyzer/test_perf_utils.cc
+++ b/src/c++/perf_analyzer/test_perf_utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -102,6 +102,16 @@ TEST_CASE("test_distribution")
       TestPerfUtils::TestDistribution(dist, rate);
     }
   }
+}
+
+TEST_CASE("testing the ParseTensorFormat function")
+{
+  CHECK(ParseTensorFormat("binary") == cb::TensorFormat::BINARY);
+  CHECK(ParseTensorFormat("BINARY") == cb::TensorFormat::BINARY);
+  CHECK(ParseTensorFormat("json") == cb::TensorFormat::JSON);
+  CHECK(ParseTensorFormat("JSON") == cb::TensorFormat::JSON);
+  CHECK(ParseTensorFormat("abc") == cb::TensorFormat::UNKNOWN);
+  CHECK(ParseTensorFormat("") == cb::TensorFormat::UNKNOWN);
 }
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/tests/cc_client_test.cc
+++ b/src/c++/tests/cc_client_test.cc
@@ -1641,7 +1641,7 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputsToJSON)
   // This tests the HttpInferRequest::ConvertBinaryInputsToJSON() function,
   // which basically cycles through all the inputs that added to an InferInput
   // via InferInput::AppendRaw(). This test confirms that an InferInput with two
-  // calls to InferInput::AppendRaw() correclty has all contents from the
+  // calls to InferInput::AppendRaw() correctly has all contents from the
   // AppendRaw() calls correctly converted into a flattened JSON array.
 
   TestHttpInferRequest test_http_infer_request{};
@@ -2078,7 +2078,7 @@ TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
   EXPECT_TRUE(err.IsOk() == true);
   EXPECT_TRUE(buf_size == sizeof(int64_t) * 2);
   EXPECT_TRUE(
-      reinterpret_cast<const int64_t*>(buf)[0] == -9223372036854775808LL);
+      reinterpret_cast<const int64_t*>(buf)[0] == -9223372036854775807L - 1);
   EXPECT_TRUE(
       reinterpret_cast<const int64_t*>(buf)[1] == 9223372036854775807LL);
 

--- a/src/c++/tests/cc_client_test.cc
+++ b/src/c++/tests/cc_client_test.cc
@@ -295,8 +295,6 @@ class GRPCTraceTest : public ::testing::Test {
   std::unique_ptr<tc::InferenceServerGrpcClient> client_;
 };
 
-class HTTPJSONDataTest : public ::testing::Test {};
-
 
 TYPED_TEST_SUITE_P(ClientTest);
 
@@ -1636,8 +1634,16 @@ class TestHttpInferRequest : public tc::HttpInferRequest {
   }
 };
 
+class HTTPJSONDataTest : public ::testing::Test {};
+
 TEST_F(HTTPJSONDataTest, ConvertBinaryInputsToJSON)
 {
+  // This tests the HttpInferRequest::ConvertBinaryInputsToJSON() function,
+  // which basically cycles through all the inputs that added to an InferInput
+  // via InferInput::AppendRaw(). This test confirms that an InferInput with two
+  // calls to InferInput::AppendRaw() correclty has all contents from the
+  // AppendRaw() calls correctly converted into a flattened JSON array.
+
   TestHttpInferRequest test_http_infer_request{};
 
   tc::InferInput* input{};
@@ -1679,6 +1685,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputsToJSON)
 
 TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
 {
+  // This tests the HttpInferRequest::ConvertBinaryInputToJSON() function,
+  // which converts one binary buffer into a corresponding JSON array of
+  // specified data type. This test tests each valid and invalid data type.
+
   TestHttpInferRequest test_http_infer_request{};
   tc::Error err{};
 
@@ -1687,9 +1697,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   std::string datatype{""};
   triton::common::TritonJson::Value data_json{};
 
+  // BOOL
+  datatype = "BOOL";
   std::array<bool, 2> bool_array({false, true});
   buf = reinterpret_cast<const uint8_t*>(bool_array.data());
-  datatype = "BOOL";
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1704,9 +1715,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsBool(1, &bool_value);
   EXPECT_TRUE(bool_value == bool_array[1]);
 
+  // UINT8
+  datatype = "UINT8";
   std::array<uint8_t, 2> uint8_array({1, UINT8_MAX});
   buf = reinterpret_cast<const uint8_t*>(uint8_array.data());
-  datatype = "UINT8";
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1721,9 +1733,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsUInt(1, &uint8_value);
   EXPECT_TRUE(uint8_value == uint8_array[1]);
 
+  // UINT16
+  datatype = "UINT16";
   std::array<uint16_t, 2> uint16_array({1, UINT16_MAX});
   buf = reinterpret_cast<const uint8_t*>(uint16_array.data());
-  datatype = "UINT16";
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1738,9 +1751,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsUInt(1, &uint16_value);
   EXPECT_TRUE(uint16_value == uint16_array[1]);
 
+  // UINT32
+  datatype = "UINT32";
   std::array<uint32_t, 2> uint32_array({1, UINT32_MAX});
   buf = reinterpret_cast<const uint8_t*>(uint32_array.data());
-  datatype = "UINT32";
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1755,9 +1769,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsUInt(1, &uint32_value);
   EXPECT_TRUE(uint32_value == uint32_array[1]);
 
+  // UINT64
+  datatype = "UINT64";
   std::array<uint64_t, 2> uint64_array({1, UINT64_MAX});
   buf = reinterpret_cast<const uint8_t*>(uint64_array.data());
-  datatype = "UINT64";
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1772,9 +1787,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsUInt(1, &uint64_value);
   EXPECT_TRUE(uint64_value == uint64_array[1]);
 
-  std::array<int8_t, 2> int8_array({1, INT8_MAX});
-  buf = reinterpret_cast<const uint8_t*>(int8_array.data());
+  // INT8
   datatype = "INT8";
+  std::array<int8_t, 2> int8_array({INT8_MIN, INT8_MAX});
+  buf = reinterpret_cast<const uint8_t*>(int8_array.data());
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1789,9 +1805,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsInt(1, &int8_value);
   EXPECT_TRUE(int8_value == int8_array[1]);
 
-  std::array<int16_t, 2> int16_array({1, INT16_MAX});
-  buf = reinterpret_cast<const uint8_t*>(int16_array.data());
+  // INT16
   datatype = "INT16";
+  std::array<int16_t, 2> int16_array({INT16_MIN, INT16_MAX});
+  buf = reinterpret_cast<const uint8_t*>(int16_array.data());
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1806,9 +1823,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsInt(1, &int16_value);
   EXPECT_TRUE(int16_value == int16_array[1]);
 
-  std::array<int32_t, 2> int32_array({1, INT32_MAX});
-  buf = reinterpret_cast<const uint8_t*>(int32_array.data());
+  // INT32
   datatype = "INT32";
+  std::array<int32_t, 2> int32_array({INT32_MIN, INT32_MAX});
+  buf = reinterpret_cast<const uint8_t*>(int32_array.data());
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1823,9 +1841,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsInt(1, &int32_value);
   EXPECT_TRUE(int32_value == int32_array[1]);
 
-  std::array<int64_t, 2> int64_array({1, INT64_MAX});
-  buf = reinterpret_cast<const uint8_t*>(int64_array.data());
+  // INT64
   datatype = "INT64";
+  std::array<int64_t, 2> int64_array({INT64_MIN, INT64_MAX});
+  buf = reinterpret_cast<const uint8_t*>(int64_array.data());
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1840,6 +1859,7 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsInt(1, &int64_value);
   EXPECT_TRUE(int64_value == int64_array[1]);
 
+  // FP16 - invalid data type
   datatype = "FP16";
 
   err = test_http_infer_request.ConvertBinaryInputToJSON(
@@ -1847,9 +1867,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
 
   EXPECT_TRUE(err.IsOk() == false);
 
-  std::array<float, 2> fp32_array({1.0, 1000.0});
-  buf = reinterpret_cast<const uint8_t*>(fp32_array.data());
+  // FP32
   datatype = "FP32";
+  std::array<float, 2> fp32_array({-1000.0, 1000.0});
+  buf = reinterpret_cast<const uint8_t*>(fp32_array.data());
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1864,9 +1885,10 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsDouble(1, &fp32_value);
   EXPECT_NEAR(fp32_value, fp32_array[1], 1.0);
 
-  std::array<double, 2> fp64_array({1.0, 1000.0});
-  buf = reinterpret_cast<const uint8_t*>(fp64_array.data());
+  // FP64
   datatype = "FP64";
+  std::array<double, 2> fp64_array({-1000.0, 1000.0});
+  buf = reinterpret_cast<const uint8_t*>(fp64_array.data());
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1881,10 +1903,11 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   data_json.IndexAsDouble(1, &fp64_value);
   EXPECT_NEAR(fp64_value, fp64_array[1], 1.0);
 
+  // BYTES
+  datatype = "BYTES";
   std::array<uint8_t, 12> bytes_array(
       {2, 0, 0, 0, 1, INT8_MAX, 2, 0, 0, 0, 2, INT8_MAX});
   buf = reinterpret_cast<const uint8_t*>(bytes_array.data());
-  datatype = "BYTES";
   data_json = triton::common::TritonJson::Value(
       triton::common::TritonJson::ValueType::ARRAY);
 
@@ -1904,6 +1927,7 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
   EXPECT_TRUE(bytes_value[0] == bytes_array[10]);
   EXPECT_TRUE(bytes_value[1] == bytes_array[11]);
 
+  // BF16 - invalid data type
   datatype = "BF16";
 
   err = test_http_infer_request.ConvertBinaryInputToJSON(
@@ -1911,6 +1935,7 @@ TEST_F(HTTPJSONDataTest, ConvertBinaryInputToJSON)
 
   EXPECT_TRUE(err.IsOk() == false);
 
+  // invaliddatatype - invalid data type
   datatype = "invaliddatatype";
 
   err = test_http_infer_request.ConvertBinaryInputToJSON(
@@ -1934,6 +1959,10 @@ class TestInferResultHttp : public tc::InferResultHttp {
 
 TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
 {
+  // This tests the InferResultHttp::ConvertJSONOutputToBinary() function,
+  // which converts one JSON array into a binary buffer of specified data type.
+  // This test tests each valid and invalid data type.
+
   TestInferResultHttp test_infer_result_http{};
   tc::Error err{};
 
@@ -1942,8 +1971,9 @@ TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
   const uint8_t* buf{nullptr};
   size_t buf_size{0};
 
-  data_json.Parse(R"([false, true])");
+  // BOOL
   datatype = "BOOL";
+  data_json.Parse(R"([false, true])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
@@ -1953,8 +1983,9 @@ TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
   EXPECT_TRUE(reinterpret_cast<const bool*>(buf)[0] == false);
   EXPECT_TRUE(reinterpret_cast<const bool*>(buf)[1] == true);
 
-  data_json.Parse(R"([1, 255])");
+  // UINT8
   datatype = "UINT8";
+  data_json.Parse(R"([1, 255])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
@@ -1964,8 +1995,9 @@ TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
   EXPECT_TRUE(reinterpret_cast<const uint8_t*>(buf)[0] == 1);
   EXPECT_TRUE(reinterpret_cast<const uint8_t*>(buf)[1] == 255);
 
-  data_json.Parse(R"([1, 65535])");
+  // UINT16
   datatype = "UINT16";
+  data_json.Parse(R"([1, 65535])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
@@ -1975,8 +2007,9 @@ TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
   EXPECT_TRUE(reinterpret_cast<const uint16_t*>(buf)[0] == 1);
   EXPECT_TRUE(reinterpret_cast<const uint16_t*>(buf)[1] == 65535);
 
-  data_json.Parse(R"([1, 4294967295])");
+  // UINT32
   datatype = "UINT32";
+  data_json.Parse(R"([1, 4294967295])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
@@ -1986,8 +2019,9 @@ TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
   EXPECT_TRUE(reinterpret_cast<const uint32_t*>(buf)[0] == 1);
   EXPECT_TRUE(reinterpret_cast<const uint32_t*>(buf)[1] == 4294967295);
 
-  data_json.Parse(R"([1, 18446744073709551615])");
+  // UINT64
   datatype = "UINT64";
+  data_json.Parse(R"([1, 18446744073709551615])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
@@ -1998,51 +2032,57 @@ TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
   EXPECT_TRUE(
       reinterpret_cast<const uint64_t*>(buf)[1] == 18446744073709551615ULL);
 
-  data_json.Parse(R"([1, 127])");
+  // INT8
   datatype = "INT8";
+  data_json.Parse(R"([-128, 127])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
 
   EXPECT_TRUE(err.IsOk() == true);
   EXPECT_TRUE(buf_size == sizeof(int8_t) * 2);
-  EXPECT_TRUE(reinterpret_cast<const int8_t*>(buf)[0] == 1);
+  EXPECT_TRUE(reinterpret_cast<const int8_t*>(buf)[0] == -128);
   EXPECT_TRUE(reinterpret_cast<const int8_t*>(buf)[1] == 127);
 
-  data_json.Parse(R"([1, 32767])");
+  // INT16
   datatype = "INT16";
+  data_json.Parse(R"([-32768, 32767])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
 
   EXPECT_TRUE(err.IsOk() == true);
   EXPECT_TRUE(buf_size == sizeof(int16_t) * 2);
-  EXPECT_TRUE(reinterpret_cast<const int16_t*>(buf)[0] == 1);
+  EXPECT_TRUE(reinterpret_cast<const int16_t*>(buf)[0] == -32768);
   EXPECT_TRUE(reinterpret_cast<const int16_t*>(buf)[1] == 32767);
 
-  data_json.Parse(R"([1, 2147483647])");
+  // INT32
   datatype = "INT32";
+  data_json.Parse(R"([-2147483648, 2147483647])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
 
   EXPECT_TRUE(err.IsOk() == true);
   EXPECT_TRUE(buf_size == sizeof(int32_t) * 2);
-  EXPECT_TRUE(reinterpret_cast<const int32_t*>(buf)[0] == 1);
+  EXPECT_TRUE(reinterpret_cast<const int32_t*>(buf)[0] == -2147483648);
   EXPECT_TRUE(reinterpret_cast<const int32_t*>(buf)[1] == 2147483647);
 
-  data_json.Parse(R"([1, 9223372036854775807])");
+  // INT64
   datatype = "INT64";
+  data_json.Parse(R"([-9223372036854775808, 9223372036854775807])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
 
   EXPECT_TRUE(err.IsOk() == true);
   EXPECT_TRUE(buf_size == sizeof(int64_t) * 2);
-  EXPECT_TRUE(reinterpret_cast<const int64_t*>(buf)[0] == 1);
+  EXPECT_TRUE(
+      reinterpret_cast<const int64_t*>(buf)[0] == -9223372036854775808LL);
   EXPECT_TRUE(
       reinterpret_cast<const int64_t*>(buf)[1] == 9223372036854775807LL);
 
+  // FP16 - invalid data type
   datatype = "FP16";
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
@@ -2050,30 +2090,33 @@ TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
 
   EXPECT_TRUE(err.IsOk() == false);
 
-  data_json.Parse(R"([1.0, 1000.0])");
+  // FP32
   datatype = "FP32";
+  data_json.Parse(R"([-1000.0, 1000.0])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
 
   EXPECT_TRUE(err.IsOk() == true);
   EXPECT_TRUE(buf_size == sizeof(float) * 2);
-  EXPECT_NEAR(reinterpret_cast<const float*>(buf)[0], 1.0, 1.0);
+  EXPECT_NEAR(reinterpret_cast<const float*>(buf)[0], -1000.0, 1.0);
   EXPECT_NEAR(reinterpret_cast<const float*>(buf)[1], 1000.0, 1.0);
 
-  data_json.Parse(R"([1.0, 1000.0])");
+  // FP64
   datatype = "FP64";
+  data_json.Parse(R"([-1000.0, 1000.0])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
 
   EXPECT_TRUE(err.IsOk() == true);
   EXPECT_TRUE(buf_size == sizeof(double) * 2);
-  EXPECT_NEAR(reinterpret_cast<const double*>(buf)[0], 1.0, 1.0);
+  EXPECT_NEAR(reinterpret_cast<const double*>(buf)[0], -1000.0, 1.0);
   EXPECT_NEAR(reinterpret_cast<const double*>(buf)[1], 1000.0, 1.0);
 
-  data_json.Parse(R"(["\u0001\u007F", "\u0002\u007F"])");
+  // BYTES
   datatype = "BYTES";
+  data_json.Parse(R"(["\u0001\u007F", "\u0002\u007F"])");
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
       data_json, datatype, &buf, &buf_size);
@@ -2087,6 +2130,7 @@ TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
   EXPECT_TRUE(reinterpret_cast<const uint8_t*>(buf)[10] == 2);
   EXPECT_TRUE(reinterpret_cast<const uint8_t*>(buf)[11] == 127);
 
+  // BF16 - invalid data type
   datatype = "BF16";
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(
@@ -2094,6 +2138,7 @@ TEST_F(HTTPJSONDataTest, ConvertJSONOutputToBinary)
 
   EXPECT_TRUE(err.IsOk() == false);
 
+  // invaliddatatype - invalid data type
   datatype = "invaliddatatype";
 
   err = test_infer_result_http.ConvertJSONOutputToBinary(


### PR DESCRIPTION
* Adds testing for
  * `HttpInferRequest::ConvertBinaryInputsToJSON()`
  * `HttpInferRequest::ConvertBinaryInputToJSON()`
  * `InferResultHttp::ConvertJSONOutputToBinary()`
  * PA `--input-tensor-format` and `--output-tensor-format` CLI options
  * PA perf_utils.cc `ParseTensorFormat()` function
  * Triton Server end-to-end `L0_http` test usage of json tensor format (via adding options to an example executable used in `L0_http`)