### PR TITLE
Fix aio HTTP status retrieval

### DIFF
--- a/src/python/library/tritonclient/http/aio/__init__.py
+++ b/src/python/library/tritonclient/http/aio/__init__.py
@@ -64,12 +64,12 @@ async def _get_error(response):
                 else {"error": "client received an empty response from the server."}
             )
             return InferenceServerException(
-                msg=error_response["error"], status=str(response.status_code)
+                msg=error_response["error"], status=str(response.status)
             )
         except Exception as e:
             return InferenceServerException(
                 msg=f"an exception occurred in the client while decoding the response: {e}",
-                status=str(response.status_code),
+                status=str(response.status),
                 debug_details=body,
             )
     else:


### PR DESCRIPTION
`aiohttp.ClientResponse` object has [`status`](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.status) instead of `status_code`