### PR TITLE
Improve sanity checking and error messages in PerfAnalyzer CLI

### DIFF
--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -634,9 +634,9 @@ CLParser::Usage(const std::string& msg)
   std::cerr
       << FormatMessage(
              " --trace-file: Set the file where trace output will be saved."
-             " If --trace-log-frequency is also specified, this argument "
+             " If --log-frequency is also specified, this argument "
              "value will be the prefix of the files to save the trace "
-             "output. See --trace-log-frequency for details. Only used for "
+             "output. See --log-frequency for details. Only used for "
              "service-kind of triton. Default value is none.",
              18)
       << std::endl;

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -812,7 +812,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 1: {
           std::string max_threads{optarg};
           if (std::stoi(max_threads) > 0) {
-            params_->max_threads = std::stoi(max_threads);
+            params_->max_threads = std::stoull(max_threads);
             params_->max_threads_specified = true;
           } else {
             Usage("Failed to parse --max-threads. The value must be > 0.");
@@ -822,7 +822,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 2: {
           std::string sequence_length{optarg};
           if (std::stoi(sequence_length) > 0) {
-            params_->sequence_length = std::stoi(sequence_length);
+            params_->sequence_length = std::stoull(sequence_length);
           } else {
             std::cerr << "WARNING: The sequence length must be > 0. Perf "
                          "Analyzer will use default value if it is measuring "
@@ -875,7 +875,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 'p': {
           std::string measurement_window_ms{optarg};
           if (std::stoi(measurement_window_ms) > 0) {
-            params_->measurement_window_ms = std::stoi(measurement_window_ms);
+            params_->measurement_window_ms = std::stoull(measurement_window_ms);
           } else {
             Usage(
                 "Failed to parse --measurement-interval (-p). The value must "
@@ -897,10 +897,10 @@ CLParser::ParseCommandLine(int argc, char** argv)
             }
             int64_t val;
             if (colon_pos == std::string::npos) {
-              val = std::stoll(arg.substr(pos, colon_pos));
+              val = std::stoull(arg.substr(pos, colon_pos));
               pos = colon_pos;
             } else {
-              val = std::stoll(arg.substr(pos, colon_pos - pos));
+              val = std::stoull(arg.substr(pos, colon_pos - pos));
               pos = colon_pos + 1;
             }
             switch (index) {
@@ -924,9 +924,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
           std::string latency_threshold_ms{optarg};
           if (std::stoi(latency_threshold_ms) == 0) {
             params_->latency_threshold_ms = NO_LIMIT;
-          }
-          if (std::stoi(latency_threshold_ms) > 0) {
-            params_->latency_threshold_ms = std::stoi(latency_threshold_ms);
+          } else if (std::stoi(latency_threshold_ms) > 0) {
+            params_->latency_threshold_ms = std::stoull(latency_threshold_ms);
           } else {
             Usage(
                 "Failed to parse --latency-threshold (-l). The value must be "
@@ -949,10 +948,10 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 10:
         case 'r': {
           std::string max_trials{optarg};
-          if (std::stoi(max_trials) >= 0) {
-            params_->max_trials = std::stoi(max_trials);
+          if (std::stoi(max_trials) > 0) {
+            params_->max_trials = std::stoull(max_trials);
           } else {
-            Usage("Failed to parse --max-trials (-r). The value must be >= 0.");
+            Usage("Failed to parse --max-trials (-r). The value must be > 0.");
           }
           break;
         }
@@ -977,7 +976,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 12: {
           std::string string_length{optarg};
           if (std::stoi(string_length) > 0) {
-            params_->string_length = std::stoi(string_length);
+            params_->string_length = std::stoull(string_length);
           } else {
             Usage("Failed to parse --string-length. The value must be > 0");
           }
@@ -1025,7 +1024,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 17: {
           std::string num_of_sequences{optarg};
           if (std::stoi(num_of_sequences) > 0) {
-            params_->num_of_sequences = std::stoi(num_of_sequences);
+            params_->num_of_sequences = std::stoul(num_of_sequences);
           } else {
             Usage("Failed to parse --num-of-sequences. The value must be > 0.");
           }
@@ -1088,7 +1087,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 22: {
           std::string output_shm_size{optarg};
           if (std::stoi(output_shm_size) >= 0) {
-            params_->output_shm_size = std::stoi(output_shm_size);
+            params_->output_shm_size = std::stoull(output_shm_size);
           } else {
             Usage(
                 "Failed to parse --output-shared-memory-size. The value must "
@@ -1153,7 +1152,14 @@ CLParser::ParseCommandLine(int argc, char** argv)
           break;
         }
         case 27: {
-          params_->measurement_request_count = std::atoi(optarg);
+          std::string request_count{optarg};
+          if (std::stoi(request_count) > 0) {
+            params_->measurement_request_count = std::stoull(request_count);
+          } else {
+            Usage(
+                "Failed to parse --measurement-request-count. The value must "
+                "be > 0.");
+          }
           break;
         }
         case 28: {
@@ -1478,10 +1484,16 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 'x':
           params_->model_version = optarg;
           break;
-        case 'b':
-          params_->batch_size = std::atoi(optarg);
-          params_->using_batch_size = true;
+        case 'b': {
+          std::string batch_size{optarg};
+          if (std::stoi(batch_size) > 0) {
+            params_->batch_size = std::stoull(batch_size);
+            params_->using_batch_size = true;
+          } else {
+            Usage("Failed to parse -b (batch size). The value must be > 0.");
+          }
           break;
+        }
         case 't':
           params_->using_old_options = true;
           params_->concurrent_request_count = std::atoi(optarg);
@@ -1549,13 +1561,6 @@ CLParser::VerifyOptions()
 {
   if (params_->model_name.empty()) {
     Usage("Failed to parse -m (model name). The value must be specified.");
-  }
-  if (params_->batch_size <= 0) {
-    Usage("Failed to parse -b (batch size). The value must be > 0.");
-  }
-  if (params_->measurement_request_count <= 0) {
-    Usage(
-        "Failed to parse --measurement-request-count. The value must be > 0.");
   }
   if (params_->concurrency_range.start <= 0 ||
       params_->concurrent_request_count < 0) {

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -67,7 +67,7 @@ void
 CLParser::Usage(const std::string& msg)
 {
   if (!msg.empty()) {
-    std::cerr << "error: " << msg << std::endl;
+    std::cerr << "Error: " << msg << std::endl;
   }
 
   std::cerr << "Usage: " << argv_[0] << " [options]" << std::endl;
@@ -815,7 +815,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
             params_->max_threads = std::stoi(max_threads);
             params_->max_threads_specified = true;
           } else {
-            Usage("maximum number of threads must be > 0");
+            Usage("Failed to parse --max-threads. The value must be > 0.");
           }
           break;
         }
@@ -824,11 +824,10 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::stoi(sequence_length) > 0) {
             params_->sequence_length = std::stoi(sequence_length);
           } else {
-            std::cerr
-                << "WARNING: The sequence length must be > 0. Perf Analyzer "
-                   "will"
-                << " use default value if it is measuring on sequence model."
-                << std::endl;
+            std::cerr << "WARNING: The sequence length must be > 0. Perf "
+                         "Analyzer will use default value if it is measuring "
+                         "on sequence model."
+                      << std::endl;
           }
           params_->sequence_length_specified = true;
           break;
@@ -844,8 +843,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           auto colon_pos = arg.rfind(":");
           if (colon_pos == std::string::npos) {
             Usage(
-                "failed to parse input shape. There must be a colon after "
-                "input "
+                "Failed to parse --shape. There must be a colon after input "
                 "name.");
           }
           std::string name = arg.substr(0, colon_pos);
@@ -863,7 +861,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
               pos = comma_pos + 1;
             }
             if (dim <= 0) {
-              Usage("input shape must be > 0");
+              Usage(
+                  "Failed to parse --shape. The dimensions of input tensor "
+                  "must be > 0.");
             }
             shape.emplace_back(dim);
           }
@@ -877,7 +877,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::stoi(measurement_window_ms) > 0) {
             params_->measurement_window_ms = std::stoi(measurement_window_ms);
           } else {
-            Usage("The --measurement-interval (-p) must be > 0 msec.");
+            Usage(
+                "Failed to parse --measurement-interval (-p). The value must "
+                "be > 0 msec.");
           }
           break;
         }
@@ -890,8 +892,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
             size_t colon_pos = arg.find(":", pos);
             if (index > 2) {
               Usage(
-                  "option concurrency-range can have maximum of three "
-                  "elements");
+                  "Failed to parse --concurrency-range. The value does not "
+                  "match <start:end:step>.");
             }
             int64_t val;
             if (colon_pos == std::string::npos) {
@@ -923,7 +925,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::stoi(latency_threshold_ms) >= 0) {
             params_->latency_threshold_ms = std::stoi(latency_threshold_ms);
           } else {
-            Usage("The latency threshold (in msecs) must be non-negative.");
+            Usage(
+                "Failed to parse --latency-threshold (-l). The value must be "
+                ">= 0 msecs.");
           }
           break;
         }
@@ -933,7 +937,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::stof(stability_threshold) >= 0.0) {
             params_->stability_threshold = std::stof(optarg) / 100;
           } else {
-            Usage("The stability percentage must be non-negative.");
+            Usage(
+                "Failed to parse --stability-percentage (-s). The value must "
+                "be >= 0.0.");
           }
           break;
         }
@@ -943,7 +949,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::stoi(max_trials) >= 0) {
             params_->max_trials = std::stoi(max_trials);
           } else {
-            Usage("The maximum number of trials must be non-negative.");
+            Usage("Failed to parse --max-trials (-r). The value must be >= 0.");
           }
           break;
         }
@@ -957,7 +963,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           } else if (arg.compare("random") == 0) {
             break;
           } else {
-            Usage("unsupported input data provided " + std::string(optarg));
+            Usage(
+                "Failed to parse --input-data. Unsupported type provided: '" +
+                std::string(optarg) +
+                "'. The available options are 'zero', 'random', path to a "
+                "directory, or a json file.");
           }
           break;
         }
@@ -966,7 +976,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::stoi(string_length) > 0) {
             params_->string_length = std::stoi(string_length);
           } else {
-            Usage("The string length must be > 0");
+            Usage("Failed to parse --string-length. The value must be > 0");
           }
           break;
         }
@@ -992,8 +1002,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
             size_t colon_pos = arg.find(":", pos);
             if (index > 2) {
               Usage(
-                  "option request_rate_range can have maximum of three "
-                  "elements");
+                  "Failed to parse --request-rate-range. The value does not "
+                  "match <start:end:step>.");
             }
             if (colon_pos == std::string::npos) {
               params_->request_rate_range[index] =
@@ -1014,7 +1024,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::stoi(num_of_sequences) > 0) {
             params_->num_of_sequences = std::stoi(num_of_sequences);
           } else {
-            Usage("The number of concurrent sequences must be > 0");
+            Usage("Failed to parse --num-of-sequences. The value must be > 0.");
           }
           break;
         }
