### PR TITLE
Add new command line options to enable periodic concurrency mode

### DIFF
--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -334,8 +334,8 @@ CLParser::Usage(const std::string& msg)
              "--request-parameter <name:value:type>: Specifies a custom "
              "parameter that can be sent to a Triton backend as part of the "
              "request. For example, providing '--request-parameter "
-             "max_tokens:256:uint' to the command line will set an additional "
-             "parameter 'max_tokens' of type 'uint' to 256 as part of the "
+             "max_tokens:256:int' to the command line will set an additional "
+             "parameter 'max_tokens' of type 'int' to 256 as part of the "
              "request. The --request-parameter may be specified multiple times "
              "for different custom parameters.",
              18)
@@ -1538,7 +1538,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           break;
         }
         case 59: {
-          params_->using_periodic_concurrency_range = true;
+          params_->is_using_periodic_concurrency_mode = true;
           std::string arg = optarg;
           std::vector<std::string> values{SplitString(arg)};
           if (values.size() < 2) {
@@ -1605,9 +1605,6 @@ CLParser::ParseCommandLine(int argc, char** argv)
           if (type == "bool") {
             param.type = RequestParameterType::BOOL;
             param.bool_value = value == "true" ? true : false;
-          } else if (type == "uint") {
-            param.type = RequestParameterType::UINT;
-            param.uint_value = std::stoull(value);
           } else if (type == "int") {
             param.type = RequestParameterType::INT;
             param.int_value = std::stoll(value);
@@ -1780,7 +1777,7 @@ CLParser::VerifyOptions()
   }
 
   std::vector<bool> load_modes{
-      params_->using_periodic_concurrency_range,
+      params_->is_using_periodic_concurrency_mode,
       params_->using_concurrency_range, params_->using_request_rate_range,
       params_->using_custom_intervals};
   if (std::count(load_modes.begin(), load_modes.end(), true) > 1) {
@@ -1791,13 +1788,13 @@ CLParser::VerifyOptions()
         "--request-intervals.");
   }
 
-  if (params_->using_periodic_concurrency_range && !params_->streaming) {
+  if (params_->is_using_periodic_concurrency_mode && !params_->streaming) {
     Usage(
         "The --periodic-concurrency-range option requires bi-directional gRPC "
         "streaming.");
   }
 
-  if (params_->using_periodic_concurrency_range &&
+  if (params_->is_using_periodic_concurrency_mode &&
       (params_->profile_export_file == "")) {
     Usage(
         "Must provide --profile-export-file when using the "

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1799,6 +1799,13 @@ CLParser::VerifyOptions()
         "--periodic-concurrency-range option.");
   }
 
+  if (params_->request_parameters.size() > 0 &&
+      params_->protocol != cb::ProtocolType::GRPC) {
+    Usage(
+        "The --request-parameter option is currently only supported by gRPC "
+        "protocol.");
+  }
+
   if (params_->using_request_rate_range && params_->mpi_driver->IsMPIRun() &&
       (params_->request_rate_range[SEARCH_RANGE::kEND] != 1.0 ||
        params_->request_rate_range[SEARCH_RANGE::kSTEP] != 1.0)) {

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -964,37 +964,23 @@ CLParser::ParseCommandLine(int argc, char** argv)
         case 7: {
           params_->using_concurrency_range = true;
           std::string arg = optarg;
-          size_t pos = 0;
-          int index = 0;
-          while (pos != std::string::npos) {
-            size_t colon_pos = arg.find(":", pos);
-            if (index > 2) {
-              Usage(
-                  "Failed to parse --concurrency-range. The value does not "
-                  "match <start:end:step>.");
-            }
-            int64_t val;
-            if (colon_pos == std::string::npos) {
-              val = std::stoull(arg.substr(pos, colon_pos));
-              pos = colon_pos;
-            } else {
-              val = std::stoull(arg.substr(pos, colon_pos - pos));
-              pos = colon_pos + 1;
-            }
-            switch (index) {
-              case 0:
-                params_->concurrency_range.start = val;
-                break;
-              case 1:
-                params_->concurrency_range.end = val;
-                break;
-              case 2:
-                params_->concurrency_range.step = val;
-                break;
-            }
-            index++;
+          std::vector<std::string> values{SplitString(arg)};
+          if (values.size() > 3) {
+            Usage(
+                "Failed to parse --concurrency-range. The value does not match "
+                "<start:end:step>.");
           }
 
+          for (size_t i = 0; i < values.size(); ++i) {
+            uint64_t val = std::stoull(values[i]);
+            if (i == 0) {
+              params_->concurrency_range.start = val;
+            } else if (i == 1) {
+              params_->concurrency_range.end = val;
+            } else if (i == 2) {
+              params_->concurrency_range.step = val;
+            }
+          }
           break;
         }
         case 8:

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1735,6 +1735,12 @@ CLParser::VerifyOptions()
         "--request-intervals.");
   }
 
+  if (params_->using_periodic_concurrency_range && !params_->streaming) {
+    Usage(
+        "The --periodic-concurrency-range option requires bi-directional gRPC "
+        "streaming.");
+  }
+
   if (params_->using_periodic_concurrency_range &&
       (params_->profile_export_file == "")) {
     Usage(

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -279,15 +279,15 @@ CLParser::Usage(const std::string& msg)
   std::cerr
       << FormatMessage(
              "--periodic-concurrency-range <start:end:step>: Determines the "
-             "range of concurrency levels in the similar manner as the "
-             "--concurrency-range. The perf_analyzer will start from the "
+             "range of concurrency levels in the similar manner as "
+             "--concurrency-range. Perf Analyzer will start from the "
              "concurrency level of 'start' and go until it reaches 'end' with "
              "a stride of 'step'. Unlike --concurrency-range, the user can "
              "specify *when* to periodically increase the concurrency level "
              "using the --request-period option. The concurrency level will "
              "periodically increase for every n-th response specified by "
              "--request-period. Since this disables stability check in "
-             "perf_analyzer and reports response timestamps only, the user "
+             "Perf Analyzer and reports response timestamps only, the user "
              "must provide --profile-export-file to specify where to dump all "
              "the measured timestamps. The default values of 'start', 'end', "
              "and 'step' are 1.",
@@ -295,10 +295,10 @@ CLParser::Usage(const std::string& msg)
       << std::endl;
   std::cerr
       << FormatMessage(
-             "--request-period: Indicates the number of responses that each "
-             "request will wait until it launches a new, concurrent "
-             "request when --periodic-concurrency-range is specified. "
-             "Default value is 10.",
+             "--request-period <n>: Indicates the number of responses that "
+             "each request must receive before new, concurrent requests are "
+             "sent when --periodic-concurrency-range is specified. Default "
+             "value is 10.",
              18)
       << std::endl;
   std::cerr

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1603,18 +1603,23 @@ CLParser::ParseCommandLine(int argc, char** argv)
 
           RequestParameter param;
           if (type == "bool") {
+            param.type = RequestParameterType::BOOL;
             param.bool_value = value == "true" ? true : false;
           } else if (type == "uint") {
+            param.type = RequestParameterType::UINT;
             param.uint_value = std::stoull(value);
           } else if (type == "int") {
+            param.type = RequestParameterType::INT;
             param.int_value = std::stoll(value);
           } else if (type == "string") {
+            param.type = RequestParameterType::STRING;
             param.str_value = value;
           } else {
             Usage(
                 "Failed to parse --request-parameter. Unsupported type: '" +
                 type + "'.");
           }
+          params_->request_parameters[name] = param;
           break;
         }
         case 'v':

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -58,9 +58,6 @@ struct PerfAnalyzerParameters {
   uint64_t measurement_window_ms = 5000;
   bool using_concurrency_range = false;
   Range<uint64_t> concurrency_range{1, 1, 1};
-  bool using_periodic_concurrency_range = false;
-  Range<uint64_t> periodic_concurrency_range{1, 1, 1};
-  uint64_t request_period = 10;
   std::unordered_map<std::string, RequestParameter> request_parameters;
   uint64_t latency_threshold_ms = NO_LIMIT;
   double stability_threshold = 0.1;
@@ -155,9 +152,8 @@ struct PerfAnalyzerParameters {
   std::string profile_export_file{""};
 
   bool is_using_periodic_concurrency_mode{false};
-
   Range<uint64_t> periodic_concurrency_range{1, 1, 1};
-  uint64_t periodic_concurrency_request_period{10};
+  uint64_t request_period{10};
 };
 
 using PAParamsPtr = std::shared_ptr<PerfAnalyzerParameters>;

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -61,6 +61,7 @@ struct PerfAnalyzerParameters {
   bool using_periodic_concurrency_range = false;
   Range<uint64_t> periodic_concurrency_range{1, 1, 1};
   uint64_t request_period = 10;
+  std::unordered_map<std::string, RequestParameter> request_parameters;
   uint64_t latency_threshold_ms = NO_LIMIT;
   double stability_threshold = 0.1;
   size_t max_trials = 10;

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -58,6 +58,9 @@ struct PerfAnalyzerParameters {
   uint64_t measurement_window_ms = 5000;
   bool using_concurrency_range = false;
   Range<uint64_t> concurrency_range{1, 1, 1};
+  bool using_periodic_concurrency_range = false;
+  Range<uint64_t> periodic_concurrency_range{1, 1, 1};
+  uint64_t request_period = 10;
   uint64_t latency_threshold_ms = NO_LIMIT;
   double stability_threshold = 0.1;
   size_t max_trials = 10;

--- a/src/c++/perf_analyzer/docs/cli.md
+++ b/src/c++/perf_analyzer/docs/cli.md
@@ -207,12 +207,12 @@ Default value is `10`.
 #### `--request-parameter=<name:value:type>`
 
 Specifies a custom parameter that can be sent to a Triton backend as part of
-the request. For example, providing '--request-parameter max_tokens:256:uint'
+the request. For example, providing '--request-parameter max_tokens:256:int'
 to the command line will set an additional parameter 'max_tokens' of type
-'uint' to 256 as part of the request. The --request-parameter may be specified
+'int' to 256 as part of the request. The --request-parameter may be specified
 multiple times for different custom parameters.
 
-Valid `type` values are: `bool`, `int`, `uint`, and `string`.
+Valid `type` values are: `bool`, `int`, and `string`.
 
 > **NOTE**
 >

--- a/src/c++/perf_analyzer/docs/cli.md
+++ b/src/c++/perf_analyzer/docs/cli.md
@@ -182,16 +182,18 @@ mode.
 
 #### `--periodic-concurrency-range=<start:end:step>`
 
-Specifies the range of concurrency levels in the similar manner as
-`--concurrency-range`. Perf Analyzer will start from the concurrency level
-of 'start' and go until it reaches 'end' with a stride of 'step'.
-Unlike `--concurrency-range`, the user can specify *when* to periodically
-increase the concurrency level using the `--request-period` option.
-The concurrency level will periodically increase for every `n`-th response
-specified by `--request-period`.
-Since this disables stability check in Perf Analyzer and reports response
-timestamps only, the user must provide `--profile-export-file` to specify where
-to dump all the measured response timestamps.
+Specifies the range of concurrency levels in the similar but slightly different
+manner as the `--concurrency-range`. Perf Analyzer will start from the
+concurrency level of 'start' and increase by 'step' each time. Unlike
+`--concurrency-range`, the 'end' indicates the *total* number of concurrency
+since the 'start' (including) and will stop increasing once the cumulative
+number of concurrent requests has reached the 'end'. The user can specify
+*when* to periodically increase the concurrency level using the
+`--request-period` option. The concurrency level will periodically increase for
+every `n`-th response specified by `--request-period`. Since this disables
+stability check in Perf Analyzer and reports response timestamps only, the user
+must provide `--profile-export-file` to specify where to dump all the measured
+timestamps.
 
 The default values of 'start', 'end', and 'step' are `1`.
 
@@ -201,6 +203,20 @@ Specifies the number of responses that each request must receive before new,
 concurrent requests are sent when `--periodic-concurrency-range` is specified.
 
 Default value is `10`.
+
+#### `--request-parameter=<name:value:type>`
+
+Specifies a custom parameter that can be sent to a Triton backend as part of
+the request. For example, providing '--request-parameter max_tokens:256:uint'
+to the command line will set an additional parameter 'max_tokens' of type
+'uint' to 256 as part of the request. The --request-parameter may be specified
+multiple times for different custom parameters.
+
+Valid `type` values are: `bool`, `int`, `uint`, and `string`.
+
+> **NOTE**
+>
+> The `--request-parameter` is currently only supported by gRPC protocol.
 
 #### `--request-rate-range=<start:end:step>`
 

--- a/src/c++/perf_analyzer/docs/cli.md
+++ b/src/c++/perf_analyzer/docs/cli.md
@@ -209,7 +209,7 @@ Default value is `10`.
 Specifies a custom parameter that can be sent to a Triton backend as part of
 the request. For example, providing '--request-parameter max_tokens:256:int'
 to the command line will set an additional parameter 'max_tokens' of type
-'int' to 256 as part of the request. The --request-parameter may be specified
+'int64' to 256 as part of the request. The --request-parameter may be specified
 multiple times for different custom parameters.
 
 Valid `type` values are: `bool`, `int`, and `string`.

--- a/src/c++/perf_analyzer/docs/cli.md
+++ b/src/c++/perf_analyzer/docs/cli.md
@@ -182,23 +182,23 @@ mode.
 
 #### `--periodic-concurrency-range=<start:end:step>`
 
-Determines the range of concurrency levels in the similar manner as the
-`--concurrency-range`. The perf_analyzer will start from the concurrency level
+Specifies the range of concurrency levels in the similar manner as
+`--concurrency-range`. Perf Analyzer will start from the concurrency level
 of 'start' and go until it reaches 'end' with a stride of 'step'.
 Unlike `--concurrency-range`, the user can specify *when* to periodically
 increase the concurrency level using the `--request-period` option.
 The concurrency level will periodically increase for every `n`-th response
 specified by `--request-period`.
-Since this disables stability check in perf_analyzer and reports response
+Since this disables stability check in Perf Analyzer and reports response
 timestamps only, the user must provide `--profile-export-file` to specify where
 to dump all the measured response timestamps.
 
 The default values of 'start', 'end', and 'step' are `1`.
 
-#### `--request-period <number of responses>`
+#### `--request-period=<n>`
 
-Indicates the number of responses that each request will wait until it launches
-a new, concurrent request when `--periodic-concurrency-range` is specified.
+Specifies the number of responses that each request must receive before new,
+concurrent requests are sent when `--periodic-concurrency-range` is specified.
 
 Default value is `10`.
 

--- a/src/c++/perf_analyzer/docs/cli.md
+++ b/src/c++/perf_analyzer/docs/cli.md
@@ -173,12 +173,34 @@ Specifies the range of concurrency levels covered by Perf Analyzer. Perf
 Analyzer will start from the concurrency level of 'start' and go until 'end'
 with a stride of 'step'.
 
-Default of 'end' and 'step' are `1`. If 'end' is not specified then Perf
-Analyzer will run for a single concurrency level determined by 'start'. If
+Default of 'start', 'end', and 'step' are `1`. If 'end' is not specified then
+Perf Analyzer will run for a single concurrency level determined by 'start'. If
 'end' is set as `0`, then the concurrency limit will be incremented by 'step'
 until the latency threshold is met. 'end' and `--latency-threshold` cannot
 both be `0`. 'end' cannot be `0` for sequence models while using asynchronous
 mode.
+
+#### `--periodic-concurrency-range=<start:end:step>`
+
+Determines the range of concurrency levels in the similar manner as the
+`--concurrency-range`. The perf_analyzer will start from the concurrency level
+of 'start' and go until it reaches 'end' with a stride of 'step'.
+Unlike `--concurrency-range`, the user can specify *when* to periodically
+increase the concurrency level using the `--request-period` option.
+The concurrency level will periodically increase for every `n`-th response
+specified by `--request-period`.
+Since this disables stability check in perf_analyzer and reports response
+timestamps only, the user must provide `--profile-export-file` to specify where
+to dump all the measured response timestamps.
+
+The default values of 'start', 'end', and 'step' are `1`.
+
+#### `--request-period <number of responses>`
+
+Indicates the number of responses that each request will wait until it launches
+a new, concurrent request when `--periodic-concurrency-range` is specified.
+
+Default value is `10`.
 
 #### `--request-rate-range=<start:end:step>`
 

--- a/src/c++/perf_analyzer/docs/cli.md
+++ b/src/c++/perf_analyzer/docs/cli.md
@@ -209,7 +209,7 @@ Default value is `10`.
 Specifies a custom parameter that can be sent to a Triton backend as part of
 the request. For example, providing '--request-parameter max_tokens:256:int'
 to the command line will set an additional parameter 'max_tokens' of type
-'int64' to 256 as part of the request. The --request-parameter may be specified
+'int' to 256 as part of the request. The --request-parameter may be specified
 multiple times for different custom parameters.
 
 Valid `type` values are: `bool`, `int`, and `string`.

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -160,13 +160,6 @@ PerfAnalyzer::CreateAnalyzerObjects()
   }
 
   std::unique_ptr<pa::LoadManager> manager;
-  params_->is_using_periodic_concurrency_mode = true;
-  params_->periodic_concurrency_range = {
-      std::stoi(std::getenv("MY_START")), std::stoi(std::getenv("MY_END")),
-      std::stoi(std::getenv("MY_STEP"))};
-  params_->periodic_concurrency_request_period =
-      std::stoi(std::getenv("MY_REQUEST_PERIOD"));
-
   if (params_->targeting_concurrency()) {
     if ((parser_->SchedulerType() == pa::ModelParser::SEQUENCE) ||
         (parser_->SchedulerType() == pa::ModelParser::ENSEMBLE_SEQUENCE)) {
@@ -221,8 +214,7 @@ PerfAnalyzer::CreateAnalyzerObjects()
         params_->async, params_->streaming, params_->batch_size,
         params_->max_threads, params_->max_concurrency,
         params_->shared_memory_type, params_->output_shm_size, parser_, factory,
-        params_->periodic_concurrency_range,
-        params_->periodic_concurrency_request_period);
+        params_->periodic_concurrency_range, params_->request_period);
   } else if (params_->using_request_rate_range) {
     if ((params_->sequence_id_range != 0) &&
         (params_->sequence_id_range < params_->num_of_sequences)) {

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -83,12 +83,11 @@ class Range {
   T step;
 };
 
-enum RequestParameterType { STRING = 0, INT = 1, UINT = 2, BOOL = 3 };
+enum RequestParameterType { STRING = 0, INT = 1, BOOL = 3 };
 
 struct RequestParameter {
   std::string str_value;
   int64_t int_value;
-  uint64_t uint_value;
   bool bool_value;
   RequestParameterType type;
 };

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -83,7 +83,7 @@ class Range {
   T step;
 };
 
-enum RequestParameterType { STRING = 0, INT = 1, BOOL = 3 };
+enum RequestParameterType { STRING = 0, INT = 1, BOOL = 2 };
 
 struct RequestParameter {
   std::string str_value;

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -83,6 +83,13 @@ class Range {
   T step;
 };
 
+struct RequestParameter {
+  std::string str_value;
+  int64_t int_value;
+  uint64_t uint_value;
+  bool bool_value;
+};
+
 // Converts the datatype from tensorflow to perf analyzer space
 // \param tf_dtype The data type string returned from the model metadata.
 // \param datatype Returns the datatype in perf_analyzer space.

--- a/src/c++/perf_analyzer/perf_utils.h
+++ b/src/c++/perf_analyzer/perf_utils.h
@@ -83,11 +83,14 @@ class Range {
   T step;
 };
 
+enum RequestParameterType { STRING = 0, INT = 1, UINT = 2, BOOL = 3 };
+
 struct RequestParameter {
   std::string str_value;
   int64_t int_value;
   uint64_t uint_value;
   bool bool_value;
+  RequestParameterType type;
 };
 
 // Converts the datatype from tensorflow to perf analyzer space

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -493,26 +493,6 @@ CheckInvalidRange(
 
     check_params = false;
   }
-
-  SUBCASE("wrong separator")
-  {
-    args.push_back(option_name);
-    args.push_back("100,400,10");
-
-    int argc = args.size();
-    char* argv[argc];
-    std::copy(args.begin(), args.end(), argv);
-
-    REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
-    CHECK(parser.UsageCalled());
-
-    // BUG (TMA-1307): Should detect this and through an error. User will
-    // enter this and have no clue why the end and step sizes are not used
-    // correctly.
-    //
-
-    check_params = false;
-  }
 }
 
 
@@ -1166,6 +1146,26 @@ TEST_CASE("Testing Command Line Parser")
         exp->concurrency_range);
 
     CheckInvalidRange(args, option_name, parser, act, check_params);
+
+    SUBCASE("wrong separator")
+    {
+      args.push_back(option_name);
+      args.push_back("100,400,10");
+
+      int argc = args.size();
+      char* argv[argc];
+      std::copy(args.begin(), args.end(), argv);
+
+      REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
+      CHECK(!parser.UsageCalled());
+
+      // BUG (TMA-1307): Should detect this and through an error. User will
+      // enter this and have no clue why the end and step sizes are not used
+      // correctly.
+      //
+
+      check_params = false;
+    }
 
     SUBCASE("invalid condition - end and latency threshold are 0")
     {

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -1194,8 +1194,13 @@ TEST_CASE("Testing Command Line Parser")
     char* option_name = "--periodic-concurrency-range";
 
     // Add required args that specifies where to dump profiled data
-    args.push_back("--profile-export-file");
-    args.push_back("profile.json");
+    args.insert(
+        args.end(), {"-i", "grpc", "--async", "--streaming",
+                     "--profile-export-file", "profile.json"});
+    exp->protocol = cb::ProtocolType::GRPC;
+    exp->async = true;
+    exp->streaming = true;
+    exp->url = "localhost:8001";  // gRPC url
 
     CheckValidRange(
         args, option_name, parser, act, exp->using_periodic_concurrency_range,
@@ -1229,7 +1234,7 @@ TEST_CASE("Testing Command Line Parser")
 
     SUBCASE("no export file specified")
     {
-      // Remove the required args
+      // Remove the export file args
       args.pop_back();
       args.pop_back();
 

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -1171,6 +1171,24 @@ TEST_CASE("Testing Command Line Parser")
     CHECK_RANGE_STEP_VALUE("--periodic-concurrency-range", expected_msg);
   }
 
+  SUBCASE("Option : --request-period")
+  {
+    expected_msg =
+        CreateUsageMessage("--request-period", "The value must be > 0");
+    CHECK_INT_OPTION("--request-period", exp->request_period, expected_msg);
+
+    SUBCASE("set to 0")
+    {
+      int argc = 5;
+      char* argv[argc] = {app_name, "-m", model_name, "--request-period", "0"};
+
+      REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
+      CHECK(parser.UsageCalled());
+
+      CHECK_STRING("Usage Message", parser.GetUsageMessage(), expected_msg);
+    }
+  }
+
   SUBCASE("Option : --latency-threshold")
   {
     expected_msg = CreateUsageMessage(

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -1367,6 +1367,23 @@ TEST_CASE("Testing Command Line Parser")
       check_params = false;
     }
 
+    SUBCASE("valid parameter")
+    {
+      args.push_back(option_name);
+      args.push_back("max_tokens:256:uint");
+
+      int argc = args.size();
+      char* argv[argc];
+      std::copy(args.begin(), args.end(), argv);
+
+      REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
+      CHECK(!parser.UsageCalled());
+
+      RequestParameter param;
+      param.uint_value = 256;
+      exp->request_parameters["max_tokens"] = param;
+    }
+
     SUBCASE("unsupported type")
     {
       args.push_back(option_name);

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -1159,19 +1159,24 @@ TEST_CASE("Testing Command Line Parser")
 
   SUBCASE("Option : --concurrency-range")
   {
+    char* option_name = "--concurrency-range";
+
     CheckValidRange(
-        args, "--concurrency-range", parser, act, exp->using_concurrency_range,
+        args, option_name, parser, act, exp->using_concurrency_range,
         exp->concurrency_range);
 
-    CheckInvalidRange(args, "--concurrency-range", parser, act, check_params);
+    CheckInvalidRange(args, option_name, parser, act, check_params);
 
     SUBCASE("invalid condition - end and latency threshold are 0")
     {
-      int argc = 7;
-      char* argv[argc] = {app_name,   "-m",
-                          model_name, "--concurrency-range",
-                          "100:0:25", "--latency-threshold",
-                          "0"};
+      args.push_back(option_name);
+      args.push_back("100:0:25");
+      args.push_back("--latency-threshold");
+      args.push_back("0");
+
+      int argc = args.size();
+      char* argv[argc];
+      std::copy(args.begin(), args.end(), argv);
 
       REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
       CHECK(parser.UsageCalled());
@@ -1180,11 +1185,7 @@ TEST_CASE("Testing Command Line Parser")
           "The end of the search range and the latency limit can not be both 0 "
           "(or 0.0) simultaneously");
 
-      exp->using_concurrency_range = true;
-      exp->concurrency_range.start = 100;
-      exp->concurrency_range.end = 0;
-      exp->concurrency_range.step = 25;
-      exp->latency_threshold_ms = 0;
+      check_params = false;
     }
   }
 

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -1614,9 +1614,10 @@ TEST_CASE("Testing Command Line Parser")
 
   if (check_params) {
     if (act == nullptr) {
-      std::cerr << "Error: Attempting to access a null pointer `act` will lead "
-                   "to undefined behavior. Terminating the test."
-                << std::endl;
+      std::cerr
+          << "Error: Attempting to access `act` but was not initialized. Check "
+             "if the test cases are missing `check_params = false` statement."
+          << std::endl;
       exit(1);
     }
     CHECK_PARAMS(act, exp);

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -536,7 +536,9 @@ TEST_CASE("Testing Command Line Parser")
 {
   char* model_name = "my_model";
   char* app_name = "test_perf_analyzer";
+
   std::string expected_msg;
+  std::vector<char*> args{app_name, "-m", model_name};
 
   opterr = 1;  // Enable error output for GetOpt library
   bool check_params = true;
@@ -1157,7 +1159,6 @@ TEST_CASE("Testing Command Line Parser")
 
   SUBCASE("Option : --concurrency-range")
   {
-    std::vector<char*> args{app_name, "-m", model_name};
     CheckValidRange(
         args, "--concurrency-range", parser, act, exp->using_concurrency_range,
         exp->concurrency_range);
@@ -1190,8 +1191,10 @@ TEST_CASE("Testing Command Line Parser")
   SUBCASE("Option : --periodic-concurrency-range")
   {
     char* option_name = "--periodic-concurrency-range";
-    std::vector<char*> args{
-        app_name, "-m", model_name, "--profile-export-file", "profile.json"};
+
+    // Add required args that specifies where to dump profiled data
+    args.push_back("--profile-export-file");
+    args.push_back("profile.json");
 
     CheckValidRange(
         args, option_name, parser, act, exp->using_periodic_concurrency_range,
@@ -1225,13 +1228,16 @@ TEST_CASE("Testing Command Line Parser")
 
     SUBCASE("no export file specified")
     {
-      std::vector<char*> args_{app_name, "-m", model_name};
-      args_.push_back(option_name);
-      args_.push_back("100:400");
+      // Remove the required args
+      args.pop_back();
+      args.pop_back();
 
-      int argc = args_.size();
+      args.push_back(option_name);
+      args.push_back("100:400");
+
+      int argc = args.size();
       char* argv[argc];
-      std::copy(args_.begin(), args_.end(), argv);
+      std::copy(args.begin(), args.end(), argv);
 
       REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
       CHECK(parser.UsageCalled());
@@ -1293,8 +1299,12 @@ TEST_CASE("Testing Command Line Parser")
 
     SUBCASE("set to 0")
     {
-      int argc = 5;
-      char* argv[argc] = {app_name, "-m", model_name, "--request-period", "0"};
+      args.push_back("--request-period");
+      args.push_back("0");
+
+      int argc = args.size();
+      char* argv[argc];
+      std::copy(args.begin(), args.end(), argv);
 
       REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
       CHECK(parser.UsageCalled());

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -176,8 +176,8 @@ CHECK_PARAMS(PAParamsPtr act, PAParamsPtr exp)
   CHECK(act->mpi_driver != nullptr);
   CHECK_STRING(act->memory_type, exp->memory_type);
   CHECK(
-      act->using_periodic_concurrency_range ==
-      exp->using_periodic_concurrency_range);
+      act->is_using_periodic_concurrency_mode ==
+      exp->is_using_periodic_concurrency_mode);
   CHECK(
       act->periodic_concurrency_range.start ==
       exp->periodic_concurrency_range.start);
@@ -200,8 +200,6 @@ CHECK_PARAMS(PAParamsPtr act, PAParamsPtr exp)
       CHECK(act_param.second.str_value == exp_param->second.str_value);
     } else if (act_param.second.type == RequestParameterType::INT) {
       CHECK(act_param.second.int_value == exp_param->second.int_value);
-    } else if (act_param.second.type == RequestParameterType::UINT) {
-      CHECK(act_param.second.uint_value == exp_param->second.uint_value);
     } else if (act_param.second.type == RequestParameterType::BOOL) {
       CHECK(act_param.second.bool_value == exp_param->second.bool_value);
     }
@@ -1232,6 +1230,7 @@ TEST_CASE("Testing Command Line Parser")
     exp->async = true;
     exp->streaming = true;
     exp->url = "localhost:8001";  // gRPC url
+    exp->max_threads = 4;         // not targeting concurrency
 
     SUBCASE("start provided")
     {
@@ -1254,7 +1253,7 @@ TEST_CASE("Testing Command Line Parser")
     }
 
     CheckValidRange(
-        args, option_name, parser, act, exp->using_periodic_concurrency_range,
+        args, option_name, parser, act, exp->is_using_periodic_concurrency_mode,
         exp->periodic_concurrency_range);
 
     CheckInvalidRange(args, option_name, parser, act, check_params);
@@ -1384,7 +1383,7 @@ TEST_CASE("Testing Command Line Parser")
     SUBCASE("valid parameter")
     {
       args.push_back(option_name);
-      args.push_back("max_tokens:256:uint");
+      args.push_back("max_tokens:256:int");
 
       int argc = args.size();
       char* argv[argc];
@@ -1394,8 +1393,8 @@ TEST_CASE("Testing Command Line Parser")
       CHECK(!parser.UsageCalled());
 
       RequestParameter param;
-      param.uint_value = 256;
-      param.type = RequestParameterType::UINT;
+      param.int_value = 256;
+      param.type = RequestParameterType::INT;
       exp->request_parameters["max_tokens"] = param;
     }
 

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -1145,6 +1145,32 @@ TEST_CASE("Testing Command Line Parser")
     }
   }
 
+  SUBCASE("Option: --periodic-concurrency-range")
+  {
+    CHECK_RANGE_PASS(
+        "--periodic-concurrency-range", exp->using_periodic_concurrency_range,
+        exp->periodic_concurrency_range.start,
+        exp->periodic_concurrency_range.end,
+        exp->periodic_concurrency_range.step);
+
+    expected_msg = CreateUsageMessage(
+        "--periodic-concurrency-range",
+        "The value does not match <start:end:step>.");
+    CHECK_RANGE_FAIL("--periodic-concurrency-range", expected_msg);
+
+    expected_msg = CreateUsageMessage(
+        "--periodic-concurrency-range", "Invalid value provided: bad:400:10");
+    CHECK_RANGE_START_VALUE("--periodic-concurrency-range", expected_msg);
+
+    expected_msg = CreateUsageMessage(
+        "--periodic-concurrency-range", "Invalid value provided: 100:bad:10");
+    CHECK_RANGE_END_VALUE("--periodic-concurrency-range", expected_msg);
+
+    expected_msg = CreateUsageMessage(
+        "--periodic-concurrency-range", "Invalid value provided: 100:400:bad");
+    CHECK_RANGE_STEP_VALUE("--periodic-concurrency-range", expected_msg);
+  }
+
   SUBCASE("Option : --latency-threshold")
   {
     expected_msg = CreateUsageMessage(


### PR DESCRIPTION
Add two new command line options to enable periodic concurrency mode in Perf Analyzer:
- `--periodic-concurrency-range=<start:end:step>`
- `--request-period=<n>`
- `--request-parameter=<name:value:type>`

The new command line options will users to launch Perf Analyzer in periodic concurrency mode and can be used as in the following command:
```bash
perf_analyzer -m <model_name> -i grpc --aync --streaming \
    --profile-export-file profile.json \
    --periodic-concurrency-range 20:400:10 \
    --request-period 50 \
    --request-parameter max_tokens:256:int
```

> **Note**
> The periodic concurrency mode only supports the decoupled models, so the user must use gRPC streaming in order to launch it on PA. Additionally, the user must also specify a file where PA could dump all the profiled data since there will be no command line outputs that display the profile statistics as in other modes.