### PR TITLE
Downgrade missing model version to warning

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1517,8 +1517,8 @@ InferenceProfiler::DetermineStatsModelVersion(
   }
 
   if (*status_model_version == -1) {
-    return cb::Error(
-        "failed to find the requested model version", pa::GENERIC_ERROR);
+    std::cerr << "WARNING: Failed to find the requested model version."
+              << std::endl;
   }
 
   if (multiple_found) {


### PR DESCRIPTION
Missing model version should not cause PA to hang. 
Report to the user but allow the measurements to finish.