### PR TITLE
Replace deprecated distutils 

### DIFF
--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -32,7 +32,6 @@ import re
 import shutil
 import subprocess
 import sys
-from distutils.dir_util import copy_tree
 from tempfile import mkstemp
 
 
@@ -51,7 +50,7 @@ def touch(path):
 
 
 def cpdir(src, dest):
-    copy_tree(src, dest, preserve_symlinks=1)
+    shutil.copytree(src, dest, preserve_symlinks=1)
 
 
 def sed(pattern, replace, source, dest=None):

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -50,7 +50,7 @@ def touch(path):
 
 
 def cpdir(src, dest):
-    shutil.copytree(src, dest, symlinks=True)
+    shutil.copytree(src, dest, symlinks=True, dirs_exist_ok=True)
 
 
 def sed(pattern, replace, source, dest=None):

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -50,7 +50,7 @@ def touch(path):
 
 
 def cpdir(src, dest):
-    shutil.copytree(src, dest, preserve_symlinks=1)
+    shutil.copytree(src, dest, symlinks=True)
 
 
 def sed(pattern, replace, source, dest=None):


### PR DESCRIPTION
Distutils is being deprecated. Replace the use of copy_tree with the shutil version.

Related server PR: https://github.com/triton-inference-server/server/pull/6190
Related model analyzer PR: https://github.com/triton-inference-server/model_analyzer/pull/746