### PR TITLE
Implement periodic concurrency manager/worker and inference profiler workflow

### DIFF
--- a/src/c++/perf_analyzer/CMakeLists.txt
+++ b/src/c++/perf_analyzer/CMakeLists.txt
@@ -69,6 +69,8 @@ set(
   sequence_manager.cc
   profile_data_collector.cc
   profile_data_exporter.cc
+  periodic_concurrency_manager.cc
+  periodic_concurrency_worker.cc
 )
 
 set(
@@ -109,6 +111,8 @@ set(
   request_record.h
   profile_data_collector.h
   profile_data_exporter.h
+  periodic_concurrency_manager.h
+  periodic_concurrency_worker.h
 )
 
 add_executable(

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -130,7 +130,8 @@ struct PerfAnalyzerParameters {
   {
     return (
         using_concurrency_range || using_old_options ||
-        !(using_request_rate_range || using_custom_intervals));
+        !(using_request_rate_range || using_custom_intervals ||
+          using_periodic_concurrency_mode));
   }
 
   // Sets the threshold for PA client overhead.
@@ -148,6 +149,12 @@ struct PerfAnalyzerParameters {
 
   // The profile export file path.
   std::string profile_export_file{""};
+
+  // Whether periodic concurrency mode is being used
+  bool using_periodic_concurrency_mode{false};
+
+  Range<uint64_t> periodic_concurrency_range{1, 1, 1};
+  uint64_t periodic_concurrency_request_period{10};
 };
 
 using PAParamsPtr = std::shared_ptr<PerfAnalyzerParameters>;

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -95,7 +95,6 @@ class ConcurrencyManager : public LoadManager {
       std::shared_ptr<ThreadStat>,
       std::shared_ptr<ConcurrencyWorker::ThreadConfig>);
 
- private:
   ConcurrencyManager(
       const bool async, const bool streaming, const int32_t batch_size,
       const size_t max_threads, const size_t max_concurrency,
@@ -103,6 +102,16 @@ class ConcurrencyManager : public LoadManager {
       const std::shared_ptr<ModelParser>& parser,
       const std::shared_ptr<cb::ClientBackendFactory>& factory);
 
+  // The number of worker threads with non-zero concurrencies
+  size_t active_threads_;
+
+  bool execute_;
+
+  size_t max_concurrency_;
+
+  std::vector<std::shared_ptr<ConcurrencyWorker::ThreadConfig>> threads_config_;
+
+ private:
   void InitManagerFinalize() override;
 
   // Pause all worker threads that are working on sequences
@@ -117,14 +126,6 @@ class ConcurrencyManager : public LoadManager {
   // Restart all worker threads that were working on sequences
   //
   void ResumeSequenceWorkers();
-
-  // The number of worker threads with non-zero concurrencies
-  size_t active_threads_;
-
-  bool execute_;
-
-  size_t max_concurrency_;
-  std::vector<std::shared_ptr<ConcurrencyWorker::ThreadConfig>> threads_config_;
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend TestConcurrencyManager;

--- a/src/c++/perf_analyzer/concurrency_worker.cc
+++ b/src/c++/perf_analyzer/concurrency_worker.cc
@@ -46,31 +46,40 @@ ConcurrencyWorker::Infer()
 
   // run inferencing until receiving exit signal to maintain server load.
   do {
-    HandleExecuteOff();
-
-    if (HandleNoConcurrency()) {
-      return;
+    if (RunInference()) {
+      break;
     }
-
-    CreateContextsAsNecessary();
-
-    if (HandleExitConditions()) {
-      return;
-    }
-
-    SendInferRequests();
-
-    if (HandleExitConditions()) {
-      return;
-    }
-
-    WaitForResponses();
-
-    if (HandleExitConditions()) {
-      return;
-    }
-
   } while (true);
+}
+
+bool
+ConcurrencyWorker::RunInference()
+{
+  HandleExecuteOff();
+
+  if (HandleNoConcurrency()) {
+    return true;
+  }
+
+  CreateContextsAsNecessary();
+
+  if (HandleExitConditions()) {
+    return true;
+  }
+
+  SendInferRequests();
+
+  if (HandleExitConditions()) {
+    return true;
+  }
+
+  WaitForResponses();
+
+  if (HandleExitConditions()) {
+    return true;
+  }
+
+  return false;
 }
 
 void

--- a/src/c++/perf_analyzer/concurrency_worker.h
+++ b/src/c++/perf_analyzer/concurrency_worker.h
@@ -50,9 +50,11 @@ class NaggyMockConcurrencyWorker;
 class ConcurrencyWorker : public LoadWorker {
  public:
   struct ThreadConfig {
-    ThreadConfig(size_t thread_id)
-        : thread_id_(thread_id), concurrency_(0), seq_stat_index_offset_(0),
-          is_paused_(false)
+    ThreadConfig(
+        size_t thread_id, size_t concurrency = 0,
+        size_t seq_stat_index_offset = 0)
+        : thread_id_(thread_id), concurrency_(concurrency),
+          seq_stat_index_offset_(seq_stat_index_offset), is_paused_(false)
     {
     }
 
@@ -91,7 +93,15 @@ class ConcurrencyWorker : public LoadWorker {
   {
   }
 
-  void Infer() override;
+  virtual void Infer() override;
+
+ protected:
+  bool RunInference();
+
+  void CreateCtxIdTracker();
+
+  // Reserve vector size for contexts
+  void ReserveContexts();
 
  private:
   const size_t max_concurrency_;
@@ -100,11 +110,6 @@ class ConcurrencyWorker : public LoadWorker {
   size_t& active_threads_;
 
   std::shared_ptr<ThreadConfig> thread_config_;
-
-  void CreateCtxIdTracker();
-
-  // Reserve vector size for contexts
-  void ReserveContexts();
 
   // Handle the case where execute_ is false
   void HandleExecuteOff();

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -258,6 +258,7 @@ InferContext::AsyncCallbackFuncImpl(cb::InferResult* result)
           return;
         }
         it->second.response_times_.push_back(std::chrono::system_clock::now());
+        num_responses_++;
         if (is_null_response == true) {
           it->second.has_null_last_response_ = true;
         }
@@ -267,6 +268,7 @@ InferContext::AsyncCallbackFuncImpl(cb::InferResult* result)
           return;
         }
         if (is_final_response) {
+          has_received_final_response_ = is_final_response;
           thread_stat_->request_records_.emplace_back(
               it->second.start_time_, it->second.response_times_,
               it->second.sequence_end_, it->second.delayed_,
@@ -279,8 +281,13 @@ InferContext::AsyncCallbackFuncImpl(cb::InferResult* result)
     }
   }
 
+  if (worker_callback_) {
+    worker_callback_(id_);
+  }
+
   if (is_final_response) {
     total_ongoing_requests_--;
+    num_responses_ = 0;
 
     if (async_callback_finalize_func_ != nullptr) {
       async_callback_finalize_func_(id_);

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -116,10 +116,18 @@ class InferContext {
   // object and have not returned
   uint GetNumOngoingRequests() { return total_ongoing_requests_; }
 
+  // Returns the number of responses for the current request
+  uint64_t GetNumResponsesForCurrentRequest() { return num_responses_; }
+
   // Register a function that will get called after every async request returns
   void RegisterAsyncCallbackFinalize(std::function<void(uint32_t)> callback)
   {
     async_callback_finalize_func_ = callback;
+  }
+
+  void RegisterWorkerCallback(std::function<void(uint32_t)> worker_callback)
+  {
+    worker_callback_ = worker_callback;
   }
 
   // TODO REFACTOR TMA-1043 this should be in memory class
@@ -127,6 +135,8 @@ class InferContext {
   {
     num_active_threads_ = num_threads;
   }
+
+  bool HasReceivedFinalResponse() { return has_received_final_response_; }
 
  protected:
   /// A helper function to issue inference request to the server.
@@ -191,6 +201,9 @@ class InferContext {
   std::reference_wrapper<const bool> execute_{execute_placeholder_};
 
   std::shared_ptr<SequenceManager> sequence_manager_{nullptr};
+  uint64_t num_responses_{0};
+  std::function<void(uint32_t)> worker_callback_{nullptr};
+  bool has_received_final_response_{false};
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend NaggyMockInferContext;

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -43,6 +43,7 @@
 #include "metrics_manager.h"
 #include "model_parser.h"
 #include "mpi_utils.h"
+#include "periodic_concurrency_manager.h"
 #include "profile_data_collector.h"
 #include "request_rate_manager.h"
 
@@ -303,6 +304,18 @@ class InferenceProfiler {
         }
       }
     }
+    return cb::Error::Success;
+  }
+
+  cb::Error ProfilePeriodicConcurrencyMode()
+  {
+    auto& manager{dynamic_cast<PeriodicConcurrencyManager&>(*manager_)};
+    std::vector<RequestRecord> request_records{manager.RunExperiment()};
+
+    InferenceLoadMode id{1, 0.0};
+    collector_->AddWindow(id, 0, UINT64_MAX);
+    collector_->AddData(id, std::move(request_records));
+
     return cb::Error::Success;
   }
 

--- a/src/c++/perf_analyzer/periodic_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/periodic_concurrency_manager.cc
@@ -1,0 +1,121 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "periodic_concurrency_manager.h"
+
+namespace triton { namespace perfanalyzer {
+
+std::vector<RequestRecord>
+PeriodicConcurrencyManager::RunExperiment()
+{
+  AddConcurrentRequests(concurrency_range_.start);
+  WaitForRequestsToFinish();
+  return GetRequestRecords();
+}
+
+std::shared_ptr<IWorker>
+PeriodicConcurrencyManager::MakeWorker(
+    std::shared_ptr<ThreadStat> thread_stat,
+    std::shared_ptr<PeriodicConcurrencyWorker::ThreadConfig> thread_config)
+{
+  uint32_t id = workers_.size();
+
+  auto worker = std::make_shared<PeriodicConcurrencyWorker>(
+      id, thread_stat, thread_config, parser_, data_loader_, factory_,
+      on_sequence_model_, async_, max_concurrency_, using_json_data_,
+      streaming_, batch_size_, wake_signal_, wake_mutex_, active_threads_,
+      execute_, infer_data_manager_, sequence_manager_, request_period_,
+      period_completed_callback_, request_completed_callback_);
+  return worker;
+};
+
+void
+PeriodicConcurrencyManager::AddConcurrentRequests(
+    uint64_t num_concurrent_requests)
+{
+  for (size_t i = 0; i < num_concurrent_requests; i++) {
+    threads_stat_.emplace_back(std::make_shared<ThreadStat>());
+    threads_config_.emplace_back(
+        std::make_shared<ConcurrencyWorker::ThreadConfig>(
+            threads_config_.size(), 1, i));
+    workers_.emplace_back(
+        MakeWorker(threads_stat_.back(), threads_config_.back()));
+    threads_.emplace_back(&IWorker::Infer, workers_.back());
+    active_threads_++;
+  }
+  num_incomplete_periods_ = num_concurrent_requests;
+}
+
+void
+PeriodicConcurrencyManager::PeriodCompletedCallback()
+{
+  std::lock_guard<std::mutex> lock(period_completed_callback_mutex_);
+
+  num_incomplete_periods_--;
+
+  if (num_incomplete_periods_ == 0) {
+    steps_completed_++;
+    if (steps_completed_ * concurrency_range_.step < concurrency_range_.end) {
+      AddConcurrentRequests(concurrency_range_.step);
+    }
+  }
+}
+
+void
+PeriodicConcurrencyManager::RequestCompletedCallback()
+{
+  std::lock_guard<std::mutex> lock(request_completed_callback_mutex_);
+
+  num_completed_requests_++;
+
+  if (num_completed_requests_ == concurrency_range_.end) {
+    all_requests_completed_promise_.set_value(true);
+  }
+}
+
+void
+PeriodicConcurrencyManager::WaitForRequestsToFinish()
+{
+  std::future<bool> all_requests_completed_future{
+      all_requests_completed_promise_.get_future()};
+  all_requests_completed_future.get();
+}
+
+std::vector<RequestRecord>
+PeriodicConcurrencyManager::GetRequestRecords()
+{
+  std::vector<RequestRecord> request_records{};
+
+  for (const auto& thread_stat : threads_stat_) {
+    request_records.insert(
+        request_records.end(), thread_stat->request_records_.cbegin(),
+        thread_stat->request_records_.cend());
+  }
+
+  return request_records;
+}
+
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/periodic_concurrency_manager.h
+++ b/src/c++/perf_analyzer/periodic_concurrency_manager.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <future>
+
+#include "concurrency_manager.h"
+#include "periodic_concurrency_worker.h"
+
+namespace triton { namespace perfanalyzer {
+
+/// @brief Concurrency manager for periodically increasing concurrency by a step
+/// amount based on the number of responses received (request period) by the
+/// latest N (step or start concurrency for first-issued concurrent requests)
+/// concurrent requests/workers.
+class PeriodicConcurrencyManager : public ConcurrencyManager {
+ public:
+  PeriodicConcurrencyManager(
+      const bool async, const bool streaming, const int32_t batch_size,
+      const size_t max_threads, const size_t max_concurrency,
+      const SharedMemoryType shared_memory_type, const size_t output_shm_size,
+      const std::shared_ptr<ModelParser>& parser,
+      const std::shared_ptr<cb::ClientBackendFactory>& factory,
+      const Range<uint64_t> concurrency_range, const uint64_t request_period)
+      : ConcurrencyManager(
+            async, streaming, batch_size, max_threads, max_concurrency,
+            shared_memory_type, output_shm_size, parser, factory),
+        concurrency_range_(concurrency_range), request_period_(request_period)
+  {
+  }
+
+  std::vector<RequestRecord> RunExperiment();
+
+ private:
+  std::shared_ptr<IWorker> MakeWorker(
+      std::shared_ptr<ThreadStat> thread_stat,
+      std::shared_ptr<PeriodicConcurrencyWorker::ThreadConfig> thread_config)
+      override;
+
+  void AddConcurrentRequests(uint64_t num_concurrent_requests);
+
+  void PeriodCompletedCallback();
+
+  void RequestCompletedCallback();
+
+  void WaitForRequestsToFinish();
+
+  std::vector<RequestRecord> GetRequestRecords();
+
+  Range<uint64_t> concurrency_range_{1, 1, 1};
+  uint64_t request_period_{0};
+  uint64_t steps_completed_{0};
+  uint64_t num_incomplete_periods_{0};
+  uint64_t num_completed_requests_{0};
+  std::mutex period_completed_callback_mutex_{};
+  std::mutex request_completed_callback_mutex_{};
+  std::promise<bool> all_requests_completed_promise_{};
+  std::function<void()> period_completed_callback_{
+      std::bind(&PeriodicConcurrencyManager::PeriodCompletedCallback, this)};
+  std::function<void()> request_completed_callback_{
+      std::bind(&PeriodicConcurrencyManager::RequestCompletedCallback, this)};
+  std::function<void(std::vector<RequestRecord>&&)> finalize_callback_{nullptr};
+};
+
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/periodic_concurrency_worker.cc
+++ b/src/c++/perf_analyzer/periodic_concurrency_worker.cc
@@ -1,0 +1,62 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "periodic_concurrency_worker.h"
+
+namespace triton { namespace perfanalyzer {
+
+void
+PeriodicConcurrencyWorker::Infer()
+{
+  CreateCtxIdTracker();
+  ReserveContexts();
+  RunInference();
+}
+
+std::shared_ptr<InferContext>
+PeriodicConcurrencyWorker::CreateInferContext()
+{
+  std::shared_ptr infer_context{std::make_shared<InferContext>(
+      id_, ctxs_.size(), async_, streaming_, on_sequence_model_,
+      using_json_data_, batch_size_, thread_stat_, data_loader_, parser_,
+      factory_, execute_, infer_data_manager_, sequence_manager_)};
+  infer_context->RegisterWorkerCallback(worker_callback_);
+  return infer_context;
+}
+
+void
+PeriodicConcurrencyWorker::WorkerCallback(uint32_t infer_context_id)
+{
+  if (ctxs_.at(infer_context_id)->GetNumResponsesForCurrentRequest() ==
+      request_period_) {
+    period_completed_callback_();
+  }
+  if (ctxs_.at(infer_context_id)->HasReceivedFinalResponse()) {
+    request_completed_callback_();
+  }
+}
+
+}}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/periodic_concurrency_worker.h
+++ b/src/c++/perf_analyzer/periodic_concurrency_worker.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <thread>
+
+#include "concurrency_worker.h"
+
+namespace triton { namespace perfanalyzer {
+
+/// @brief Worker class for periodic concurrency mode. Issues one request only
+/// and waits for all responses to come in. Notifies manager when N responses
+/// (request period) have been received. Notifies manager when final response
+/// has been received.
+class PeriodicConcurrencyWorker : public ConcurrencyWorker {
+ public:
+  PeriodicConcurrencyWorker(
+      uint32_t id, std::shared_ptr<ThreadStat> thread_stat,
+      std::shared_ptr<ThreadConfig> thread_config,
+      const std::shared_ptr<ModelParser> parser,
+      std::shared_ptr<DataLoader> data_loader,
+      const std::shared_ptr<cb::ClientBackendFactory> factory,
+      const bool on_sequence_model, const bool async,
+      const size_t max_concurrency, const bool using_json_data,
+      const bool streaming, const int32_t batch_size,
+      std::condition_variable& wake_signal, std::mutex& wake_mutex,
+      size_t& active_threads, bool& execute,
+      const std::shared_ptr<IInferDataManager>& infer_data_manager,
+      std::shared_ptr<SequenceManager> sequence_manager,
+      uint64_t request_period, std::function<void()> period_completed_callback,
+      std::function<void()> request_completed_callback)
+      : ConcurrencyWorker(
+            id, thread_stat, thread_config, parser, data_loader, factory,
+            on_sequence_model, async, max_concurrency, using_json_data,
+            streaming, batch_size, wake_signal, wake_mutex, active_threads,
+            execute, infer_data_manager, sequence_manager),
+        request_period_(request_period),
+        period_completed_callback_(period_completed_callback),
+        request_completed_callback_(request_completed_callback)
+  {
+  }
+
+  void Infer() override;
+
+  std::shared_ptr<InferContext> CreateInferContext() override;
+
+  void WorkerCallback(uint32_t infer_context_id);
+
+ private:
+  uint64_t request_period_{0};
+  std::function<void()> period_completed_callback_{nullptr};
+  std::function<void()> request_completed_callback_{nullptr};
+  std::function<void(uint32_t)> worker_callback_{std::bind(
+      &PeriodicConcurrencyWorker::WorkerCallback, this, std::placeholders::_1)};
+};
+
+}}  // namespace triton::perfanalyzer


### PR DESCRIPTION
Implements new concurrency manager and worker that begin concurrency at user-specified START and increments it by STEP (adds STEP new concurrent requests) after each of the latest concurrent requests/threads reaches REQUEST_PERIOD number of responses received. Repeats until END requests have been sent/all of their responses received.