### PR TITLE
Prevent double close in HTTP client __del__

### DIFF
--- a/src/python/library/tritonclient/http/_client.py
+++ b/src/python/library/tritonclient/http/_client.py
@@ -190,6 +190,7 @@ class InferenceServerClient(InferenceServerClientBase):
         )
         self._pool = gevent.pool.Pool(max_greenlets)
         self._verbose = verbose
+        self._closed = False
 
     def __enter__(self):
         return self
@@ -205,8 +206,10 @@ class InferenceServerClient(InferenceServerClientBase):
         will result in an Error.
 
         """
-        self._pool.join()
-        self._client_stub.close()
+        if not self._closed:
+            self._pool.join()
+            self._client_stub.close()
+            self._closed = True
 
     def _get(self, request_uri, headers, query_params):
         """Issues the GET request to the server


### PR DESCRIPTION
Can you consider extending __del__ operator to prevent double close() in multi thread environments?

See:
https://github.com/triton-inference-server/server/issues/4223

See:
https://github.com/triton-inference-server/pytriton/issues/63
