### PR TITLE
Clean up dataloader functions

### DIFF
--- a/src/c++/perf_analyzer/data_loader.cc
+++ b/src/c++/perf_analyzer/data_loader.cc
@@ -323,7 +323,7 @@ DataLoader::GenerateData(
 cb::Error
 DataLoader::GetInputData(
     const ModelTensor& input, const int stream_id, const int step_id,
-    DataLoaderData& data)
+    TensorData& data)
 {
   data.data_ptr = nullptr;
   data.batch1_size = 0;
@@ -379,7 +379,7 @@ DataLoader::GetInputData(
 cb::Error
 DataLoader::GetOutputData(
     const std::string& output_name, const int stream_id, const int step_id,
-    DataLoaderData& data)
+    TensorData& data)
 {
   data.data_ptr = nullptr;
   data.batch1_size = 0;

--- a/src/c++/perf_analyzer/data_loader.cc
+++ b/src/c++/perf_analyzer/data_loader.cc
@@ -336,20 +336,14 @@ DataLoader::GetInputData(
     std::string key_name(
         input.name_ + "_" + std::to_string(stream_id) + "_" +
         std::to_string(step_id));
+
     // Get the data and the corresponding byte-size
     auto it = input_data_.find(key_name);
     if (it != input_data_.end()) {
+      std::vector<char>* data_vec = &it->second;
       data.is_valid = true;
-
-      if (input.datatype_.compare("BYTES") != 0) {
-        data.batch1_size = it->second.size();
-      } else {
-        std::vector<char>* string_data;
-        string_data = &it->second;
-        data.batch1_size = string_data->size();
-      }
-
-      data.data_ptr = (const uint8_t*)&((it->second)[0]);
+      data.batch1_size = data_vec->size();
+      data.data_ptr = (const uint8_t*)data_vec->data();
     }
   }
 
@@ -395,9 +389,10 @@ DataLoader::GetOutputData(
     // Get the data and the corresponding byte-size
     auto it = output_data_.find(key_name);
     if (it != output_data_.end()) {
-      data.batch1_size = it->second.size();
-      data.data_ptr = (const uint8_t*)&((it->second)[0]);
+      std::vector<char>* data_vec = &it->second;
       data.is_valid = true;
+      data.batch1_size = data_vec->size();
+      data.data_ptr = (const uint8_t*)data_vec->data();
     }
   }
   return cb::Error::Success;

--- a/src/c++/perf_analyzer/data_loader.h
+++ b/src/c++/perf_analyzer/data_loader.h
@@ -36,6 +36,15 @@ namespace triton { namespace perfanalyzer {
 class NaggyMockDataLoader;
 #endif
 
+/// Data for one input or output tensor
+///
+struct DataLoaderData {
+  const uint8_t* data_ptr{nullptr};
+  size_t batch1_size{0};
+  bool is_valid{false};
+};
+
+
 class DataLoader {
  public:
   DataLoader(size_t batch_size);
@@ -92,13 +101,11 @@ class DataLoader {
   /// \param input The target model input tensor
   /// \param stream_id The data stream_id to use for retrieving input data.
   /// \param step_id The data step_id to use for retrieving input data.
-  /// \param data Returns the pointer to the data for the requested input. Will
-  /// be nullptr if the data is not found.
-  /// \param batch1_size Returns the size of the input data in bytes.
+  /// \param data Returns the input DataLoaderData
   /// Returns error object indicating status
   cb::Error GetInputData(
       const ModelTensor& input, const int stream_id, const int step_id,
-      const uint8_t** data_ptr, size_t* batch1_size);
+      DataLoaderData& data);
 
   /// Helper function to get the shape values to the input
   /// \param input The target model input tensor
@@ -116,12 +123,11 @@ class DataLoader {
   /// \param output_name The name of the output tensor
   /// \param stream_id The data stream_id to use for retrieving output data.
   /// \param step_id The data step_id to use for retrieving output data.
-  /// \param data Returns the pointer to the data for the requested output.
-  /// \param batch1_size Returns the size of the output data in bytes.
+  /// \param data Returns the output DataLoaderData
   /// Returns error object indicating status
   cb::Error GetOutputData(
       const std::string& output_name, const int stream_id, const int step_id,
-      const uint8_t** data_ptr, size_t* batch1_size);
+      DataLoaderData& data);
 
   /// Return an error if the stream index or step index are invalid
   cb::Error ValidateIndexes(int stream_index, int step_index);

--- a/src/c++/perf_analyzer/data_loader.h
+++ b/src/c++/perf_analyzer/data_loader.h
@@ -38,7 +38,7 @@ class NaggyMockDataLoader;
 
 /// Data for one input or output tensor
 ///
-struct DataLoaderData {
+struct TensorData {
   const uint8_t* data_ptr{nullptr};
   size_t batch1_size{0};
   bool is_valid{false};
@@ -101,11 +101,11 @@ class DataLoader {
   /// \param input The target model input tensor
   /// \param stream_id The data stream_id to use for retrieving input data.
   /// \param step_id The data step_id to use for retrieving input data.
-  /// \param data Returns the input DataLoaderData
+  /// \param data Returns the input TensorData
   /// Returns error object indicating status
   cb::Error GetInputData(
       const ModelTensor& input, const int stream_id, const int step_id,
-      DataLoaderData& data);
+      TensorData& data);
 
   /// Helper function to get the shape values to the input
   /// \param input The target model input tensor
@@ -123,11 +123,11 @@ class DataLoader {
   /// \param output_name The name of the output tensor
   /// \param stream_id The data stream_id to use for retrieving output data.
   /// \param step_id The data step_id to use for retrieving output data.
-  /// \param data Returns the output DataLoaderData
+  /// \param data Returns the output TensorData
   /// Returns error object indicating status
   cb::Error GetOutputData(
       const std::string& output_name, const int stream_id, const int step_id,
-      DataLoaderData& data);
+      TensorData& data);
 
   /// Return an error if the stream index or step index are invalid
   cb::Error ValidateIndexes(int stream_index, int step_index);

--- a/src/c++/perf_analyzer/data_loader.h
+++ b/src/c++/perf_analyzer/data_loader.h
@@ -29,20 +29,13 @@
 
 #include "model_parser.h"
 #include "perf_utils.h"
+#include "tensor_data.h"
 
 namespace triton { namespace perfanalyzer {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 class NaggyMockDataLoader;
 #endif
-
-/// Data for one input or output tensor
-///
-struct TensorData {
-  const uint8_t* data_ptr{nullptr};
-  size_t batch1_size{0};
-  bool is_valid{false};
-};
 
 
 class DataLoader {

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -207,7 +207,8 @@ InferContext::ValidateOutputs(const cb::InferResult* result_ptr)
       result_ptr->RawData(infer_data_.outputs_[i]->Name(), &buf, &byte_size);
       for (const auto& expected : infer_data_.expected_outputs_[i]) {
         if (!expected.is_valid) {
-          continue;
+          return cb::Error(
+              "Expected output can't be invalid", pa::GENERIC_ERROR);
         }
         if (byte_size < expected.batch1_size) {
           return cb::Error(

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -206,6 +206,9 @@ InferContext::ValidateOutputs(const cb::InferResult* result_ptr)
       size_t byte_size = 0;
       result_ptr->RawData(infer_data_.outputs_[i]->Name(), &buf, &byte_size);
       for (const auto& expected : infer_data_.expected_outputs_[i]) {
+        if (!expected.is_valid) {
+          continue;
+        }
         if (byte_size < expected.batch1_size) {
           return cb::Error(
               "Output size doesn't match expected size", pa::GENERIC_ERROR);

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -206,15 +206,15 @@ InferContext::ValidateOutputs(const cb::InferResult* result_ptr)
       size_t byte_size = 0;
       result_ptr->RawData(infer_data_.outputs_[i]->Name(), &buf, &byte_size);
       for (const auto& expected : infer_data_.expected_outputs_[i]) {
-        if (byte_size < expected.second) {
+        if (byte_size < expected.batch1_size) {
           return cb::Error(
               "Output size doesn't match expected size", pa::GENERIC_ERROR);
-        } else if (memcmp(buf, expected.first, expected.second) != 0) {
+        } else if (memcmp(buf, expected.data_ptr, expected.batch1_size) != 0) {
           return cb::Error(
               "Output doesn't match expected output", pa::GENERIC_ERROR);
         } else {
-          buf += expected.second;
-          byte_size -= expected.second;
+          buf += expected.batch1_size;
+          byte_size -= expected.batch1_size;
         }
       }
       if (byte_size != 0) {

--- a/src/c++/perf_analyzer/infer_data.h
+++ b/src/c++/perf_analyzer/infer_data.h
@@ -51,7 +51,9 @@ struct InferData {
   // to be used with the inference request.
   std::vector<const cb::InferRequestedOutput*> outputs_;
   // If not empty, the expected output data in the same order as 'outputs_'
-  std::vector<std::vector<std::pair<const uint8_t*, size_t>>> expected_outputs_;
+  // The outer vector is per-output. The inner vector is for batching of each
+  // output
+  std::vector<std::vector<TensorData>> expected_outputs_;
   // The InferOptions object holding the details of the
   // inference.
   std::unique_ptr<cb::InferOptions> options_;

--- a/src/c++/perf_analyzer/infer_data_manager.cc
+++ b/src/c++/perf_analyzer/infer_data_manager.cc
@@ -65,7 +65,7 @@ InferDataManager::CreateAndPopulateInput(
     const size_t thread_id, const std::string& name, const ModelTensor& tensor,
     int stream_id, int step_id)
 {
-  std::vector<DataLoaderData> input_datas;
+  std::vector<TensorData> input_datas;
   size_t count = 0;
 
   RETURN_IF_ERROR(GetInputData(name, tensor, stream_id, step_id, input_datas));
@@ -152,7 +152,7 @@ InferDataManager::InitInferDataInput(
   infer_data.inputs_.push_back(infer_input);
 
 
-  DataLoaderData input_data;
+  TensorData input_data;
   RETURN_IF_ERROR(data_loader_->GetInputData(model_tensor, 0, 0, input_data));
 
   // Add optional input to request if data was found

--- a/src/c++/perf_analyzer/infer_data_manager.cc
+++ b/src/c++/perf_analyzer/infer_data_manager.cc
@@ -65,16 +65,14 @@ InferDataManager::CreateAndPopulateInput(
     const size_t thread_id, const std::string& name, const ModelTensor& tensor,
     int stream_id, int step_id)
 {
-  std::vector<const uint8_t*> data_ptrs;
-  std::vector<size_t> byte_size;
+  std::vector<DataLoaderData> input_datas;
   size_t count = 0;
 
-  RETURN_IF_ERROR(
-      GetInputData(name, tensor, stream_id, step_id, data_ptrs, byte_size));
+  RETURN_IF_ERROR(GetInputData(name, tensor, stream_id, step_id, input_datas));
 
   if (tensor.is_shape_tensor_) {
     RETURN_IF_ERROR(
-        ValidateShapeTensor(tensor, stream_id, step_id, data_ptrs, byte_size));
+        ValidateShapeTensor(tensor, stream_id, step_id, input_datas));
   }
 
   std::vector<int64_t> shape;
@@ -93,13 +91,14 @@ InferDataManager::CreateAndPopulateInput(
 
   // Number of missing pieces of data for optional inputs
   int missing_data_cnt = 0;
-  int total_cnt = data_ptrs.size();
+  int total_cnt = input_datas.size();
 
   for (size_t i = 0; i < total_cnt; i++) {
-    if (data_ptrs[i] == nullptr) {
+    if (!input_datas[i].is_valid) {
       missing_data_cnt++;
     } else {
-      RETURN_IF_ERROR(input->AppendRaw(data_ptrs[i], byte_size[i]));
+      RETURN_IF_ERROR(input->AppendRaw(
+          input_datas[i].data_ptr, input_datas[i].batch1_size));
     }
   }
 
@@ -153,20 +152,19 @@ InferDataManager::InitInferDataInput(
   infer_data.inputs_.push_back(infer_input);
 
 
-  const uint8_t* data_ptr{nullptr};
-  size_t batch1_bytesize;
-  RETURN_IF_ERROR(data_loader_->GetInputData(
-      model_tensor, 0, 0, &data_ptr, &batch1_bytesize));
+  DataLoaderData input_data;
+  RETURN_IF_ERROR(data_loader_->GetInputData(model_tensor, 0, 0, input_data));
 
   // Add optional input to request if data was found
-  if (data_ptr != nullptr) {
+  if (input_data.is_valid) {
     infer_data.valid_inputs_.push_back(infer_input);
   }
 
   if (!shape.empty()) {
     size_t max_count = (parser_->MaxBatchSize() == 0) ? 1 : batch_size_;
     for (size_t i = 0; i < max_count; ++i) {
-      RETURN_IF_ERROR(infer_input->AppendRaw(data_ptr, batch1_bytesize));
+      RETURN_IF_ERROR(
+          infer_input->AppendRaw(input_data.data_ptr, input_data.batch1_size));
     }
   }
   return cb::Error::Success;

--- a/src/c++/perf_analyzer/infer_data_manager_base.cc
+++ b/src/c++/perf_analyzer/infer_data_manager_base.cc
@@ -148,7 +148,7 @@ InferDataManagerBase::UpdateValidationOutputs(
     const int* set_shape_values = nullptr;
     int set_shape_value_cnt = 0;
 
-    std::vector<std::pair<const uint8_t*, size_t>> outputs;
+    std::vector<TensorData> outputs;
     for (size_t i = 0; i < batch_size_; ++i) {
       RETURN_IF_ERROR(data_loader_->GetOutputData(
           output->Name(), stream_index,
@@ -157,7 +157,7 @@ InferDataManagerBase::UpdateValidationOutputs(
         break;
       }
 
-      outputs.emplace_back(output_data.data_ptr, output_data.batch1_size);
+      outputs.emplace_back(output_data);
       // Shape tensor only need the first batch element
       if (model_output.is_shape_tensor_) {
         break;

--- a/src/c++/perf_analyzer/infer_data_manager_base.cc
+++ b/src/c++/perf_analyzer/infer_data_manager_base.cc
@@ -33,7 +33,7 @@ namespace triton { namespace perfanalyzer {
 cb::Error
 InferDataManagerBase::GetInputData(
     const std::string& name, const ModelTensor& tensor, int stream_id,
-    int step_id, std::vector<DataLoaderData>& input_datas)
+    int step_id, std::vector<TensorData>& input_datas)
 {
   size_t max_count = tensor.is_shape_tensor_ ? 1 : batch_size_;
   std::vector<int64_t> shape;
@@ -43,7 +43,7 @@ InferDataManagerBase::GetInputData(
     int local_step_id =
         (step_id + count) % data_loader_->GetTotalSteps(stream_id);
 
-    DataLoaderData input_data;
+    TensorData input_data;
 
     RETURN_IF_ERROR(
         data_loader_->GetInputShape(tensor, stream_id, local_step_id, &shape));
@@ -74,7 +74,7 @@ InferDataManagerBase::GetInputData(
 cb::Error
 InferDataManagerBase::ValidateShapeTensor(
     const ModelTensor& tensor, int stream_id, int step_id,
-    const std::vector<DataLoaderData>& input_datas)
+    const std::vector<TensorData>& input_datas)
 {
   // Validate that steps 1 through N are exactly the same as step 0, since step
   // 0 is the only one we send for shape tensors
@@ -82,7 +82,7 @@ InferDataManagerBase::ValidateShapeTensor(
     int local_step_id =
         (step_id + count) % data_loader_->GetTotalSteps(stream_id);
 
-    DataLoaderData input_data;
+    TensorData input_data;
     RETURN_IF_ERROR(data_loader_->GetInputData(
         tensor, stream_id, local_step_id, input_data));
 
@@ -144,7 +144,7 @@ InferDataManagerBase::UpdateValidationOutputs(
   for (const auto& output : infer_data.outputs_) {
     const auto& model_output = (*(parser_->Outputs()))[output->Name()];
 
-    DataLoaderData output_data;
+    TensorData output_data;
     const int* set_shape_values = nullptr;
     int set_shape_value_cnt = 0;
 

--- a/src/c++/perf_analyzer/infer_data_manager_base.cc
+++ b/src/c++/perf_analyzer/infer_data_manager_base.cc
@@ -33,8 +33,7 @@ namespace triton { namespace perfanalyzer {
 cb::Error
 InferDataManagerBase::GetInputData(
     const std::string& name, const ModelTensor& tensor, int stream_id,
-    int step_id, std::vector<const uint8_t*>& data_ptrs,
-    std::vector<size_t>& byte_size)
+    int step_id, std::vector<DataLoaderData>& input_datas)
 {
   size_t max_count = tensor.is_shape_tensor_ ? 1 : batch_size_;
   std::vector<int64_t> shape;
@@ -43,8 +42,8 @@ InferDataManagerBase::GetInputData(
   for (size_t count = 0; count < max_count; count++) {
     int local_step_id =
         (step_id + count) % data_loader_->GetTotalSteps(stream_id);
-    const uint8_t* data_ptr{nullptr};
-    size_t batch1_bytesize;
+
+    DataLoaderData input_data;
 
     RETURN_IF_ERROR(
         data_loader_->GetInputShape(tensor, stream_id, local_step_id, &shape));
@@ -64,10 +63,9 @@ InferDataManagerBase::GetInputData(
     }
 
     RETURN_IF_ERROR(data_loader_->GetInputData(
-        tensor, stream_id, local_step_id, &data_ptr, &batch1_bytesize));
+        tensor, stream_id, local_step_id, input_data));
 
-    data_ptrs.push_back(data_ptr);
-    byte_size.push_back(batch1_bytesize);
+    input_datas.push_back(input_data);
   }
 
   return cb::Error::Success;
@@ -76,8 +74,7 @@ InferDataManagerBase::GetInputData(
 cb::Error
 InferDataManagerBase::ValidateShapeTensor(
     const ModelTensor& tensor, int stream_id, int step_id,
-    const std::vector<const uint8_t*>& data_ptrs,
-    const std::vector<size_t>& byte_size)
+    const std::vector<DataLoaderData>& input_datas)
 {
   // Validate that steps 1 through N are exactly the same as step 0, since step
   // 0 is the only one we send for shape tensors
@@ -85,20 +82,20 @@ InferDataManagerBase::ValidateShapeTensor(
     int local_step_id =
         (step_id + count) % data_loader_->GetTotalSteps(stream_id);
 
-    const uint8_t* data_ptr{nullptr};
-    size_t batch1_bytesize;
+    DataLoaderData input_data;
     RETURN_IF_ERROR(data_loader_->GetInputData(
-        tensor, stream_id, local_step_id, &data_ptr, &batch1_bytesize));
+        tensor, stream_id, local_step_id, input_data));
 
-    if (batch1_bytesize != byte_size.back()) {
+    if (input_data.batch1_size != input_datas.back().batch1_size) {
       return cb::Error(
           "The shape tensors should be identical in a batch (mismatch "
           "in size)",
           pa::GENERIC_ERROR);
     }
 
-    for (size_t data_idx = 0; data_idx < batch1_bytesize; data_idx++) {
-      if (*(data_ptr + data_idx) != *(data_ptrs.back() + data_idx)) {
+    for (size_t data_idx = 0; data_idx < input_data.batch1_size; data_idx++) {
+      if (*(input_data.data_ptr + data_idx) !=
+          *(input_datas.back().data_ptr + data_idx)) {
         return cb::Error(
             "The shape tensors should be identical in a batch "
             "(mismatch in content)",
@@ -146,28 +143,28 @@ InferDataManagerBase::UpdateValidationOutputs(
 
   for (const auto& output : infer_data.outputs_) {
     const auto& model_output = (*(parser_->Outputs()))[output->Name()];
-    const uint8_t* data_ptr;
-    size_t batch1_bytesize;
+
+    DataLoaderData output_data;
     const int* set_shape_values = nullptr;
     int set_shape_value_cnt = 0;
 
-    std::vector<std::pair<const uint8_t*, size_t>> output_data;
+    std::vector<std::pair<const uint8_t*, size_t>> outputs;
     for (size_t i = 0; i < batch_size_; ++i) {
       RETURN_IF_ERROR(data_loader_->GetOutputData(
           output->Name(), stream_index,
-          (step_index + i) % data_loader_->GetTotalSteps(0), &data_ptr,
-          &batch1_bytesize));
-      if (data_ptr == nullptr) {
+          (step_index + i) % data_loader_->GetTotalSteps(0), output_data));
+      if (!output_data.is_valid) {
         break;
       }
-      output_data.emplace_back(data_ptr, batch1_bytesize);
+
+      outputs.emplace_back(output_data.data_ptr, output_data.batch1_size);
       // Shape tensor only need the first batch element
       if (model_output.is_shape_tensor_) {
         break;
       }
     }
-    if (!output_data.empty()) {
-      infer_data.expected_outputs_.emplace_back(std::move(output_data));
+    if (!outputs.empty()) {
+      infer_data.expected_outputs_.emplace_back(std::move(outputs));
     }
   }
   return cb::Error::Success;

--- a/src/c++/perf_analyzer/infer_data_manager_base.h
+++ b/src/c++/perf_analyzer/infer_data_manager_base.h
@@ -73,7 +73,7 @@ class InferDataManagerBase : public IInferDataManager {
   std::unique_ptr<cb::ClientBackend> backend_;
   cb::BackendKind backend_kind_;
 
-  /// Gets the input datas for the specified input for the specified batch size
+  /// Gets the input data for the specified input for the specified batch size
   ///
   /// \param name The name of the input to get data for
   /// \param tensor The ModelTensor of the input to get data for

--- a/src/c++/perf_analyzer/infer_data_manager_base.h
+++ b/src/c++/perf_analyzer/infer_data_manager_base.h
@@ -32,6 +32,7 @@
 #include "infer_data.h"
 #include "model_parser.h"
 #include "perf_utils.h"
+#include "tensor_data.h"
 
 namespace triton { namespace perfanalyzer {
 

--- a/src/c++/perf_analyzer/infer_data_manager_base.h
+++ b/src/c++/perf_analyzer/infer_data_manager_base.h
@@ -72,33 +72,28 @@ class InferDataManagerBase : public IInferDataManager {
   std::unique_ptr<cb::ClientBackend> backend_;
   cb::BackendKind backend_kind_;
 
-  /// Gets the input data for the specified Input at the specified stream_id +
-  /// step_id combination, and adds it to data_ptrs. The byte size of the data
-  /// is added to byte_size.
+  /// Gets the input datas for the specified input for the specified batch size
+  ///
   /// \param name The name of the input to get data for
   /// \param tensor The ModelTensor of the input to get data for
   /// \param stream_id The ID of the stream to get data for
   /// \param step_id The ID of the step within the stream
-  /// \param data_ptrs Pointer to the data for the batch
-  /// \param byte_size Size of the input data
+  /// \param input_datas The returned vector of DataLoaderDatas
   /// \return cb::Error object indicating success or failure.
   cb::Error GetInputData(
       const std::string& name, const ModelTensor& tensor, int stream_id,
-      int step_id, std::vector<const uint8_t*>& data_ptrs,
-      std::vector<size_t>& byte_size);
+      int step_id, std::vector<DataLoaderData>& input_datas);
 
   /// For the case of an input with is_shape_tensor true, validate that
   /// it follows all rules, and throw an error if it does not
   /// \param tensor The ModelTensor of the input to validate
   /// \param stream_id The ID of the stream to validate
   /// \param step_id The ID of the step within the stream
-  /// \param data_ptrs Pointer to the data for the batch
-  /// \param byte_size Size of the input data
+  /// \param input_datas vector of DataLoaderDatas to validate
   /// \return cb::Error object indicating success or failure.
   cb::Error ValidateShapeTensor(
       const ModelTensor& tensor, int stream_id, int step_id,
-      const std::vector<const uint8_t*>& data_ptrs,
-      const std::vector<size_t>& byte_size);
+      const std::vector<DataLoaderData>& input_datas);
 
   /// Helper function to update the inputs
   /// \param thread_id The ID of the calling thread

--- a/src/c++/perf_analyzer/infer_data_manager_base.h
+++ b/src/c++/perf_analyzer/infer_data_manager_base.h
@@ -78,22 +78,22 @@ class InferDataManagerBase : public IInferDataManager {
   /// \param tensor The ModelTensor of the input to get data for
   /// \param stream_id The ID of the stream to get data for
   /// \param step_id The ID of the step within the stream
-  /// \param input_datas The returned vector of DataLoaderDatas
+  /// \param input_datas The returned vector of TensorDatas
   /// \return cb::Error object indicating success or failure.
   cb::Error GetInputData(
       const std::string& name, const ModelTensor& tensor, int stream_id,
-      int step_id, std::vector<DataLoaderData>& input_datas);
+      int step_id, std::vector<TensorData>& input_datas);
 
   /// For the case of an input with is_shape_tensor true, validate that
   /// it follows all rules, and throw an error if it does not
   /// \param tensor The ModelTensor of the input to validate
   /// \param stream_id The ID of the stream to validate
   /// \param step_id The ID of the step within the stream
-  /// \param input_datas vector of DataLoaderDatas to validate
+  /// \param input_datas vector of TensorDatas to validate
   /// \return cb::Error object indicating success or failure.
   cb::Error ValidateShapeTensor(
       const ModelTensor& tensor, int stream_id, int step_id,
-      const std::vector<DataLoaderData>& input_datas);
+      const std::vector<TensorData>& input_datas);
 
   /// Helper function to update the inputs
   /// \param thread_id The ID of the calling thread

--- a/src/c++/perf_analyzer/infer_data_manager_shm.cc
+++ b/src/c++/perf_analyzer/infer_data_manager_shm.cc
@@ -262,7 +262,7 @@ InferDataManagerShm::CreateMemoryRegion(
 
 cb::Error
 InferDataManagerShm::CopySharedMemory(
-    uint8_t* input_shm_ptr, const std::vector<TensorData>& datas,
+    uint8_t* input_shm_ptr, const std::vector<TensorData>& tensor_datas,
     bool is_shape_tensor, std::string& region_name)
 {
   if (shared_memory_type_ == SharedMemoryType::SYSTEM_SHARED_MEMORY) {
@@ -272,9 +272,9 @@ InferDataManagerShm::CopySharedMemory(
     size_t max_count = is_shape_tensor ? 1 : batch_size_;
     while (count < max_count) {
       memcpy(
-          input_shm_ptr + offset, datas[count].data_ptr,
-          datas[count].batch1_size);
-      offset += datas[count].batch1_size;
+          input_shm_ptr + offset, tensor_datas[count].data_ptr,
+          tensor_datas[count].batch1_size);
+      offset += tensor_datas[count].batch1_size;
       count++;
     }
   } else {
@@ -285,15 +285,15 @@ InferDataManagerShm::CopySharedMemory(
     size_t max_count = is_shape_tensor ? 1 : batch_size_;
     while (count < max_count) {
       cudaError_t cuda_err = cudaMemcpy(
-          (void*)(input_shm_ptr + offset), (void*)datas[count].data_ptr,
-          datas[count].batch1_size, cudaMemcpyHostToDevice);
+          (void*)(input_shm_ptr + offset), (void*)tensor_datas[count].data_ptr,
+          tensor_datas[count].batch1_size, cudaMemcpyHostToDevice);
       if (cuda_err != cudaSuccess) {
         return cb::Error(
             "Failed to copy data to cuda shared memory for " + region_name +
                 " : " + std::string(cudaGetErrorString(cuda_err)),
             pa::GENERIC_ERROR);
       }
-      offset += datas[count].batch1_size;
+      offset += tensor_datas[count].batch1_size;
       count++;
     }
 #endif  // TRITON_ENABLE_GPU

--- a/src/c++/perf_analyzer/infer_data_manager_shm.cc
+++ b/src/c++/perf_analyzer/infer_data_manager_shm.cc
@@ -128,7 +128,7 @@ InferDataManagerShm::CreateAndPopulateInputMemoryRegion(
     const std::string& name, const ModelTensor& tensor, int stream_id,
     int step_id)
 {
-  std::vector<DataLoaderData> input_datas;
+  std::vector<TensorData> input_datas;
   size_t count = 0;
 
   RETURN_IF_ERROR(GetInputData(name, tensor, stream_id, step_id, input_datas));
@@ -262,7 +262,7 @@ InferDataManagerShm::CreateMemoryRegion(
 
 cb::Error
 InferDataManagerShm::CopySharedMemory(
-    uint8_t* input_shm_ptr, const std::vector<DataLoaderData>& datas,
+    uint8_t* input_shm_ptr, const std::vector<TensorData>& datas,
     bool is_shape_tensor, std::string& region_name)
 {
   if (shared_memory_type_ == SharedMemoryType::SYSTEM_SHARED_MEMORY) {

--- a/src/c++/perf_analyzer/infer_data_manager_shm.h
+++ b/src/c++/perf_analyzer/infer_data_manager_shm.h
@@ -125,15 +125,13 @@ class InferDataManagerShm : public InferDataManagerBase {
   /// \brief Helper function to handle copying shared memory to the correct
   /// memory region
   /// \param input_shm_ptr Pointer to the shared memory for a specific input
-  /// \param data_ptrs Pointer to the data for the batch
-  /// \param byte_size Size of the data being copied
+  /// \param input_datas The DataLoaderDatas to be copied
   /// \param is_shape_tensor Is the input a shape tensor
   /// \param region_name Name of the shared memory region
   /// \return cb::Error object indicating success or failure
   virtual cb::Error CopySharedMemory(
-      uint8_t* input_shm_ptr, std::vector<const uint8_t*>& data_ptrs,
-      std::vector<size_t>& byte_size, bool is_shape_tensor,
-      std::string& region_name);
+      uint8_t* input_shm_ptr, const std::vector<DataLoaderData>& input_datas,
+      bool is_shape_tensor, std::string& region_name);
 
   cb::Error InitInferDataInput(
       const std::string& name, const ModelTensor& model_tensor,

--- a/src/c++/perf_analyzer/infer_data_manager_shm.h
+++ b/src/c++/perf_analyzer/infer_data_manager_shm.h
@@ -125,12 +125,12 @@ class InferDataManagerShm : public InferDataManagerBase {
   /// \brief Helper function to handle copying shared memory to the correct
   /// memory region
   /// \param input_shm_ptr Pointer to the shared memory for a specific input
-  /// \param input_datas The DataLoaderDatas to be copied
+  /// \param input_datas The TensorDatas to be copied
   /// \param is_shape_tensor Is the input a shape tensor
   /// \param region_name Name of the shared memory region
   /// \return cb::Error object indicating success or failure
   virtual cb::Error CopySharedMemory(
-      uint8_t* input_shm_ptr, const std::vector<DataLoaderData>& input_datas,
+      uint8_t* input_shm_ptr, const std::vector<TensorData>& input_datas,
       bool is_shape_tensor, std::string& region_name);
 
   cb::Error InitInferDataInput(

--- a/src/c++/perf_analyzer/mock_infer_data_manager.h
+++ b/src/c++/perf_analyzer/mock_infer_data_manager.h
@@ -50,14 +50,13 @@ class MockInferDataManagerShm : public InferDataManagerShm {
   // Tracks the mapping of shared memory label to data
   //
   cb::Error CopySharedMemory(
-      uint8_t* input_shm_ptr, std::vector<const uint8_t*>& data_ptrs,
-      std::vector<size_t>& byte_size, bool is_shape_tensor,
-      std::string& region_name) override
+      uint8_t* input_shm_ptr, const std::vector<DataLoaderData>& input_datas,
+      bool is_shape_tensor, std::string& region_name) override
   {
     std::vector<int32_t> vals;
 
-    for (size_t i = 0; i < data_ptrs.size(); i++) {
-      int32_t val = *reinterpret_cast<const int32_t*>(data_ptrs[i]);
+    for (size_t i = 0; i < input_datas.size(); i++) {
+      int32_t val = *reinterpret_cast<const int32_t*>(input_datas[i].data_ptr);
       vals.push_back(val);
     }
     mocked_shared_memory_regions.insert(std::make_pair(region_name, vals));

--- a/src/c++/perf_analyzer/mock_infer_data_manager.h
+++ b/src/c++/perf_analyzer/mock_infer_data_manager.h
@@ -50,7 +50,7 @@ class MockInferDataManagerShm : public InferDataManagerShm {
   // Tracks the mapping of shared memory label to data
   //
   cb::Error CopySharedMemory(
-      uint8_t* input_shm_ptr, const std::vector<DataLoaderData>& input_datas,
+      uint8_t* input_shm_ptr, const std::vector<TensorData>& input_datas,
       bool is_shape_tensor, std::string& region_name) override
   {
     std::vector<int32_t> vals;

--- a/src/c++/perf_analyzer/tensor_data.h
+++ b/src/c++/perf_analyzer/tensor_data.h
@@ -25,39 +25,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include "client_backend/client_backend.h"
-#include "tensor_data.h"
-
 namespace triton { namespace perfanalyzer {
 
-/// Holds all the data needed to send an inference request
-struct InferData {
-  ~InferData()
-  {
-    for (const auto input : inputs_) {
-      delete input;
-    }
-    for (const auto output : outputs_) {
-      delete output;
-    }
-  }
-
-  // The vector of pointers to InferInput objects for all possible inputs,
-  // potentially including optional inputs with no provided data.
-  std::vector<cb::InferInput*> inputs_;
-  // The vector of pointers to InferInput objects to be
-  // used for inference request.
-  std::vector<cb::InferInput*> valid_inputs_;
-  // The vector of pointers to InferRequestedOutput objects
-  // to be used with the inference request.
-  std::vector<const cb::InferRequestedOutput*> outputs_;
-  // If not empty, the expected output data in the same order as 'outputs_'
-  // The outer vector is per-output. The inner vector is for batching of each
-  // output
-  std::vector<std::vector<TensorData>> expected_outputs_;
-  // The InferOptions object holding the details of the
-  // inference.
-  std::unique_ptr<cb::InferOptions> options_;
+/// Data for one input or output tensor
+///
+struct TensorData {
+  const uint8_t* data_ptr{nullptr};
+  size_t batch1_size{0};
+  bool is_valid{false};
 };
 
 

--- a/src/c++/perf_analyzer/test_dataloader.cc
+++ b/src/c++/perf_analyzer/test_dataloader.cc
@@ -109,7 +109,7 @@ TEST_CASE("dataloader: GetInputData missing data")
   MockDataLoader dataloader;
   ModelTensor input1 = TestDataLoader::CreateTensor("INPUT1");
 
-  DataLoaderData data;
+  TensorData data;
 
   cb::Error status = dataloader.GetInputData(input1, 0, 0, data);
   REQUIRE(status.IsOk() == false);
@@ -491,7 +491,7 @@ TEST_CASE("dataloader: ParseData: Valid Data")
 
   // Confirm the correct data is in the dataloader
   //
-  DataLoaderData data;
+  TensorData data;
   std::vector<int64_t> shape;
 
   dataloader.GetInputShape(input1, 0, 1, &shape);
@@ -616,7 +616,7 @@ TEST_CASE("dataloader: ParseData: Multiple Streams Valid")
 
   // Confirm the correct data is in the dataloader
   //
-  DataLoaderData data;
+  TensorData data;
 
   status = dataloader.GetInputData(input1, 0, 1, data);
   REQUIRE(status.IsOk());
@@ -738,7 +738,7 @@ TEST_CASE(
   CHECK_EQ(shape[1], 2);
 
   // Confirm that the zero-shape input IS valid, but with size=0 and ptr=null
-  DataLoaderData data;
+  TensorData data;
   status = dataloader.GetInputData(input1, 0, 0, data);
   REQUIRE(status.IsOk());
   CHECK(data.is_valid);
@@ -793,7 +793,7 @@ TEST_CASE(
 
   // Confirm the correct data is in the dataloader
   //
-  DataLoaderData data;
+  TensorData data;
 
   status = dataloader.GetInputData(input1, 0, 3, data);
   REQUIRE(status.IsOk());
@@ -857,7 +857,7 @@ TEST_CASE(
 
   // Confirm the correct data is in the dataloader
   //
-  DataLoaderData data;
+  TensorData data;
 
   status = dataloader.GetInputData(input1, 1, 1, data);
   REQUIRE(status.IsOk());
@@ -981,7 +981,7 @@ TEST_CASE(
   CHECK_EQ(dataloader.GetDataStreamsCount(), 1);
   CHECK_EQ(dataloader.GetTotalSteps(0), 1);
 
-  DataLoaderData data;
+  TensorData data;
 
   status = dataloader.GetInputData(input1, 0, 0, data);
   REQUIRE(status.IsOk());
@@ -1036,7 +1036,7 @@ TEST_CASE(
   CHECK_EQ(dataloader.GetDataStreamsCount(), 1);
   CHECK_EQ(dataloader.GetTotalSteps(0), 1);
 
-  DataLoaderData data;
+  TensorData data;
 
   status = dataloader.GetInputData(input1, 0, 0, data);
   REQUIRE(status.IsOk());
@@ -1188,7 +1188,7 @@ TEST_CASE(
   cb::Error status = dataloader.ReadDataFromDir(inputs, outputs, dir);
   CHECK(status.IsOk() == true);
 
-  DataLoaderData data;
+  TensorData data;
 
   dataloader.GetOutputData("OUTPUT1", 0, 0, data);
   CHECK(!data.is_valid);
@@ -1407,7 +1407,7 @@ TEST_CASE(
   CHECK_EQ(dataloader.GetTotalSteps(0), 1);
 
   // Validate input and output data
-  DataLoaderData data;
+  TensorData data;
 
   status = dataloader.GetInputData(input1, 0, 0, data);
   REQUIRE(status.IsOk());


### PR DESCRIPTION
Creates a struct TensorData to wrap up the data_ptr, size, and valid bit into one. 
Cleans up many function prototypes by using the new struct 
Removes ugly workaround that had code looking for "data_ptr not null but byte_size == 0" for the case of valid data with 0 shape (now it just relies on the valid bit)