@@ -1030,8 +1040,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
             params_->request_distribution = Distribution::CONSTANT;
           } else {
             Usage(
-                "unsupported request distribution provided " +
-                std::string(optarg));
+                "Failed to parse --request-distribution. Unsupported type "
+                "provided: '" +
+                std::string(optarg) + "'. Choices are 'posson' or 'constant'.");
           }
           break;
         }
@@ -1041,7 +1052,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
             params_->request_intervals_file = request_intervals_file;
             params_->using_custom_intervals = true;
           } else {
-            Usage("--request-intervals must be a valid file path");
+            Usage(
+                "Failed to parse --request-intervals. The value must be a "
+                "valid file path");
           }
           break;
         }
@@ -1055,15 +1068,17 @@ CLParser::ParseCommandLine(int argc, char** argv)
             params_->shared_memory_type = SharedMemoryType::CUDA_SHARED_MEMORY;
 #else
             Usage(
-                "cuda shared memory is not supported when TRITON_ENABLE_GPU=0");
+                "Cuda shared memory is not supported when "
+                "TRITON_ENABLE_GPU=0.");
 #endif  // TRITON_ENABLE_GPU
           } else if (arg.compare("none") == 0) {
             params_->shared_memory_type = SharedMemoryType::NO_SHARED_MEMORY;
           } else {
             Usage(
-                "unsupported --shared-memory type provided: '" +
+                "Failed to parse --shared-memory. Unsupported type provided: "
+                "'" +
                 std::string(optarg) +
-                "'. Choices are 'system', 'cuda', or 'none'.");
+                "'. The available options are 'system', 'cuda', or 'none'.");
           }
           break;
         }
