### PR TITLE
Remove an unused function `ShapeTensorValuesToString()` in perf_utils

### DIFF
--- a/src/c++/perf_analyzer/perf_utils.cc
+++ b/src/c++/perf_analyzer/perf_utils.cc
@@ -338,23 +338,6 @@ ShapeVecToString(const std::vector<int64_t> shape_vec, bool skip_first)
 }
 
 std::string
-ShapeTensorValuesToString(const int* data_ptr, const int count)
-{
-  bool first = true;
-  std::string str("[");
-  for (int i = 0; i < count; i++) {
-    if (!first) {
-      str += ",";
-    }
-    str += std::to_string(*(data_ptr + i));
-    first = false;
-  }
-
-  str += "]";
-  return str;
-}
-
-std::string
 TensorToRegionName(std::string name)
 {
   // Remove slashes from the name, if any.

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -128,9 +128,6 @@ std::string GetRandomString(const int string_length);
 std::string ShapeVecToString(
     const std::vector<int64_t> shape_vec, bool skip_first = false);
 
-// Returns the string containing the shape tensor values
-std::string ShapeTensorValuesToString(const int* data_ptr, const int count);
-
 // Remove slashes from tensor name, if any
 std::string TensorToRegionName(std::string name);
 


### PR DESCRIPTION
Follow up PR addressing the removal of unused function from [#362](https://github.com/triton-inference-server/client/pull/362)