### PR TITLE
fix: Add missing import to aio support

### DIFF
--- a/src/python/library/tritonclient/http/aio/__init__.py
+++ b/src/python/library/tritonclient/http/aio/__init__.py
@@ -35,6 +35,8 @@ except ModuleNotFoundError as error:
 
 from urllib.parse import quote
 
+import gzip
+import zlib
 import rapidjson as json
 
 # In case user try to import dependency from here


### PR DESCRIPTION
Fix NameError. Add missing import to aio support
``` 
File "python-3.11.4/lib/python3.11/site-packages/tritonclient/http/aio/__init__.py", line 725, in infer
    request_body = gzip.compress(request_body)
                   ^^^^
NameError: name 'gzip' is not defined
```