### PR TITLE
Add CLI unit tests for GenAI-PA CLI

### DIFF
--- a/src/c++/perf_analyzer/genai-pa/genai_pa/parser.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/parser.py
@@ -37,7 +37,6 @@ def prune_args(args: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """
     Prune the parsed arguments to remove args with None or False values.
     """
-    print(args)
     return argparse.Namespace(
         **{k: v for k, v in vars(args).items() if v is not None if v is not False}
     )
@@ -199,6 +198,7 @@ def parse_args(argv=None):
     parser = argparse.ArgumentParser(
         prog="genai-pa",
         description="CLI to profile LLMs and Generative AI models with Perf Analyzer",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.set_defaults(func=handler)
 

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/parser.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/parser.py
@@ -198,7 +198,6 @@ def parse_args(argv=None):
     parser = argparse.ArgumentParser(
         prog="genai-pa",
         description="CLI to profile LLMs and Generative AI models with Perf Analyzer",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.set_defaults(func=handler)
 

--- a/src/c++/perf_analyzer/genai-pa/pyproject.toml
+++ b/src/c++/perf_analyzer/genai-pa/pyproject.toml
@@ -47,6 +47,7 @@ keywords = []
 requires-python = ">=3.8,<4"
 dependencies = [
   "numpy",
+  "pytest",
   "rich"
 ]
 

--- a/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
@@ -84,8 +84,6 @@ class TestCLIArguments:
 
         try:
             # Call the run function
-            # TODO: Un-comment the below when the perf analyzer call works for all the tests.
-            # with pytest.raises(SystemExit):
             run(combined_args)
         finally:
             # Restore stdout and stderr

--- a/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
@@ -84,7 +84,7 @@ class TestCLIArguments:
 
         try:
             # Call the run function
-            # TODO: Un-comment the below when the perf analyzer call works.
+            # TODO: Un-comment the below when the perf analyzer call works for all the tests.
             # with pytest.raises(SystemExit):
             run(combined_args)
         finally:

--- a/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
@@ -43,10 +43,8 @@ class TestCLIArguments:
         ],
     )
     def test_help_arguments_output_and_exit(self, arg, expected_output, capsys):
-        combined_args = ["-m", "test_model"] + arg
-
         with pytest.raises(SystemExit) as exc_info:
-            run(combined_args)
+            run(arg)
 
         # Confirm the exit was successful
         assert exc_info.value.code == 0

--- a/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
@@ -24,9 +24,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import io
-import sys
-
 import pytest
 from genai_pa import parser
 from genai_pa.main import run

--- a/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
@@ -28,6 +28,7 @@ import io
 import sys
 
 import pytest
+from genai_pa import parser
 from genai_pa.main import run
 
 
@@ -43,13 +44,13 @@ class TestCLIArguments:
         ],
     )
     def test_help_arguments_output_and_exit(self, arg, expected_output, capsys):
-        with pytest.raises(SystemExit) as exc_info:
-            run(arg)
+        with pytest.raises(SystemExit) as excinfo:
+            _ = parser.parse_args(arg)
 
-        # Confirm the exit was successful
-        assert exc_info.value.code == 0
+        # Check that the exit was successful
+        assert excinfo.value.code == 0
 
-        # Confirm the message is correct
+        # Capture that the correct message was displayed
         captured = capsys.readouterr()
         assert expected_output in captured.out
 
@@ -75,26 +76,16 @@ class TestCLIArguments:
         ],
     )
     def test_arguments_output(self, arg, expected_output, capsys):
-        combined_args = ["-m", "test_model"] + arg
-        # Redirect stdout and stderr to capture output
-        original_stdout, original_stderr = sys.stdout, sys.stderr
-        sys.stdout, sys.stderr = io.StringIO(), io.StringIO()
+        combined_args = ["--model", "test_model"] + arg
+        _ = parser.parse_args(combined_args)
 
-        try:
-            # Call the run function
-            run(combined_args)
-        finally:
-            # Restore stdout and stderr
-            captured_stdout, captured_stderr = (
-                sys.stdout.getvalue(),
-                sys.stderr.getvalue(),
-            )
-            sys.stdout, sys.stderr = original_stdout, original_stderr
-
-        assert expected_output in captured_stdout
-        assert "" == captured_stderr  # Assuming no error, adjust if needed
+        # Capture that the correct message was displayed
+        captured = capsys.readouterr()
+        assert expected_output in captured.out
 
     def test_arguments_model_not_provided(self):
         with pytest.raises(SystemExit) as exc_info:
-            run()
+            parser.parse_args()
+
+        # Check that the exit was unsuccessful
         assert exc_info.value.code != 0

--- a/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_cli.py
@@ -85,7 +85,7 @@ class TestCLIArguments:
 
     def test_arguments_model_not_provided(self):
         with pytest.raises(SystemExit) as exc_info:
-            parser.parse_args()
+            _ = parser.parse_args()
 
         # Check that the exit was unsuccessful
         assert exc_info.value.code != 0


### PR DESCRIPTION
Built off of Ryan's test files, here are the first few unit tests for the GenAI-PA CLI. These test all the current CLI args.

To run, you can call `pip install .` and `pytest tests/` in `perf_analyzer/genai_pa`.

This is the draft for CLI unit testing. If we want to write unit tests that actually check output, I'll need to mock the server (or copy over MA's mock) so that we can test that the subprocess call returns the expected output. Given the scope of the CLI at present, I think that may be overkill and we should be testing that the subprocess call is correct, then have end-to-end testing to show that it works as expected with a Triton server running.