@@ -1072,7 +1087,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::stoi(output_shm_size) >= 0) {
             params_->output_shm_size = std::stoi(output_shm_size);
           } else {
-            Usage("The output shared memory size must be non-negative.");
+            Usage(
+                "Failed to parse --output-shared-memory-size. The value must "
+                "be >= 0.");
           }
           break;
         }
@@ -1087,7 +1104,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           } else if (arg.compare("triton_c_api") == 0) {
             params_->kind = cb::TRITON_C_API;
           } else {
-            Usage("unsupported --service-kind specified");
+            Usage(
+                "Failed to parse --service-kind. Unsupported type provided: '" +
+                std::string{optarg} +
+                "'. The available options are 'triton', 'tfserving', "
+                "'torchserve', or 'triton_c_api'.");
           }
           break;
         }
@@ -1103,7 +1124,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           } else if (arg.compare("gzip") == 0) {
             params_->compression_algorithm = cb::COMPRESS_GZIP;
           } else {
-            Usage("unsupported --grpc-compression-algorithm specified");
+            Usage(
+                "Failed to parse --grpc-compression-algorithm. Unsupported "
+                "type provided: '" +
+                arg +
+                "'. The available options are 'gzip', 'deflate', or 'none'.");
           }
           params_->using_grpc_compression = true;
           break;
@@ -1115,7 +1140,12 @@ CLParser::ParseCommandLine(int argc, char** argv)
           } else if (arg.compare("count_windows") == 0) {
             params_->measurement_mode = MeasurementMode::COUNT_WINDOWS;
           } else {
-            Usage("unsupported --measurement-mode specified");
+            Usage(
+                "Failed to parse --measurement-mode. Unsupported type "
+                "provided: '" +
+                arg +
+                "'. The available options are 'time_windows' or "
+                "'count_windows'.");
           }
           break;
         }
@@ -1141,8 +1171,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
             size_t colon_pos = arg.find(":", pos);
             if (index > 1) {
               Usage(
-                  "option sequence-id-range can have maximum of two "
-                  "elements");
+                  "Failed to parse --sequence-id-range. The value does not "
+                  "match <start:end>.");
             }
             if (colon_pos == std::string::npos) {
               std::string sequence_id{arg.substr(pos, colon_pos)};
@@ -1162,9 +1192,13 @@ CLParser::ParseCommandLine(int argc, char** argv)
 
           // Check for invalid inputs
           if (start_id < 0 || end_id < 0) {
-            Usage("Start and end sequence IDs must be non-negative.");
+            Usage(
+                "Failed to parse --sequence-id-range. The range values must be "
+                ">= 0.");
           } else if (start_id > end_id) {
-            Usage("Start sequence ID cannot be greater than end sequence ID.");
+            Usage(
+                "Failed to parse --sequence-id-range. The 'end' value must be "
+                "greater than 'start' value.");
           }
 
           if (index == 0) {  // Only start ID is given
@@ -1184,8 +1218,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
             params_->ssl_options.ssl_grpc_root_certifications_file = optarg;
           } else {
             Usage(
-                "--ssl-grpc-root-certifications-file must be a valid file "
-                "path");
+                "Failed to parse --ssl-grpc-root-certifications-file. The "
+                "value must be a valid file path.");
           }
           break;
         }
@@ -1193,7 +1227,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (IsFile(optarg)) {
             params_->ssl_options.ssl_grpc_private_key_file = optarg;
           } else {
-            Usage("--ssl-grpc-private-key-file must be a valid file path");
+            Usage(
+                "Failed to parse --ssl-grpc-private-key-file. The value must "
+                "be a valid file path.");
           }
           break;
         }
@@ -1202,7 +1238,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
             params_->ssl_options.ssl_grpc_certificate_chain_file = optarg;
           } else {
             Usage(
-                "--ssl-grpc-certificate-chain-file must be a valid file path");
+                "Failed to parse --ssl-grpc-certificate-chain-file. The value "
+                "must be a valid file path.");
           }
           break;
         }
@@ -1210,7 +1247,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::atol(optarg) == 0 || std::atol(optarg) == 1) {
             params_->ssl_options.ssl_https_verify_peer = std::atol(optarg);
           } else {
-            Usage("--ssl-https-verify-peer must be 0 or 1");
+            Usage(
+                "Failed to parse --ssl-https-verify-peer. The value must be "
+                "either 0 or 1.");
           }
           break;
         }
