### PR TITLE
LlmInputs - Updated API + generic framework + convert to vLLM format

### DIFF
--- a/src/c++/perf_analyzer/genai-pa/genai_pa/constants.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/constants.py
@@ -28,4 +28,4 @@ LOGGER_NAME: str = "genai-pa"
 
 OPEN_ORCA = "openorca"
 CNN_DAILY_MAIL = "cnn_dailymail"
-DEFAULT_INPUT_DATA_JSON = "./llm_inputs.json"
+DEFAULT_INPUT_DATA_JSON = "llm_inputs.json"

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/constants.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/constants.py
@@ -25,3 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 LOGGER_NAME: str = "genai-pa"
+
+OPEN_ORCA = "openorca"
+CNN_DAILY_MAIL = "cnn_dailymail"
+DEFAULT_INPUT_DATA_JSON = "./llm_inputs.json"

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
@@ -26,6 +26,7 @@ from requests import Response
 class InputType(Enum):
     URL = auto()
     FILE = auto()
+    SYNTHETIC = auto()
 
 
 class InputFormat(Enum):

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
@@ -105,12 +105,12 @@ class LlmInputs:
 
         LlmInputs._check_for_valid_args(input_type, model_name, starting_index, length)
 
+        dataset = None
         if input_type == InputType.URL:
             dataset = LlmInputs._get_input_dataset_from_url(
                 model_name, starting_index, length
             )
         else:
-            dataset = None
             raise GenAiPAException(
                 "Using file/synthetic to supply LLM Input is not supported at this time"
             )

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
@@ -18,7 +18,7 @@ from enum import Enum, auto
 from typing import Dict, List, Optional, Tuple
 
 import requests
-from genai_pa.constants import CNN_DAILY_MAIL, OPEN_ORCA
+from genai_pa.constants import CNN_DAILY_MAIL, DEFAULT_INPUT_DATA_JSON, OPEN_ORCA
 from genai_pa.exceptions import GenAiPAException
 from requests import Response
 
@@ -45,8 +45,6 @@ class LlmInputs:
     """
     A library of methods that control the generation of LLM Inputs
     """
-
-    OUTPUT_FILENAME = "./llm_inputs.json"
 
     OPEN_ORCA_URL = "https://datasets-server.huggingface.co/rows?dataset=Open-Orca%2FOpenOrca&config=default&split=train"
     CNN_DAILYMAIL_URL = "https://datasets-server.huggingface.co/rows?dataset=cnn_dailymail&config=1.0.0&split=train"
@@ -301,7 +299,7 @@ class LlmInputs:
     @classmethod
     def _write_json_to_file(cls, json_in_pa_format: Dict):
         try:
-            f = open(LlmInputs.OUTPUT_FILENAME, "w")
+            f = open(DEFAULT_INPUT_DATA_JSON, "w")
             f.write(json.dumps(json_in_pa_format, indent=2))
         finally:
             f.close()

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
@@ -109,9 +109,10 @@ class LlmInputs:
             dataset = LlmInputs._get_input_dataset_from_url(
                 model_name, starting_index, length
             )
-        elif input_type == InputType.FILE:
+        else:
+            dataset = None
             raise GenAiPAException(
-                "Using a file to supply LLM Input is not supported at this time"
+                "Using file/synthetic to supply LLM Input is not supported at this time"
             )
 
         generic_dataset_json = LlmInputs._convert_input_dataset_to_generic_json(

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
@@ -184,19 +184,37 @@ class LlmInputs:
             )
         else:
             raise GenAiPAException(
-                f"An input format of {input_format} is not supported at this time"
+                f"Input format {input_format} is not supported at this time"
             )
 
         return generic_dataset_json
 
     @classmethod
     def _convert_openai_to_generic_input_json(cls, dataset_json: Dict) -> Dict:
-        generic_input_json = {}
+        generic_input_json = LlmInputs._add_openai_features_to_generic_json(
+            {}, dataset_json
+        )
+        generic_input_json = LlmInputs._add_openai_rows_to_generic_json(
+            generic_input_json, dataset_json
+        )
+
+        return generic_input_json
+
+    @classmethod
+    def _add_openai_features_to_generic_json(
+        cls, generic_input_json: Dict, dataset_json: Dict
+    ) -> Dict:
         if "features" in dataset_json.keys():
             generic_input_json["features"] = []
             for feature in dataset_json["features"]:
                 generic_input_json["features"].append(feature["name"])
 
+        return generic_input_json
+
+    @classmethod
+    def _add_openai_rows_to_generic_json(
+        cls, generic_input_json: Dict, dataset_json: Dict
+    ) -> Dict:
         generic_input_json["rows"] = []
         for row in dataset_json["rows"]:
             generic_input_json["rows"].append(row["row"])
@@ -265,6 +283,7 @@ class LlmInputs:
             user_role_headers,
             text_input_headers,
         ) = LlmInputs._determine_json_feature_roles(dataset_json)
