### PR TITLE
Bugfix: get_response(as_json=True) now returns output

### DIFF
--- a/src/python/library/tritonclient/grpc/_infer_result.py
+++ b/src/python/library/tritonclient/grpc/_infer_result.py
@@ -124,7 +124,7 @@ class InferResult:
         for output in self._result.outputs:
             if output.name == name:
                 if as_json:
-                    MessageToJson(output, preserving_proto_field_name=True)
+                    return json.loads(MessageToJson(output, preserving_proto_field_name=True))
                 else:
                     return output
 


### PR DESCRIPTION
Before, the `get_response` method on the GRPC client was not returning valid JSON output when `as_json=True` was set. The if-branch was almost correct: it parsed the protobuf contents into JSON, but it was simply not returning this result.