### PR TITLE
Ensure request body is always returned as bytes

### DIFF
--- a/src/python/library/tritonclient/http/_utils.py
+++ b/src/python/library/tritonclient/http/_utils.py
@@ -153,4 +153,4 @@ def _get_inference_request(
         )
         return request_body, json_size
 
-    return request_body, None
+    return request_body.encode(), None


### PR DESCRIPTION
This updates `_get_inference_request` to always return the request body as `bytes`, as per the `InferenceServerClient .generate_request_body` docstring.

Issues are disabled for this repository, so I apologize if it isn't appropriate to open PRs here!