+
         pa_json = LlmInputs._populate_vllm_output_json(
             dataset_json,
             system_role_headers,

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
@@ -117,7 +117,9 @@ class TestLlmInputs:
             LlmInputs.DEFAULT_STARTING_INDEX,
             LlmInputs.DEFAULT_LENGTH,
         )
-        dataset_json = LlmInputs._convert_dataset_to_json(dataset)
+        dataset_json = LlmInputs._convert_input_dataset_to_generic_json(
+            input_format=InputFormat.OPENAI, dataset=dataset
+        )
 
         assert dataset_json is not None
         assert len(dataset_json["rows"]) == LlmInputs.DEFAULT_LENGTH
@@ -136,7 +138,9 @@ class TestLlmInputs:
             LlmInputs.DEFAULT_STARTING_INDEX,
             length=(int(LlmInputs.DEFAULT_LENGTH / 2)),
         )
-        dataset_json = LlmInputs._convert_dataset_to_json(dataset)
+        dataset_json = LlmInputs._convert_input_dataset_to_generic_json(
+            input_format=InputFormat.OPENAI, dataset=dataset
+        )
 
         assert dataset_json is not None
         assert len(dataset_json["rows"]) == LlmInputs.DEFAULT_LENGTH / 2
@@ -150,8 +154,15 @@ class TestLlmInputs:
             LlmInputs.DEFAULT_STARTING_INDEX,
             LlmInputs.DEFAULT_LENGTH,
         )
-        dataset_json = LlmInputs._convert_dataset_to_json(dataset)
-        pa_json = LlmInputs._convert_json_to_pa_format(dataset_json, "", False)
+        dataset_json = LlmInputs._convert_input_dataset_to_generic_json(
+            input_format=InputFormat.OPENAI, dataset=dataset
+        )
+        pa_json = LlmInputs._convert_generic_json_to_output_format(
+            output_format=OutputFormat.OPENAI,
+            generic_dataset=dataset_json,
+            add_model_name=False,
+            add_stream=False,
+        )
 
         assert pa_json is not None
         assert len(pa_json["data"][0]["payload"]) == LlmInputs.DEFAULT_LENGTH

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
@@ -37,6 +37,8 @@ class TestLlmInputs:
 
         yield default_configured_url
 
+    # TODO: Add tests that verify json schemas
+
     def test_input_type_url_no_model_name(self):
         """
         Test for exception when input type is URL and no model name

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
@@ -203,3 +203,21 @@ class TestLlmInputs:
             os.remove(LlmInputs.OUTPUT_FILENAME)
 
         assert pa_json == json.loads(json_str)
+
+    def test_create_openai_to_vllm(self):
+        """
+        Test conversion of openai to vllm
+        """
+        pa_json = LlmInputs.create_llm_inputs(
+            input_type=InputType.URL,
+            input_format=InputFormat.OPENAI,
+            output_format=OutputFormat.VLLM,
+            model_name=OPEN_ORCA,
+            add_model_name=False,
+            add_stream=True,
+        )
+
+        os.remove(LlmInputs.OUTPUT_FILENAME)
+
+        assert pa_json is not None
+        assert len(pa_json["data"]) == LlmInputs.DEFAULT_LENGTH

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
@@ -16,8 +16,14 @@ import json
 import os
 
 import pytest
+from genai_pa.constants import CNN_DAILY_MAIL, OPEN_ORCA
 from genai_pa.exceptions import GenAiPAException
-from genai_pa.llm_inputs.llm_inputs import LlmInputs
+from genai_pa.llm_inputs.llm_inputs import (
+    InputFormat,
+    InputType,
+    LlmInputs,
+    OutputFormat,
+)
 
 
 class TestLlmInputs:
@@ -31,33 +37,34 @@ class TestLlmInputs:
 
         yield default_configured_url
 
+    def test_input_type_url_no_model_name(self):
+        """
+        Test for exception when input type is URL and no model name
+        """
+        with pytest.raises(GenAiPAException):
+            _ = LlmInputs._check_for_model_name_if_input_type_is_url(
+                input_type=InputType.URL, model_name=""
+            )
+
     def test_illegal_starting_index(self):
         """
         Test for exceptions when illegal values are given for starting index
         """
         with pytest.raises(GenAiPAException):
-            _ = LlmInputs._check_for_valid_args(
-                starting_index="foo", length=LlmInputs.DEFAULT_LENGTH
-            )
+            _ = LlmInputs._check_for_valid_starting_index(starting_index="foo")
 
         with pytest.raises(GenAiPAException):
-            _ = LlmInputs._check_for_valid_args(
-                starting_index=-1, length=LlmInputs.DEFAULT_LENGTH
-            )
+            _ = LlmInputs._check_for_valid_starting_index(starting_index=-1)
 
     def test_illegal_length(self):
         """
         Test for exceptions when illegal values are given for length
         """
         with pytest.raises(GenAiPAException):
-            _ = LlmInputs._check_for_valid_args(
-                starting_index=LlmInputs.DEFAULT_STARTING_INDEX, length="foo"
-            )
+            _ = LlmInputs._check_for_valid_length(length="foo")
 
         with pytest.raises(GenAiPAException):
-            _ = LlmInputs._check_for_valid_args(
-                starting_index=LlmInputs.DEFAULT_STARTING_INDEX, length=0
-            )
+            _ = LlmInputs._check_for_valid_length(length=0)
 
     def test_create_configured_url(self):
         """
