### PR TITLE
Fix trailing comma in CSV for verbose_csv and collect_metrics modes

### DIFF
--- a/src/c++/perf_analyzer/report_writer.cc
+++ b/src/c++/perf_analyzer/report_writer.cc
@@ -98,17 +98,16 @@ ReportWriter::GenerateReport()
       ofs << ",p" << percentile.first << " latency";
     }
     if (verbose_csv_) {
-      ofs << ",";
       if (percentile_ == -1) {
-        ofs << "Avg latency,";
+        ofs << ",Avg latency";
       }
-      ofs << "request/response,";
-      ofs << "response wait,";
+      ofs << ",request/response";
+      ofs << ",response wait";
       if (should_output_metrics_) {
-        ofs << "Avg GPU Utilization,";
-        ofs << "Avg GPU Power Usage,";
-        ofs << "Max GPU Memory Usage,";
-        ofs << "Total GPU Memory";
+        ofs << ",Avg GPU Utilization";
+        ofs << ",Avg GPU Power Usage";
+        ofs << ",Max GPU Memory Usage";
+        ofs << ",Total GPU Memory";
       }
     }
     ofs << std::endl;
@@ -221,12 +220,11 @@ ReportWriter::GenerateReport()
             status.client_stats.avg_request_time_ns / 1000;
         const uint64_t avg_response_wait_time_us =
             avg_request_time_us - avg_send_time_us - avg_receive_time_us;
-        ofs << ",";
         if (percentile_ == -1) {
-          ofs << avg_latency_us << ",";
+          ofs << "," << avg_latency_us;
         }
-        ofs << std::to_string(avg_send_time_us + avg_receive_time_us) << ",";
-        ofs << std::to_string(avg_response_wait_time_us) << ",";
+        ofs << "," << std::to_string(avg_send_time_us + avg_receive_time_us);
+        ofs << "," << std::to_string(avg_response_wait_time_us);
         if (should_output_metrics_) {
           if (status.metrics.size() == 1) {
             WriteGpuMetrics(ofs, status.metrics[0]);
@@ -371,6 +369,8 @@ ReportWriter::WriteGpuMetrics(std::ostream& ofs, const Metrics& metric)
   auto& gpu_power_usage_map = metric.gpu_power_usage_per_gpu;
   auto& gpu_mem_usage_map = metric.gpu_memory_used_bytes_per_gpu;
   auto& gpu_total_mem_map = metric.gpu_memory_total_bytes_per_gpu;
+  // Currently assume GPU metrics will be appended to existing line
+  ofs << ",";
   for (auto& entry : gpu_util_map) {
     ofs << entry.first << ":" << entry.second << ";";
   }
@@ -386,7 +386,6 @@ ReportWriter::WriteGpuMetrics(std::ostream& ofs, const Metrics& metric)
   for (auto& entry : gpu_total_mem_map) {
     ofs << entry.first << ":" << entry.second << ";";
   }
-  ofs << ",";
 }
 
 }}  // namespace triton::perfanalyzer


### PR DESCRIPTION
## Overview

There are a few places where trailing commas are left depending on config flags:
- [Here](https://github.com/triton-inference-server/client/blob/d257c0e5c3de6e15d6ef289ff2b96cecd0a69b5f/src/c%2B%2B/perf_analyzer/report_writer.cc#L106) if should_output_metrics is false
- When [writing metrics](https://github.com/triton-inference-server/client/blob/d257c0e5c3de6e15d6ef289ff2b96cecd0a69b5f/src/c%2B%2B/perf_analyzer/report_writer.cc#L389)

## Test/verification
Ideally there should be some unit tests to validate the produced CSVs are actually valid CSV files (no trailing delimiters), but verified locally here:

```
# Gather CSVs for different combinations of flags
./perf_analyzer -m id --shape INPUT0:1,1 --concurrency 1:2 -f report.csv
./perf_analyzer -m id --shape INPUT0:1,1 --concurrency 1:2 -f report_metrics.csv --collect-metrics
./perf_analyzer -m id --shape INPUT0:1,1 --concurrency 1:2 -f report_verbose.csv --verbose-csv
./perf_analyzer -m id --shape INPUT0:1,1 --concurrency 1:2 -f report_verbose_metrics.csv --verbose-csv --collect-metrics

# Verify CSVs set concurrency column correctly instead of getting shifted over
CSVS="report.csv report_metrics.csv report_verbose.csv report_verbose_metrics.csv"
for csv in ${CSVS}; do
  python -c "import pandas as pd; df = pd.read_csv('${csv}'); print(df); assert df['Concurrency'][0] == 1"
done
```
Side note, nice tool for visual verification via `jq`:
```
$ jq -cR 'split(",")' report.csv
["Concurrency","Inferences/Second","Client Send","Network+Server Send/Recv","Server Queue","Server Compute Input","Server Compute Infer","Server Compute Output","Client Recv","p50 latency","p90 latency","p95 latency","p99 latency"]
["1","2281.23","109","284","29","1","12","0","0","413","588","656","806"]
["2","4174.56","120","315","28","1","11","0","0","459","636","701","864"]
```