### PR TITLE
Test multiple input data

### DIFF
--- a/src/c++/perf_analyzer/data_loader.cc
+++ b/src/c++/perf_analyzer/data_loader.cc
@@ -694,7 +694,7 @@ DataLoader::ValidateTensorDataSize(
 cb::Error
 DataLoader::ValidateParsingMode(const rapidjson::Value& steps)
 {
-  // If our first time parsing data, set the mode
+  // If our first time parsing data, capture the mode
   if (step_num_.size() == 0) {
     multiple_stream_mode_ = steps.IsArray();
   } else {

--- a/src/c++/perf_analyzer/data_loader.cc
+++ b/src/c++/perf_analyzer/data_loader.cc
@@ -221,8 +221,6 @@ DataLoader::ParseData(
         offset = step_num_[0];
         step_num_[0] += (count);
       }
-      // FIXME TMA-1211 At least part of the bug is here. datastream is reset
-      // ignoring previous calls!
       data_stream_cnt_ = 1;
       for (size_t k = offset; k < step_num_[0]; k++) {
         RETURN_IF_ERROR(

--- a/src/c++/perf_analyzer/data_loader.h
+++ b/src/c++/perf_analyzer/data_loader.h
@@ -179,10 +179,14 @@ class DataLoader {
   cb::Error ValidateTensorShape(
       const std::vector<int64_t>& shape, const ModelTensor& model_tensor);
 
+  /// Helper function to validate the provided data's size
   cb::Error ValidateTensorDataSize(
       const std::vector<char>& data, int64_t batch1_byte,
       const ModelTensor& model_tensor);
 
+  /// Helper function to validate consistency of parsing mode for provided input
+  /// data
+  cb::Error ValidateParsingMode(const rapidjson::Value& steps);
 
   // The batch_size_ for the data
   size_t batch_size_{1};
@@ -203,6 +207,9 @@ class DataLoader {
   // Placeholder for generated input data, which will be used for all inputs
   // except string
   std::vector<uint8_t> input_buf_;
+
+  // Tracks what type of input data has been provided
+  bool multiple_stream_mode_ = false;
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend NaggyMockDataLoader;

--- a/src/c++/perf_analyzer/data_loader.h
+++ b/src/c++/perf_analyzer/data_loader.h
@@ -185,7 +185,9 @@ class DataLoader {
       const ModelTensor& model_tensor);
 
   /// Helper function to validate consistency of parsing mode for provided input
-  /// data
+  /// data.  The code explicitly does not support a mixture of objects (multiple
+  /// entries of a single stream) and arrays (multiple streams)
+  ///
   cb::Error ValidateParsingMode(const rapidjson::Value& steps);
 
   // The batch_size_ for the data

--- a/src/c++/perf_analyzer/data_loader.h
+++ b/src/c++/perf_analyzer/data_loader.h
@@ -176,10 +176,17 @@ class DataLoader {
       const int step_index);
 
   /// Helper function to validate the provided shape for a tensor
+  /// \param shape Shape for the tensor
+  /// \param model_tensor The tensor to validate
+  /// Returns error object indicating status
   cb::Error ValidateTensorShape(
       const std::vector<int64_t>& shape, const ModelTensor& model_tensor);
 
   /// Helper function to validate the provided data's size
+  /// \param data The provided data for the tensor
+  /// \param batch1_byte The expected number of bytes of data
+  /// \param model_tensor The tensor to validate
+  /// Returns error object indicating status
   cb::Error ValidateTensorDataSize(
       const std::vector<char>& data, int64_t batch1_byte,
       const ModelTensor& model_tensor);
@@ -188,6 +195,7 @@ class DataLoader {
   /// data.  The code explicitly does not support a mixture of objects (multiple
   /// entries of a single stream) and arrays (multiple streams)
   ///
+  /// \param steps The json data provided for one or multiple streams
   cb::Error ValidateParsingMode(const rapidjson::Value& steps);
 
   // The batch_size_ for the data

--- a/src/c++/perf_analyzer/test_dataloader.cc
+++ b/src/c++/perf_analyzer/test_dataloader.cc
@@ -912,7 +912,10 @@ TEST_CASE(
   REQUIRE(status.IsOk());
   status = dataloader.ReadDataFromStr(json_str2, inputs, outputs);
   REQUIRE(!status.IsOk());
-  // FIXME msg
+  CHECK(
+      status.Message() ==
+      "Inconsistency in input-data provided. Can not have a combination of "
+      "objects and arrays inside of the Data array");
 }
 
 TEST_CASE(


### PR DESCRIPTION
Multiple input-data files can be supplied to PA. This is legal, but bad things happen if there is a mixture of objects (single-stream) and arrays (multi-stream).  This PR explicitly tests the cases of all-objects and all-arrays, and also explicitly fails on a mixture of the two.