### PR TITLE
Llm inputs - Add openai legacy completions output format

### DIFF
--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
@@ -106,6 +106,7 @@ class TestLlmInputs:
                 input_format=InputFormat.OPENAI,
                 output_format=OutputFormat.OPENAI,
                 dataset_name=OPEN_ORCA,
+                output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
                 starting_index=LlmInputs.DEFAULT_STARTING_INDEX,
                 length=int(LlmInputs.DEFAULT_LENGTH * 100),
             )
@@ -160,7 +161,7 @@ class TestLlmInputs:
             input_format=InputFormat.OPENAI, dataset=dataset
         )
         pa_json = LlmInputs._convert_generic_json_to_output_format(
-            output_format=OutputFormat.OPENAI,
+            output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
             generic_dataset=dataset_json,
             add_model_name=False,
             add_stream=False,
@@ -178,6 +179,7 @@ class TestLlmInputs:
             input_format=InputFormat.OPENAI,
             output_format=OutputFormat.OPENAI,
             dataset_name=CNN_DAILY_MAIL,
+            output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
         )
 
         os.remove(DEFAULT_INPUT_DATA_JSON)
@@ -194,7 +196,7 @@ class TestLlmInputs:
             input_format=InputFormat.OPENAI,
             output_format=OutputFormat.OPENAI,
             dataset_name=OPEN_ORCA,
-            model_name=OPEN_ORCA,
+            output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
             add_model_name=True,
             add_stream=True,
         )
@@ -224,3 +226,21 @@ class TestLlmInputs:
 
         assert pa_json is not None
         assert len(pa_json["data"]) == LlmInputs.DEFAULT_LENGTH
+
+    def test_create_openai_to_completions(self):
+        """
+        Test conversion of openai to completions
+        """
+        pa_json = LlmInputs.create_llm_inputs(
+            input_type=InputType.URL,
+            input_format=InputFormat.OPENAI,
+            output_format=OutputFormat.OPENAI_COMPLETIONS,
+            model_name=OPEN_ORCA,
+            add_model_name=False,
+            add_stream=True,
+        )
+
+        os.remove(DEFAULT_INPUT_DATA_JSON)
+
+        assert pa_json is not None
+        assert len(pa_json["data"][0]["payload"]) == LlmInputs.DEFAULT_LENGTH

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
@@ -104,7 +104,6 @@ class TestLlmInputs:
             _ = LlmInputs.create_llm_inputs(
                 input_type=InputType.URL,
                 input_format=InputFormat.OPENAI,
-                output_format=OutputFormat.OPENAI,
                 dataset_name=OPEN_ORCA,
                 output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
                 starting_index=LlmInputs.DEFAULT_STARTING_INDEX,
@@ -177,7 +176,6 @@ class TestLlmInputs:
         pa_json = LlmInputs.create_llm_inputs(
             input_type=InputType.URL,
             input_format=InputFormat.OPENAI,
-            output_format=OutputFormat.OPENAI,
             dataset_name=CNN_DAILY_MAIL,
             output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
         )
@@ -194,7 +192,6 @@ class TestLlmInputs:
         pa_json = LlmInputs.create_llm_inputs(
             input_type=InputType.URL,
             input_format=InputFormat.OPENAI,
-            output_format=OutputFormat.OPENAI,
             dataset_name=OPEN_ORCA,
             output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
             add_model_name=True,
@@ -235,7 +232,7 @@ class TestLlmInputs:
             input_type=InputType.URL,
             input_format=InputFormat.OPENAI,
             output_format=OutputFormat.OPENAI_COMPLETIONS,
-            model_name=OPEN_ORCA,
+            dataset_name=OPEN_ORCA,
             add_model_name=False,
             add_stream=True,
         )


### PR DESCRIPTION
Created a new output format: OPENAI_COMPLETIONS

Here is an example json output:
```
{
  "data": [
    {
      "payload": [
        {
          "prompt": [
            "You will be given a definition of a task first, then some input of the task.\nThis task is about using the specified sentence and converting the sentence to Resource Description Framework (RDF) triplets of the form (subject, predicate object). The RDF triplets generated must be such that the triplets accurately capture the structure and semantics of the input sentence. The input is a sentence and the output is a list of triplets of the form [subject, predicate, object] that capture the relationships present in the sentence. When a sentence has more than 1 RDF triplet possible, the output must contain all of them.\n\nAFC Ajax (amateurs)'s ground is Sportpark De Toekomst where Ajax Youth Academy also play.\nOutput:"
          ],
          "stream": [
            true
          ]
        }
    ]
}
```
    