### PR TITLE
Fixing compression imports in python aio client

### DIFF
--- a/src/python/library/tritonclient/http/aio/__init__.py
+++ b/src/python/library/tritonclient/http/aio/__init__.py
@@ -35,7 +35,9 @@ except ModuleNotFoundError as error:
 
 from urllib.parse import quote
 
+import gzip
 import rapidjson as json
+import zlib
 
 # In case user try to import dependency from here
 from tritonclient.http import *


### PR DESCRIPTION
The aio python client gave import errors whenever we pass in the `request_compression_algorithm` and `response_compression_algorithm` parameters. Fixing it in this PR.