@@ -92,10 +99,13 @@ class TestLlmInputs:
         Test for exception when length is out of range
         """
         with pytest.raises(GenAiPAException):
-            _ = LlmInputs.create_openai_llm_inputs(
-                LlmInputs.OPEN_ORCA_URL,
-                LlmInputs.DEFAULT_STARTING_INDEX,
-                int(LlmInputs.DEFAULT_LENGTH * 100),
+            _ = LlmInputs.create_llm_inputs(
+                input_type=InputType.URL,
+                input_format=InputFormat.OPENAI,
+                output_format=OutputFormat.OPENAI,
+                model_name=OPEN_ORCA,
+                starting_index=LlmInputs.DEFAULT_STARTING_INDEX,
+                length=int(LlmInputs.DEFAULT_LENGTH * 100),
             )
 
     def test_llm_inputs_with_defaults(self, default_configured_url):
@@ -150,7 +160,12 @@ class TestLlmInputs:
         """
         Test CNN_DAILYMAIL can be accessed
         """
-        pa_json = LlmInputs.create_openai_llm_inputs(LlmInputs.CNN_DAILYMAIL_URL)
+        pa_json = LlmInputs.create_llm_inputs(
+            input_type=InputType.URL,
+            input_format=InputFormat.OPENAI,
+            output_format=OutputFormat.OPENAI,
+            model_name=CNN_DAILY_MAIL,
+        )
 
         os.remove(LlmInputs.OUTPUT_FILENAME)
 
@@ -161,8 +176,13 @@ class TestLlmInputs:
         """
         Test that write to file is working correctly
         """
-        pa_json = LlmInputs.create_openai_llm_inputs(
-            model_name="OpenOrca", add_stream=True
+        pa_json = LlmInputs.create_llm_inputs(
+            input_type=InputType.URL,
+            input_format=InputFormat.OPENAI,
+            output_format=OutputFormat.OPENAI,
+            model_name=OPEN_ORCA,
+            add_model_name=True,
+            add_stream=True,
         )
         try:
             f = open(LlmInputs.OUTPUT_FILENAME, "r")

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
@@ -16,7 +16,7 @@ import json
 import os
 
 import pytest
-from genai_pa.constants import CNN_DAILY_MAIL, OPEN_ORCA
+from genai_pa.constants import CNN_DAILY_MAIL, DEFAULT_INPUT_DATA_JSON, OPEN_ORCA
 from genai_pa.exceptions import GenAiPAException
 from genai_pa.llm_inputs.llm_inputs import (
     InputFormat,
@@ -180,7 +180,7 @@ class TestLlmInputs:
             model_name=CNN_DAILY_MAIL,
         )
 
-        os.remove(LlmInputs.OUTPUT_FILENAME)
+        os.remove(DEFAULT_INPUT_DATA_JSON)
 
         assert pa_json is not None
         assert len(pa_json["data"][0]["payload"]) == LlmInputs.DEFAULT_LENGTH
@@ -198,11 +198,11 @@ class TestLlmInputs:
             add_stream=True,
         )
         try:
-            f = open(LlmInputs.OUTPUT_FILENAME, "r")
+            f = open(DEFAULT_INPUT_DATA_JSON, "r")
             json_str = f.read()
         finally:
             f.close()
-            os.remove(LlmInputs.OUTPUT_FILENAME)
+            os.remove(DEFAULT_INPUT_DATA_JSON)
 
         assert pa_json == json.loads(json_str)
 
@@ -219,7 +219,7 @@ class TestLlmInputs:
             add_stream=True,
         )
 
-        os.remove(LlmInputs.OUTPUT_FILENAME)
+        os.remove(DEFAULT_INPUT_DATA_JSON)
 
         assert pa_json is not None
         assert len(pa_json["data"]) == LlmInputs.DEFAULT_LENGTH


### PR DESCRIPTION
I've updated the API, added a generic JSON framework to store the intermediate data and added methods to convert to vLLM format.

Here's an example output of HF input to vLLM output. Both role text strings (system/user) are concatenated to form the text input.
```
{
  "data": [
    {
      "text_input": [
        "You are an AI assistant. You will be given a task. You must generate a detailed and long answer.",
        "Generate an approximately fifteen-word sentence that describes all this data: Midsummer House eatType restaurant; Midsummer House food Chinese; Midsummer House priceRange moderate; Midsummer House customer rating 3 out of 5; Midsummer House near All Bar One"
      ],
      "stream": [
        true
      ]
    },
]
}
