### PR TITLE
Bump min cxx standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ cmake_minimum_required(VERSION 3.17)
 
 project(tritonclient LANGUAGES C CXX)
 
+# Use C++17 standard as Triton's minimum required.
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
+
 #
 # Options
 #
@@ -168,6 +171,7 @@ if(TRITON_ENABLE_CC_HTTP OR TRITON_ENABLE_CC_GRPC OR TRITON_ENABLE_PERF_ANALYZER
       -DTRITON_ENABLE_TESTS:BOOL=${TRITON_ENABLE_TESTS}
       -DTRITON_ENABLE_GPU:BOOL=${TRITON_ENABLE_GPU}
       -DTRITON_ENABLE_ZLIB:BOOL=${TRITON_ENABLE_ZLIB}
+      -DTRITON_MIN_CXX_STANDARD:STRING=${TRITON_MIN_CXX_STANDARD}
       -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
       -DCMAKE_INSTALL_PREFIX:PATH=${TRITON_INSTALL_PREFIX}
     DEPENDS ${_cc_client_depends}

--- a/src/c++/library/CMakeLists.txt
+++ b/src/c++/library/CMakeLists.txt
@@ -338,7 +338,7 @@ if(TRITON_ENABLE_CC_HTTP OR TRITON_ENABLE_PERF_ANALYZER)
   )
 
   foreach(_client_target http-client-library httpclient_static httpclient)
-    target_compile_features(${_client_target} PRIVATE cxx_std_11)
+    target_compile_features(${_client_target} PRIVATE cxx_std_17)
     target_compile_options(
       ${_client_target} PRIVATE
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/src/c++/library/CMakeLists.txt
+++ b/src/c++/library/CMakeLists.txt
@@ -155,7 +155,7 @@ if(TRITON_ENABLE_CC_GRPC OR TRITON_ENABLE_PERF_ANALYZER)
   )
 
   foreach(_client_target grpc-client-library grpcclient_static grpcclient)
-    target_compile_features(${_client_target} PRIVATE cxx_std_17)
+    target_compile_features(${_client_target} PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
     target_compile_options(
       ${_client_target} PRIVATE
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
@@ -338,7 +338,7 @@ if(TRITON_ENABLE_CC_HTTP OR TRITON_ENABLE_PERF_ANALYZER)
   )
 
   foreach(_client_target http-client-library httpclient_static httpclient)
-    target_compile_features(${_client_target} PRIVATE cxx_std_17)
+    target_compile_features(${_client_target} PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
     target_compile_options(
       ${_client_target} PRIVATE
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/src/c++/library/CMakeLists.txt
+++ b/src/c++/library/CMakeLists.txt
@@ -155,7 +155,7 @@ if(TRITON_ENABLE_CC_GRPC OR TRITON_ENABLE_PERF_ANALYZER)
   )
 
   foreach(_client_target grpc-client-library grpcclient_static grpcclient)
-    target_compile_features(${_client_target} PRIVATE cxx_std_11)
+    target_compile_features(${_client_target} PRIVATE cxx_std_17)
     target_compile_options(
       ${_client_target} PRIVATE
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:


### PR DESCRIPTION
This PR is one of the series PRs to update Triton to C++17 standard.

This PR sets Triton's min CXX standard to 17 and uses `TRITON_MIN_CXX_STANDARD` either newly set or from cmake cache