### PR TITLE
LlmInputs - trtllm output format support

### DIFF
--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
@@ -550,17 +550,13 @@ class LlmInputs:
         return empty_pa_json
 
     @classmethod
-<<<<<<< HEAD
-    def _create_new_openai_chat_completions_message(
-=======
     def _create_empty_trtllm_pa_json(cls) -> Dict:
         empty_pa_json = deepcopy(LlmInputs.EMPTY_JSON_IN_TRTLLM_PA_FORMAT)
 
         return empty_pa_json
 
     @classmethod
-    def _create_new_message(
->>>>>>> 53db856 (Adding trtllm endpoint support)
+    def _create_new_openai_chat_completions_message(
         cls,
         header: str,
         system_role_headers: List[str],
@@ -682,10 +678,6 @@ class LlmInputs:
         return pa_json
 
     @classmethod
-<<<<<<< HEAD
-    def _check_for_dataset_name_if_input_type_is_url(
-        cls, input_type: InputType, dataset_name: str
-=======
     def _add_optional_tags_to_trtllm_json(
         cls,
         pa_json: Dict,
@@ -712,9 +704,8 @@ class LlmInputs:
         return pa_json
 
     @classmethod
-    def _check_for_model_name_if_input_type_is_url(
-        cls, input_type: InputType, model_name: str
->>>>>>> 53db856 (Adding trtllm endpoint support)
+    def _check_for_dataset_name_if_input_type_is_url(
+        cls, input_type: InputType, dataset_name: str
     ) -> None:
         if input_type == InputType.URL and not dataset_name:
             raise GenAiPAException(

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
@@ -29,12 +29,6 @@ class InputType(Enum):
     SYNTHETIC = auto()
 
 
-class InputFormat(Enum):
-    OPENAI = auto()
-    TRTLLM = auto()
-    VLLM = auto()
-
-
 class OutputFormat(Enum):
     OPENAI_CHAT_COMPLETIONS = auto()
     OPENAI_COMPLETIONS = auto()
@@ -70,7 +64,6 @@ class LlmInputs:
     def create_llm_inputs(
         cls,
         input_type: InputType,
-        input_format: InputFormat,
         output_format: OutputFormat,
         dataset_name: str = "",
         model_name: str = "",
@@ -88,8 +81,6 @@ class LlmInputs:
         -------------------
         input_type:
             Specify how the input is received (file or URL)
-        input_format:
-            Specify the input format
         output_format:
             Specify the output format
 
@@ -123,9 +114,7 @@ class LlmInputs:
                 "Using file/synthetic to supply LLM Input is not supported at this time"
             )
 
-        generic_dataset_json = LlmInputs._convert_input_dataset_to_generic_json(
-            input_format, dataset
-        )
+        generic_dataset_json = LlmInputs._convert_input_dataset_to_generic_json(dataset)
 
         json_in_pa_format = LlmInputs._convert_generic_json_to_output_format(
             output_format, generic_dataset_json, add_model_name, add_stream, model_name
@@ -181,23 +170,16 @@ class LlmInputs:
         return dataset
 
     @classmethod
-    def _convert_input_dataset_to_generic_json(
-        cls, input_format: InputFormat, dataset: Response
-    ) -> Dict:
+    def _convert_input_dataset_to_generic_json(cls, dataset: Response) -> Dict:
         dataset_json = dataset.json()
         try:
             LlmInputs._check_for_error_in_json_of_dataset(dataset_json)
         except Exception as e:
             raise GenAiPAException(e)
 
-        if input_format == InputFormat.OPENAI:
-            generic_dataset_json = LlmInputs._convert_openai_to_generic_input_json(
-                dataset_json
-            )
-        else:
-            raise GenAiPAException(
-                f"Input format {input_format} is not supported at this time"
-            )
+        generic_dataset_json = LlmInputs._convert_openai_to_generic_input_json(
+            dataset_json
+        )
 
         return generic_dataset_json
 

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
@@ -177,25 +177,23 @@ class LlmInputs:
         except Exception as e:
             raise GenAiPAException(e)
 
-        generic_dataset_json = LlmInputs._convert_openai_to_generic_input_json(
+        generic_dataset_json = LlmInputs._convert_dataset_to_generic_input_json(
             dataset_json
         )
 
         return generic_dataset_json
 
     @classmethod
-    def _convert_openai_to_generic_input_json(cls, dataset_json: Dict) -> Dict:
-        generic_input_json = LlmInputs._add_openai_features_to_generic_json(
-            {}, dataset_json
-        )
-        generic_input_json = LlmInputs._add_openai_rows_to_generic_json(
+    def _convert_dataset_to_generic_input_json(cls, dataset_json: Dict) -> Dict:
+        generic_input_json = LlmInputs._add_features_to_generic_json({}, dataset_json)
+        generic_input_json = LlmInputs._add_rows_to_generic_json(
             generic_input_json, dataset_json
         )
 
         return generic_input_json
 
     @classmethod
-    def _add_openai_features_to_generic_json(
+    def _add_features_to_generic_json(
         cls, generic_input_json: Dict, dataset_json: Dict
     ) -> Dict:
         if "features" in dataset_json.keys():
@@ -206,7 +204,7 @@ class LlmInputs:
         return generic_input_json
 
     @classmethod
-    def _add_openai_rows_to_generic_json(
+    def _add_rows_to_generic_json(
         cls, generic_input_json: Dict, dataset_json: Dict
     ) -> Dict:
         generic_input_json["rows"] = []

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
@@ -250,7 +250,7 @@ class TestLlmInputs:
             input_type=InputType.URL,
             input_format=InputFormat.OPENAI,
             output_format=OutputFormat.TRTLLM,
-            model_name=OPEN_ORCA,
+            dataset_name=OPEN_ORCA,
             add_model_name=False,
             add_stream=True,
         )

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
@@ -241,3 +241,21 @@ class TestLlmInputs:
 
         assert pa_json is not None
         assert len(pa_json["data"][0]["payload"]) == LlmInputs.DEFAULT_LENGTH
+
+    def test_create_openai_to_trtllm(self):
+        """
+        Test conversion of openai to trtllm
+        """
+        pa_json = LlmInputs.create_llm_inputs(
+            input_type=InputType.URL,
+            input_format=InputFormat.OPENAI,
+            output_format=OutputFormat.TRTLLM,
+            model_name=OPEN_ORCA,
+            add_model_name=False,
+            add_stream=True,
+        )
+
+        os.remove(DEFAULT_INPUT_DATA_JSON)
+
+        assert pa_json is not None
+        assert len(pa_json["data"]) == LlmInputs.DEFAULT_LENGTH

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_inputs.py
@@ -18,12 +18,7 @@ import os
 import pytest
 from genai_pa.constants import CNN_DAILY_MAIL, DEFAULT_INPUT_DATA_JSON, OPEN_ORCA
 from genai_pa.exceptions import GenAiPAException
-from genai_pa.llm_inputs.llm_inputs import (
-    InputFormat,
-    InputType,
-    LlmInputs,
-    OutputFormat,
-)
+from genai_pa.llm_inputs.llm_inputs import InputType, LlmInputs, OutputFormat
 
 
 class TestLlmInputs:
@@ -103,7 +98,6 @@ class TestLlmInputs:
         with pytest.raises(GenAiPAException):
             _ = LlmInputs.create_llm_inputs(
                 input_type=InputType.URL,
-                input_format=InputFormat.OPENAI,
                 dataset_name=OPEN_ORCA,
                 output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
                 starting_index=LlmInputs.DEFAULT_STARTING_INDEX,
@@ -119,9 +113,7 @@ class TestLlmInputs:
             LlmInputs.DEFAULT_STARTING_INDEX,
             LlmInputs.DEFAULT_LENGTH,
         )
-        dataset_json = LlmInputs._convert_input_dataset_to_generic_json(
-            input_format=InputFormat.OPENAI, dataset=dataset
-        )
+        dataset_json = LlmInputs._convert_input_dataset_to_generic_json(dataset=dataset)
 
         assert dataset_json is not None
         assert len(dataset_json["rows"]) == LlmInputs.DEFAULT_LENGTH
@@ -140,9 +132,7 @@ class TestLlmInputs:
             LlmInputs.DEFAULT_STARTING_INDEX,
             length=(int(LlmInputs.DEFAULT_LENGTH / 2)),
         )
-        dataset_json = LlmInputs._convert_input_dataset_to_generic_json(
-            input_format=InputFormat.OPENAI, dataset=dataset
-        )
+        dataset_json = LlmInputs._convert_input_dataset_to_generic_json(dataset=dataset)
 
         assert dataset_json is not None
         assert len(dataset_json["rows"]) == LlmInputs.DEFAULT_LENGTH / 2
@@ -156,9 +146,7 @@ class TestLlmInputs:
             LlmInputs.DEFAULT_STARTING_INDEX,
             LlmInputs.DEFAULT_LENGTH,
         )
-        dataset_json = LlmInputs._convert_input_dataset_to_generic_json(
-            input_format=InputFormat.OPENAI, dataset=dataset
-        )
+        dataset_json = LlmInputs._convert_input_dataset_to_generic_json(dataset=dataset)
         pa_json = LlmInputs._convert_generic_json_to_output_format(
             output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
             generic_dataset=dataset_json,
@@ -175,7 +163,6 @@ class TestLlmInputs:
         """
         pa_json = LlmInputs.create_llm_inputs(
             input_type=InputType.URL,
-            input_format=InputFormat.OPENAI,
             dataset_name=CNN_DAILY_MAIL,
             output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
         )
@@ -191,7 +178,6 @@ class TestLlmInputs:
         """
         pa_json = LlmInputs.create_llm_inputs(
             input_type=InputType.URL,
-            input_format=InputFormat.OPENAI,
             dataset_name=OPEN_ORCA,
             output_format=OutputFormat.OPENAI_CHAT_COMPLETIONS,
             add_model_name=True,
@@ -212,7 +198,6 @@ class TestLlmInputs:
         """
         pa_json = LlmInputs.create_llm_inputs(
             input_type=InputType.URL,
-            input_format=InputFormat.OPENAI,
             output_format=OutputFormat.VLLM,
             dataset_name=OPEN_ORCA,
             add_model_name=False,
@@ -230,7 +215,6 @@ class TestLlmInputs:
         """
         pa_json = LlmInputs.create_llm_inputs(
             input_type=InputType.URL,
-            input_format=InputFormat.OPENAI,
             output_format=OutputFormat.OPENAI_COMPLETIONS,
             dataset_name=OPEN_ORCA,
             add_model_name=False,
@@ -248,7 +232,6 @@ class TestLlmInputs:
         """
         pa_json = LlmInputs.create_llm_inputs(
             input_type=InputType.URL,
-            input_format=InputFormat.OPENAI,
             output_format=OutputFormat.TRTLLM,
             dataset_name=OPEN_ORCA,
             add_model_name=False,


### PR DESCRIPTION
Added support for trtLLM endpoints.

Here's a sample output:
```
{
  "data": [
    {
      "text_input": [
        "You will be given a definition of a task first, then some input of the task.\nThis task is about using the specified sentence and converting the sentence to Resource Description Framework (RDF) triplets of the form (subject, predicate object). The RDF triplets generated must be such that the triplets accurately capture the structure and semantics of the input sentence. The input is a sentence and the output is a list of triplets of the form [subject, predicate, object] that capture the relationships present in the sentence. When a sentence has more than 1 RDF triplet possible, the output must contain all of them.\n\nAFC Ajax (amateurs)'s ground is Sportpark De Toekomst where Ajax Youth Academy also play.\nOutput:"
      ],
      "max_tokens": 256,
      "stream": [
        true
      ]
    },
  ]
}
```