### PR TITLE
🐛 Fix request hanging in periodic concurrency greater than 4

### DIFF
--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1790,6 +1790,24 @@ CLParser::VerifyOptions()
         "--periodic-concurrency-range option.");
   }
 
+  if (params_->is_using_periodic_concurrency_mode) {
+    if (params_->periodic_concurrency_range.end == pa::NO_LIMIT) {
+      std::cerr
+          << "WARNING: The maximum attainable concurrency will be limited by "
+             "max_threads specification."
+          << std::endl;
+      params_->periodic_concurrency_range.end = params_->max_threads;
+    } else {
+      if (params_->max_threads_specified) {
+        std::cerr << "WARNING: Overriding max_threads specification to ensure "
+                     "requested concurrency range."
+                  << std::endl;
+      }
+      params_->max_threads = std::max(
+          params_->max_threads, params_->periodic_concurrency_range.end);
+    }
+  }
+
   if (params_->request_parameters.size() > 0 &&
       params_->protocol != cb::ProtocolType::GRPC) {
     Usage(


### PR DESCRIPTION
While testing out the new periodic concurrency mode, @matthewkotila and I have noticed that the **5-th** request would consistently hang forever and wait for response from the server. 

**The issue was that `max_threads_` was set default to 4**, and if this value was less than the concurrency value, the request created after the `max_threads_` number of times (e.g. the 5-th one in our case) will be missing input data. This is because the infer_data_manager that prepares all the input data, uses `max_threads_` count to generate the input data and populate the requests with the input data. And I believe this is why the server - when it received the empty 5-th request - did not pass it down to the model.

The fix checks the `max_threads_` value against the concurrency range (similar to [how regular concurrency mode does](https://github.com/triton-inference-server/client/blob/eca94a86319f6b8d0b21dffe22713072da9d9c7a/src/c%2B%2B/perf_analyzer/perf_analyzer.cc#L177)). Not quite sure why we have `max_threads_` option in the first place, but I feel like we want to eventually move away from using `max_threads_` and just deduce the thread numbers from concurrency level. 

Thanks @matthewkotila for drilling down and investigating the bug and @Tabrizian & @rmccorm4 for tips and insights.