### PR TITLE
Add formatting for GenAi-PA report

### DIFF
--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -131,13 +131,6 @@ class Statistics:
         ]
         return field in time_fields
 
-    def _use_exact_length(self, value: str):
-        exact_value_length = 17
-        formatted_value = f"{value:.{exact_value_length}f}"
-        if len(formatted_value) < exact_value_length:
-            return formatted_value.ljust(exact_value_length)
-        return formatted_value[:exact_value_length]
-
     def pretty_print(self):
         table = Table(title="PA LLM Metrics")
 
@@ -161,30 +154,6 @@ class Statistics:
 
         console = Console()
         console.print(table)
-
-        field_stats = {}
-
-        for key, value in self.__dict__.items():
-            if key.startswith(
-                (
-                    "p25_",
-                    "p50_",
-                    "p75_",
-                    "p90_",
-                    "p95_",
-                    "p99_",
-                    "avg_",
-                    "min_",
-                    "max_",
-                    "std_",
-                )
-            ):
-                stat, field = key.split("_", 1)
-                stat = stat.replace("_", " ")
-
-                if field not in field_stats:
-                    field_stats[field] = {}
-                field_stats[field][stat] = value
 
 
 class LLMProfileData:

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -138,7 +138,6 @@ class Statistics:
 
     def pretty_print(self):
         field_stats = {}
-        print_length_for_seconds = 17
         print("Output:")
 
         for key, value in self.__dict__.items():

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -125,9 +125,7 @@ class Statistics:
         seconds_fields = [
             "inter_token_latency",
             "time_to_first_token",
-            "ttft",
             "end_to_end_latency",
-            "request_output_throughput_token_per",
         ]
         return stat in seconds_fields
 

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -140,6 +140,7 @@ class Statistics:
     def pretty_print(self):
         field_stats = {}
         print_length_for_seconds = 17
+        print("Output:")
 
         for key, value in self.__dict__.items():
             if key.startswith(
@@ -198,6 +199,7 @@ class LLMProfileData:
       >>> stats = pd.get_statistics(infer_mode="concurrency", level=10)
       >>>
       >>> print(stats)  # output: Statistics(avg_time_to_first_token=...)
+      >>> stats.pretty_print()  # Output: time_to_first_token_s: ...
     """
 
     def __init__(self, filename: str, tokenizer: AutoTokenizer) -> None:

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
@@ -76,7 +76,6 @@ def report_output(metrics: LLMProfileData, args):
         raise GenAiPAException(
             "Neither concurrency_range nor request_rate_range was found in args when reporting metrics"
         )
-    # TODO: metrics reporter class that consumes Stats class for nicer formatting
     stats = metrics.get_statistics(infer_mode, int(load_level))
     stats.pretty_print()
 

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
@@ -77,7 +77,8 @@ def report_output(metrics: LLMProfileData, args):
             "Neither concurrency_range nor request_rate_range was found in args when reporting metrics"
         )
     # TODO: metrics reporter class that consumes Stats class for nicer formatting
-    print(metrics.get_statistics(infer_mode, int(load_level)))
+    stats = metrics.get_statistics(infer_mode, int(load_level))
+    stats.pretty_print()
 
 
 # Separate function that can raise exceptions used for testing


### PR DESCRIPTION
This pull request formats the printed metrics produced by GenAi-PA. While we only have two metrics so far, it aims to future-proof metrics so that there is less work as new metrics are added.

Note that the below output seems to be wrong (the number of seconds is too high). This pull request is only focused on formatting. The computation will either be in a separate ticket or be added here later, if the team decides that is easier.

Output:
![image](https://github.com/triton-inference-server/client/assets/58150256/fb80e787-0501-43e9-b2bd-996bae4b593b)