@@ -1219,7 +1258,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
               std::atol(optarg) == 2) {
             params_->ssl_options.ssl_https_verify_host = std::atol(optarg);
           } else {
-            Usage("--ssl-https-verify-host must be 0, 1, or 2");
+            Usage(
+                "Failed to parse --ssl-https-verify-host. The value must be "
+                "either 0, 1, or 2.");
           }
           break;
         }
@@ -1227,7 +1268,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (IsFile(optarg)) {
             params_->ssl_options.ssl_https_ca_certificates_file = optarg;
           } else {
-            Usage("--ssl-https-ca-certificates-file must be a valid file path");
+            Usage(
+                "Failed to parse --ssl-https-ca-certificates-file. The value "
+                "must be a valid file path.");
           }
           break;
         }
@@ -1236,8 +1279,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
             params_->ssl_options.ssl_https_client_certificate_file = optarg;
           } else {
             Usage(
-                "--ssl-https-client-certificate-file must be a valid file "
-                "path");
+                "Failed to parse --ssl-https-client-certificate-file. The "
+                "value must be a valid file path.");
           }
           break;
         }
@@ -1245,7 +1288,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::string(optarg) == "PEM" || std::string(optarg) == "DER") {
             params_->ssl_options.ssl_https_client_certificate_type = optarg;
           } else {
-            Usage("--ssl-https-client-certificate-type must be 'PEM' or 'DER'");
+            Usage(
+                "Failed to parse --ssl-https-client-certificate-type. "
+                "Unsupported type provided: '" +
+                std::string{optarg} +
+                "'. The available options are 'PEM' or 'DER'.");
           }
           break;
         }
@@ -1253,7 +1300,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (IsFile(optarg)) {
             params_->ssl_options.ssl_https_private_key_file = optarg;
           } else {
-            Usage("--ssl-https-private-key-file must be a valid file path");
+            Usage(
+                "Failed to parse --ssl-https-private-key-file. The value must "
+                "be a valid file path.");
           }
           break;
         }
@@ -1261,7 +1310,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::string(optarg) == "PEM" || std::string(optarg) == "DER") {
             params_->ssl_options.ssl_https_private_key_type = optarg;
           } else {
-            Usage("--ssl-https-private-key-type must be 'PEM' or 'DER'");
+            Usage(
+                "Failed to parse --ssl-https-private-key-type. Unsupported "
+                "type provided: '" +
+                std::string{optarg} +
+                "'. The available options are 'PEM' or 'DER'.");
           }
           break;
         }
@@ -1283,7 +1336,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
               trace_level == "TENSORS") {
             params_->trace_options["trace_level"] = {trace_level};
           } else {
-            Usage("--trace-level must be 'OFF', 'TIMESTAMPS', or 'TENSORS'");
+            Usage(
+                "Failed to parse --trace-level. Unsupported type provided: '" +
+                trace_level +
+                "'. The available options are 'OFF', 'TIMESTAMPS', or "
+                "'TENSORS'.");
           }
           break;
         }
@@ -1296,7 +1353,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::stoi(trace_count) >= -1) {
             params_->trace_options["trace_count"] = {trace_count};
           } else {
-            Usage("The trace count must be >= -1");
+            Usage(
+                "Failed to parse --trace-count. The value must be >= 0 or set "
+                "to -1 (default).");
           }
           break;
         }
@@ -1305,7 +1364,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (std::stoi(log_frequency) >= 0) {
             params_->trace_options["log_frequency"] = {log_frequency};
           } else {
-            Usage("The trace log frequency value must be non-negative.");
+            Usage("Failed to parse --log-frequency. The value must be >= 0.");
           }
           break;
         }
@@ -1324,7 +1383,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
             params_->metrics_interval_ms = std::stoull(metrics_interval_ms);
             params_->metrics_interval_ms_specified = true;
           } else {
-            Usage("Metrics interval must be larger than 0 milliseconds.");
+            Usage(
+                "Failed to parse --metrics-interval. The value must be > 0 "
+                "msecs.");
           }
           break;
         }
@@ -1368,7 +1429,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 55: {
           cb::TensorFormat input_tensor_format{ParseTensorFormat(optarg)};
           if (input_tensor_format == cb::TensorFormat::UNKNOWN) {
-            Usage("--input-tensor-format must be 'binary' or 'json'");
+            Usage(
+                "Failed to parse --input-tensor-format. Unsupported type "
+                "provided: '" +
+                std::string{optarg} +
+                "'. The available options are 'binary' or 'json'.");
           }
           params_->input_tensor_format = input_tensor_format;
           break;
@@ -1376,7 +1441,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 56: {
           cb::TensorFormat output_tensor_format{ParseTensorFormat(optarg)};
           if (output_tensor_format == cb::TensorFormat::UNKNOWN) {
-            Usage("--output-tensor-format must be 'binary' or 'json'");
+            Usage(
+                "Failed to parse --output-tensor-format. Unsupported type "
+                "provided: '" +
+                std::string{optarg} +
+                "'. The available options are 'binary' or 'json'.");
           }
           params_->output_tensor_format = output_tensor_format;
           break;
@@ -1438,12 +1507,12 @@ CLParser::ParseCommandLine(int argc, char** argv)
     catch (const std::invalid_argument& ia) {
       if (opt >= 'A') {  // short options
         Usage(
-            "Failed to parse argument for -" + std::string{(char)opt} + ": " +
-            std::string{optarg});
+            "Failed to parse -" + std::string{(char)opt} +
+            ". Invalid value provided: " + std::string{optarg});
       } else {
         Usage(
-            "Failed to parse argument for --" +
-            std::string{long_options[opt].name} + ": " + std::string{optarg});
+            "Failed to parse --" + std::string{long_options[opt].name} +
+            ". Invalid value provided: " + std::string{optarg});
       }
     }
   }
