### PR TITLE
Throw exception when request period larger than max tokens rather than infinite loop

### DIFF
--- a/src/c++/perf_analyzer/periodic_concurrency_worker.cc
+++ b/src/c++/perf_analyzer/periodic_concurrency_worker.cc
@@ -55,6 +55,14 @@ PeriodicConcurrencyWorker::WorkerCallback(uint32_t infer_context_id)
     period_completed_callback_();
   }
   if (ctxs_.at(infer_context_id)->HasReceivedFinalResponse()) {
+    bool has_not_completed_period{
+        ctxs_.at(infer_context_id)->GetNumResponsesForCurrentRequest() <
+        request_period_};
+    if (has_not_completed_period) {
+      throw std::runtime_error(
+          "Request received final response before request period was reached. "
+          "Request period parameter must be less than or equal to max tokens.");
+    }
     request_completed_callback_();
   }
 }

--- a/src/c++/perf_analyzer/periodic_concurrency_worker.cc
+++ b/src/c++/perf_analyzer/periodic_concurrency_worker.cc
@@ -61,7 +61,8 @@ PeriodicConcurrencyWorker::WorkerCallback(uint32_t infer_context_id)
     if (has_not_completed_period) {
       throw std::runtime_error(
           "Request received final response before request period was reached. "
-          "Request period parameter must be less than or equal to max tokens.");
+          "Request period must be at most the total number of responses "
+          "received by any request.");
     }
     request_completed_callback_();
   }


### PR DESCRIPTION
Catches when request receives final response without having first reached the end of the request period. Throws error with suggested solution to avoid infinite loop. User error. User must provide request period less than or equal to the max tokens the model will return per request.