### PR TITLE
[Bug fix] Avoid resetting token-to-token latencies list

### DIFF
--- a/src/c++/perf_analyzer/docs/examples/profile.py
+++ b/src/c++/perf_analyzer/docs/examples/profile.py
@@ -270,7 +270,6 @@ def collect_online_metrics(export_data, output_tokens):
         first_token_latencies.append(first_token_latency)
         generation_latencies.append(generation_latency_ms)
         generation_throughputs.append(output_tokens / generation_latency_s)
-        token_to_token_latencies = []
         for prev_res, res in pairwise(responses):
             token_to_token_latencies.append((res - prev_res) / 1_000_000)
     return (


### PR DESCRIPTION
In the recent PR #431, the `token_to_token_latencies` list was getting reset for every new requests. We instead want to collect every token to token latencies across all the requests. 

This bug only affects Avg total token-to-token latency metric.