@@ -1476,33 +1545,40 @@ void
 CLParser::VerifyOptions()
 {
   if (params_->model_name.empty()) {
-    Usage("-m flag must be specified");
+    Usage("Failed to parse -m (model name). The value must be specified.");
   }
   if (params_->batch_size <= 0) {
-    Usage("batch size must be > 0");
+    Usage("Failed to parse -b (batch size). The value must be > 0.");
   }
   if (params_->measurement_request_count <= 0) {
-    Usage("measurement request count must be > 0");
+    Usage(
+        "Failed to parse --measurement-request-count. The value must be > 0.");
   }
   if (params_->concurrency_range.start <= 0 ||
       params_->concurrent_request_count < 0) {
     Usage("The start of the search range must be > 0");
   }
   if (params_->request_rate_range[SEARCH_RANGE::kSTART] <= 0) {
-    Usage("The start of the search range must be > 0");
+    Usage(
+        "Failed to parse --request-rate-range. The start of the search range "
+        "must be > 0.");
   }
   if (params_->protocol == cb::ProtocolType::UNKNOWN) {
-    Usage("protocol should be either HTTP or gRPC");
+    Usage(
+        "Failed to parse -i (protocol). The value should be either HTTP or "
+        "gRPC.");
   }
   if (params_->streaming && (params_->protocol != cb::ProtocolType::GRPC)) {
-    Usage("streaming is only allowed with gRPC protocol");
+    Usage("Streaming is only allowed with gRPC protocol.");
   }
   if (params_->using_grpc_compression &&
       (params_->protocol != cb::ProtocolType::GRPC)) {
-    Usage("compression is only allowed with gRPC protocol");
+    Usage("Using compression algorithm is only allowed with gRPC protocol.");
   }
   if (params_->sequence_length_variation < 0.0) {
-    Usage("sequence length variation must be positive");
+    Usage(
+        "Failed to parse --sequence-length-variation. The value must be >= "
+        "0.0.");
   }
   if (params_->start_sequence_id == 0) {
     params_->start_sequence_id = 1;
@@ -1512,17 +1588,19 @@ CLParser::VerifyOptions()
   }
   if (params_->percentile != -1 &&
       (params_->percentile > 99 || params_->percentile < 1)) {
-    Usage("percentile must be -1 for not reporting or in range (0, 100)");
+    Usage(
+        "Failed to parse --percentile. The value must be -1 for not reporting "
+        "or in range (0, 100).");
   }
   if (params_->zero_input && !params_->user_data.empty()) {
-    Usage("zero input can't be set when data directory is provided");
+    Usage("The -z flag cannot be set when --data-directory is provided.");
   }
   if (params_->async && params_->forced_sync) {
-    Usage("Both --async and --sync can not be specified simultaneously.");
+    Usage("Cannot specify --async and --sync simultaneously.");
   }
 
   if (params_->using_concurrency_range && params_->using_old_options) {
-    Usage("can not use deprecated options with --concurrency-range");
+    Usage("Cannot use deprecated options with --concurrency-range.");
   } else if (params_->using_old_options) {
     if (params_->dynamic_concurrency_mode) {
       params_->concurrency_range.end = params_->max_concurrency;
@@ -1531,36 +1609,36 @@ CLParser::VerifyOptions()
   }
 
   if (params_->using_request_rate_range && params_->using_old_options) {
-    Usage("can not use concurrency options with --request-rate-range");
+    Usage("Cannot use concurrency options with --request-rate-range.");
   }
 
   if (params_->using_request_rate_range && params_->using_concurrency_range) {
     Usage(
-        "can not specify concurrency_range and request_rate_range "
-        "simultaneously");
+        "Cannot specify --concurrency-range and --request-rate-range "
+        "simultaneously.");
   }
 
   if (params_->using_request_rate_range && params_->mpi_driver->IsMPIRun() &&
       (params_->request_rate_range[SEARCH_RANGE::kEND] != 1.0 ||
        params_->request_rate_range[SEARCH_RANGE::kSTEP] != 1.0)) {
-    Usage("cannot use request rate range with multi-model mode");
+    Usage("Cannot specify --request-rate-range when in multi-model mode.");
   }
 
   if (params_->using_custom_intervals && params_->using_old_options) {
-    Usage("can not use deprecated options with --request-intervals");
+    Usage("Cannot use deprecated options with --request-intervals.");
   }
 
   if ((params_->using_custom_intervals) &&
       (params_->using_request_rate_range || params_->using_concurrency_range)) {
     Usage(
-        "can not use --concurrency-range or --request-rate-range "
-        "along with --request-intervals");
+        "Cannot use --concurrency-range or --request-rate-range "
+        "along with --request-intervals.");
   }
 
   if (params_->using_concurrency_range && params_->mpi_driver->IsMPIRun() &&
       (params_->concurrency_range.end != 1 ||
        params_->concurrency_range.step != 1)) {
-    Usage("cannot use concurrency range with multi-model mode");
+    Usage("Cannot specify --concurrency-range when in multi-model mode.");
   }
 
   if (((params_->concurrency_range.end == NO_LIMIT) ||
@@ -1581,7 +1659,7 @@ CLParser::VerifyOptions()
 
   if ((params_->search_mode == SearchMode::BINARY) &&
       (params_->latency_threshold_ms == NO_LIMIT)) {
-    Usage("The latency threshold can not be 0 for binary search mode.");
+    Usage("The --latency-threshold cannot be 0 for binary search mode.");
   }
 
   if (((params_->concurrency_range.end < params_->concurrency_range.start) ||
@@ -1608,7 +1686,7 @@ CLParser::VerifyOptions()
     if (params_->user_data.empty()) {
       Usage(
           "--input-data should be provided with a json file with "
-          "input data for torchserve");
+          "input data for torchserve.");
     }
   }
 

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -871,7 +871,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->input_shapes[name] = shape;
           break;
         }
-        case 6: {
+        case 6:
+        case 'p': {
           std::string measurement_window_ms{optarg};
           if (std::stoi(measurement_window_ms) > 0) {
             params_->measurement_window_ms = std::stoi(measurement_window_ms);
@@ -916,7 +917,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
 
           break;
         }
-        case 8: {
+        case 8:
+        case 'l': {
           std::string latency_threshold_ms{optarg};
           if (std::stoi(latency_threshold_ms) >= 0) {
             params_->latency_threshold_ms = std::stoi(latency_threshold_ms);
@@ -925,7 +927,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 9: {
+        case 9:
+        case 's': {
           std::string stability_threshold{optarg};
           if (std::stof(stability_threshold) >= 0.0) {
             params_->stability_threshold = std::stof(optarg) / 100;
@@ -934,7 +937,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 10: {
+        case 10:
+        case 'r': {
           std::string max_trials{optarg};
           if (std::stoi(max_trials) >= 0) {
             params_->max_trials = std::stoi(max_trials);
@@ -970,7 +974,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->string_data = optarg;
           break;
         }
-        case 14: {
+        case 14:
+        case 'a': {
           params_->async = true;
           break;
         }
@@ -1409,15 +1414,6 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->using_old_options = true;
           params_->concurrent_request_count = std::atoi(optarg);
           break;
-        case 'p': {
-          std::string measurement_window_ms{optarg};
-          if (std::stoi(measurement_window_ms) > 0) {
-            params_->measurement_window_ms = std::stoi(measurement_window_ms);
-          } else {
-            Usage("The --measurement-interval (-p) must be > 0 msec.");
-          }
-          break;
-        }
         case 'i':
           params_->protocol = ParseProtocol(optarg);
           break;
@@ -1427,42 +1423,12 @@ CLParser::ParseCommandLine(int argc, char** argv)
           (*params_->http_headers)[header] = arg.substr(header.size() + 1);
           break;
         }
-        case 'l': {
-          std::string latency_threshold_ms{optarg};
-          if (std::stoi(latency_threshold_ms) >= 0) {
-            params_->latency_threshold_ms = std::stoi(latency_threshold_ms);
-          } else {
-            Usage("The latency threshold (in msecs) must be non-negative.");
-          }
-          break;
-        }
         case 'c':
           params_->using_old_options = true;
           params_->max_concurrency = std::atoi(optarg);
           break;
-        case 'r': {
-          std::string max_trials{optarg};
-          if (std::stoi(max_trials) >= 0) {
-            params_->max_trials = std::stoi(max_trials);
-          } else {
-            Usage("The maximum number of trials must be non-negative.");
-          }
-          break;
-        }
-        case 's': {
-          std::string stability_threshold{optarg};
-          if (std::stof(stability_threshold) >= 0.0) {
-            params_->stability_threshold = std::stof(optarg) / 100;
-          } else {
-            Usage("The stability percentage must be non-negative.");
-          }
-          break;
-        }
         case 'f':
           params_->filename = optarg;
-          break;
-        case 'a':
-          params_->async = true;
           break;
         case '?':
           Usage();

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -926,7 +926,12 @@ CLParser::ParseCommandLine(int argc, char** argv)
         break;
       }
       case 9: {
-        params_->stability_threshold = atof(optarg) / 100;
+        std::string stability_threshold{optarg};
+        if (std::stof(stability_threshold) >= 0.0) {
+          params_->stability_threshold = std::stof(optarg) / 100;
+        } else {
+          Usage("The stability percentage must be non-negative.");
+        }
         break;
       }
       case 10: {
@@ -1029,10 +1034,16 @@ CLParser::ParseCommandLine(int argc, char** argv)
         }
         break;
       }
-      case 20:
-        params_->using_custom_intervals = true;
-        params_->request_intervals_file = optarg;
+      case 20: {
+        std::string request_intervals_file{optarg};
+        if (IsFile(request_intervals_file)) {
+          params_->request_intervals_file = request_intervals_file;
+          params_->using_custom_intervals = true;
+        } else {
+          Usage("--request-intervals must be a valid file path");
+        }
         break;
+      }
       case 21: {
         std::string arg = optarg;
         if (arg.compare("system") == 0) {
@@ -1054,7 +1065,12 @@ CLParser::ParseCommandLine(int argc, char** argv)
         break;
       }
       case 22: {
-        params_->output_shm_size = std::atoi(optarg);
+        std::string output_shm_size{optarg};
+        if (std::stoi(output_shm_size) >= 0) {
+          params_->output_shm_size = std::stoi(output_shm_size);
+        } else {
+          Usage("The output shared memory size must be non-negative.");
+        }
         break;
       }
       case 23: {
@@ -1247,7 +1263,13 @@ CLParser::ParseCommandLine(int argc, char** argv)
         break;
       }
       case 45: {
-        params_->trace_options["trace_level"] = {optarg};
+        std::string trace_level{optarg};
+        if (trace_level == "OFF" || trace_level == "TIMESTAMPS" ||
+            trace_level == "TENSORS") {
+          params_->trace_options["trace_level"] = {trace_level};
+        } else {
+          Usage("--trace-level must be 'OFF', 'TIMESTAMPS', or 'TENSORS'");
+        }
         break;
       }
       case 46: {
@@ -1409,9 +1431,15 @@ CLParser::ParseCommandLine(int argc, char** argv)
         }
         break;
       }
-      case 's':
-        params_->stability_threshold = atof(optarg) / 100;
+      case 's': {
+        std::string stability_threshold{optarg};
+        if (std::stof(stability_threshold) >= 0.0) {
+          params_->stability_threshold = std::stof(optarg) / 100;
+        } else {
+          Usage("The stability percentage must be non-negative.");
+        }
         break;
+      }
       case 'f':
         params_->filename = optarg;
         break;

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -917,7 +917,12 @@ CLParser::ParseCommandLine(int argc, char** argv)
         break;
       }
       case 8: {
-        params_->latency_threshold_ms = std::atoi(optarg);
+        std::string latency_threshold_ms{optarg};
+        if (std::stoi(latency_threshold_ms) >= 0) {
+          params_->latency_threshold_ms = std::stoi(latency_threshold_ms);
+        } else {
+          Usage("The latency threshold (in msecs) must be non-negative.");
+        }
         break;
       }
       case 9: {
@@ -925,7 +930,12 @@ CLParser::ParseCommandLine(int argc, char** argv)
         break;
       }
       case 10: {
-        params_->max_trials = std::atoi(optarg);
+        std::string max_trials{optarg};
+        if (std::stoi(max_trials) >= 0) {
+          params_->max_trials = std::stoi(max_trials);
+        } else {
+          Usage("The maximum number of trials must be non-negative.");
+        }
         break;
       }
       case 11: {
@@ -1258,7 +1268,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
         if (std::stoi(log_frequency) >= 0) {
           params_->trace_options["log_frequency"] = {log_frequency};
         } else {
-          Usage("The trace log frequency must be >= 0");
+          Usage("The trace log frequency value must be non-negative.");
         }
         break;
       }
@@ -1377,16 +1387,28 @@ CLParser::ParseCommandLine(int argc, char** argv)
         (*params_->http_headers)[header] = arg.substr(header.size() + 1);
         break;
       }
-      case 'l':
-        params_->latency_threshold_ms = std::atoi(optarg);
+      case 'l': {
+        std::string latency_threshold_ms{optarg};
+        if (std::stoi(latency_threshold_ms) >= 0) {
+          params_->latency_threshold_ms = std::stoi(latency_threshold_ms);
+        } else {
+          Usage("The latency threshold (in msecs) must be non-negative.");
+        }
         break;
+      }
       case 'c':
         params_->using_old_options = true;
         params_->max_concurrency = std::atoi(optarg);
         break;
-      case 'r':
-        params_->max_trials = std::atoi(optarg);
+      case 'r': {
+        std::string max_trials{optarg};
+        if (std::stoi(max_trials) >= 0) {
+          params_->max_trials = std::stoi(max_trials);
+        } else {
+          Usage("The maximum number of trials must be non-negative.");
+        }
         break;
+      }
       case 's':
         params_->stability_threshold = atof(optarg) / 100;
         break;

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1130,8 +1130,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
       }
       case 30: {
         std::string arg = optarg;
-        int64_t start;
-        int64_t end;
+        int64_t start_id;
+        int64_t end_id;
         size_t pos = 0;
         int index = 0;
         try {
@@ -1145,14 +1145,14 @@ CLParser::ParseCommandLine(int argc, char** argv)
             if (colon_pos == std::string::npos) {
               std::string sequence_id{arg.substr(pos, colon_pos)};
               if (index == 0) {
-                start = std::stoi(sequence_id);
+                start_id = std::stoi(sequence_id);
               } else {
-                end = std::stoi(sequence_id);
+                end_id = std::stoi(sequence_id);
               }
               pos = colon_pos;
             } else {
               std::string sequence_id{arg.substr(pos, colon_pos - pos)};
-              start = std::stoi(sequence_id);
+              start_id = std::stoi(sequence_id);
               pos = colon_pos + 1;
               index++;
             }
@@ -1163,17 +1163,17 @@ CLParser::ParseCommandLine(int argc, char** argv)
         }
 
         // Check for invalid inputs
-        if (start < 0 || end < 0) {
+        if (start_id < 0 || end_id < 0) {
           Usage("Start and end sequence IDs must be non-negative.");
-        } else if (start > end) {
+        } else if (start_id > end_id) {
           Usage("Start sequence ID cannot be greater than end sequence ID.");
         }
 
         if (index == 0) {  // Only start ID is given
-          params_->start_sequence_id = start;
+          params_->start_sequence_id = start_id;
         } else {
-          params_->start_sequence_id = start;
-          params_->sequence_id_range = end - start;
+          params_->start_sequence_id = start_id;
+          params_->sequence_id_range = end_id - start_id;
         }
         break;
       }

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -922,7 +922,10 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 8:
         case 'l': {
           std::string latency_threshold_ms{optarg};
-          if (std::stoi(latency_threshold_ms) >= 0) {
+          if (std::stoi(latency_threshold_ms) == 0) {
+            params_->latency_threshold_ms = NO_LIMIT;
+          }
+          if (std::stoi(latency_threshold_ms) > 0) {
             params_->latency_threshold_ms = std::stoi(latency_threshold_ms);
           } else {
             Usage(

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -101,7 +101,7 @@ struct PerfAnalyzerParameters {
   std::string url{"localhost:8000"};
   std::string model_name;
   std::string model_version;
-  int32_t batch_size = 1;
+  uint64_t batch_size = 1;
   bool using_batch_size = false;
   int32_t concurrent_request_count = 1;
   clientbackend::ProtocolType protocol = clientbackend::ProtocolType::HTTP;

--- a/src/c++/perf_analyzer/docs/cli.md
+++ b/src/c++/perf_analyzer/docs/cli.md
@@ -540,8 +540,8 @@ Analyzer.
 
 Specifies the file where trace output will be saved.
 
-If `--trace-log-frequency` is also specified, this argument value will be the
-prefix of the files to save the trace output. See `--trace-log-frequency` for
+If `--log-frequency` is also specified, this argument value will be the
+prefix of the files to save the trace output. See `--log-frequency` for
 details. Only used for `--service-kind=triton`.
 
 #### `--trace-level=[OFF|TIMESTAMPS|TENSORS]`

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -194,17 +194,6 @@ CHECK_PARAMS(PAParamsPtr act, PAParamsPtr exp)
     CAPTURE(exp_val);                                                      \
   }                                                                        \
                                                                            \
-  SUBCASE("set to 0")                                                      \
-  {                                                                        \
-    int argc = 5;                                                          \
-    char* argv[argc] = {app_name, "-m", model_name, option_name, "0"};     \
-                                                                           \
-    REQUIRE_NOTHROW(act = parser.Parse(argc, argv));                       \
-    CHECK(!parser.UsageCalled());                                          \
-                                                                           \
-    exp_val = 0;                                                           \
-  }                                                                        \
-                                                                           \
   SUBCASE("negative value")                                                \
   {                                                                        \
     int argc = 5;                                                          \
@@ -1175,6 +1164,16 @@ TEST_CASE("Testing Command Line Parser")
         "--latency-threshold (-l)", "The value must be >= 0 msecs.");
     CHECK_INT_OPTION(
         "--latency-threshold", exp->latency_threshold_ms, expected_msg);
+
+    SUBCASE("set to 0")
+    {
+      int argc = 5;
+      char* argv[argc] = {
+          app_name, "-m", model_name, "--latency-threshold", "0"};
+
+      REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
+      CHECK(!parser.UsageCalled());
+    }
   }
 
   SUBCASE("Option : --stability-percentage")
@@ -1242,8 +1241,19 @@ TEST_CASE("Testing Command Line Parser")
   SUBCASE("Option : --max-trials")
   {
     expected_msg =
-        CreateUsageMessage("--max-trials (-r)", "The value must be >= 0.");
+        CreateUsageMessage("--max-trials (-r)", "The value must be > 0.");
     CHECK_INT_OPTION("--max-trials", exp->max_trials, expected_msg);
+
+    SUBCASE("set to 0")
+    {
+      int argc = 5;
+      char* argv[argc] = {app_name, "-m", model_name, "--max-trials", "0"};
+
+      REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
+      CHECK(parser.UsageCalled());
+
+      CHECK_STRING("Usage Message", parser.GetUsageMessage(), expected_msg);
+    }
   }
 
   SUBCASE("Option : --collect-metrics")

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -172,7 +172,7 @@ CHECK_PARAMS(PAParamsPtr act, PAParamsPtr exp)
 }
 
 
-#define CHECK_INT_OPTION(option_name, exp_val)                             \
+#define CHECK_INT_OPTION(option_name, exp_val, msg)                        \
   SUBCASE("valid value")                                                   \
   {                                                                        \
     int argc = 5;                                                          \
@@ -204,9 +204,8 @@ CHECK_PARAMS(PAParamsPtr act, PAParamsPtr exp)
     int argc = 5;                                                          \
     char* argv[argc] = {app_name, "-m", model_name, option_name, "-2000"}; \
     REQUIRE_NOTHROW(act = parser.Parse(argc, argv));                       \
-    CHECK(!parser.UsageCalled());                                          \
-                                                                           \
-    exp_val = -2000;                                                       \
+    CHECK(parser.UsageCalled());                                           \
+    CHECK_STRING("Usage Message", parser.GetUsageMessage(), msg);          \
   }                                                                        \
                                                                            \
   SUBCASE("floating point value")                                          \
@@ -1147,7 +1146,9 @@ TEST_CASE("Testing Command Line Parser")
 
   SUBCASE("Option : --latency-threshold")
   {
-    CHECK_INT_OPTION("--latency-threshold", exp->latency_threshold_ms);
+    CHECK_INT_OPTION(
+        "--latency-threshold", exp->latency_threshold_ms,
+        "The latency threshold (in msecs) must be non-negative.");
   }
 
   SUBCASE("Option : --stability-percentage")
@@ -1215,7 +1216,9 @@ TEST_CASE("Testing Command Line Parser")
 
   SUBCASE("Option : --max-trials")
   {
-    CHECK_INT_OPTION("--max-trials", exp->max_trials);
+    CHECK_INT_OPTION(
+        "--max-trials", exp->max_trials,
+        "The maximum number of trials must be non-negative.");
   }
 
   SUBCASE("Option : --collect-metrics")

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -681,6 +681,8 @@ TEST_CASE("Testing Command Line Parser")
       CHECK_STRING(
           "Usage Message", parser.GetUsageMessage(),
           "failed to parse sequence-id-range: BAD");
+
+      check_params = false;  // Usage message called
     }
     SUBCASE("Not a number 2")
     {
@@ -694,9 +696,7 @@ TEST_CASE("Testing Command Line Parser")
           "Usage Message", parser.GetUsageMessage(),
           "failed to parse sequence-id-range: 53:BAD");
 
-      // It will get the valid value
-      //
-      exp->start_sequence_id = 53;
+      check_params = false;  // Usage message called
     }
   }
 

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -1182,12 +1182,10 @@ TEST_CASE("Testing Command Line Parser")
           app_name, "-m", model_name, "--stability-percentage", "-20"};
 
       REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
-      CHECK(!parser.UsageCalled());
-
-      // BUG: There should be some check for negative values
-      // This will be interpreted as threshold of 18446744073709549616 ms
-      //
-      exp->stability_threshold = -.2f;
+      CHECK(parser.UsageCalled());
+      CHECK_STRING(
+          "Usage Message", parser.GetUsageMessage(),
+          "The stability percentage must be non-negative.");
     }
 
     SUBCASE("floating point value")


### PR DESCRIPTION
Checks made on the inputs are:
- Protect unsigned parameters against negative inputs (and potential overflow)
- Validate file path
- Validate non-negative integer range inputs (e.g. `start:end`)
- Check for valid type/option
- Rephrase all error messages to include the flag name for better clarity