### PR TITLE
Support parsing profile data JSON output of both Triton and OpenAI

### DIFF
--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -223,9 +223,9 @@ class LLMProfileDataParser(ProfileDataParser):
     """A class that calculates and aggregates all the LLM performance statistics
     across the Perf Analyzer profile results.
 
-    The LLMProfileData class parses profile export JSON file, collects the core
-    LLM performance metrics, and calculates summary statistics for each different
-    Perf Analyzer runs/experiments.
+    The LLMProfileDataParser class parses profile export JSON file, collects the
+    core LLM performance metrics, and calculates summary statistics for each
+    different Perf Analyzer runs/experiments.
 
     Example:
 
@@ -234,7 +234,7 @@ class LLMProfileDataParser(ProfileDataParser):
       >>> from transformers import AutoTokenizer
       >>>
       >>> tokenizer = AutoTokenizer.from_pretrained("gpt2")
-      >>> pd = LLMProfileData(
+      >>> pd = LLMProfileDataParser(
       >>>     filename="profile_export.json",
       >>>     service_kind="triton",
       >>>     tokenizer=tokenizer,

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
@@ -39,7 +39,7 @@ from genai_pa.llm_inputs.llm_inputs import LlmInputs
 with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
     io.StringIO()
 ) as stderr:
-    from genai_pa.llm_metrics import LLMProfileData
+    from genai_pa.llm_metrics import LLMProfileDataParser
     from transformers import AutoTokenizer as tokenizer
     from transformers import logging as token_logger
 
@@ -68,12 +68,12 @@ def generate_inputs(args):
     )
 
 
-def calculate_metrics(file: str) -> LLMProfileData:
+def calculate_metrics(file: str, service_kind: str) -> LLMProfileDataParser:
     t = tokenizer.from_pretrained("gpt2")
-    return LLMProfileData(file, t)
+    return LLMProfileDataParser(file, service_kind, t)
 
 
-def report_output(metrics: LLMProfileData, args):
+def report_output(metrics: LLMProfileDataParser, args):
     if "concurrency_range" in args:
         infer_mode = "concurrency"
         load_level = args.concurrency_range
@@ -96,7 +96,7 @@ def run(argv=None):
         args, extra_args = parser.parse_args(argv)
         generate_inputs(args)
         args.func(args, extra_args)
-        metrics = calculate_metrics(args.profile_export_file)
+        metrics = calculate_metrics(args.profile_export_file, args.service_kind)
         report_output(metrics, args)
     except Exception as e:
         raise GenAiPAException(e)

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/utils.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/utils.py
@@ -28,6 +28,10 @@ import json
 from pathlib import Path
 
 
+def remove_sse_prefix(msg: str) -> str:
+    return msg.removeprefix("data: ").strip()
+
+
 def load_json(filename: str):
     with open(filename) as f:
         return json.load(f)

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_metrics.py
@@ -106,6 +106,9 @@ class TestLLMProfileData:
         * output token throughputs
             - experiment 1: [3/(8 - 1), 5/(11 - 2)] = [3/7, 5/9]
             - experiment 2: [4/(18 - 5), 5/(11 - 3)] = [4/13, 5/8]
+        * num output tokens
+            - experiment 1: [3, 5]
+            - experiment 2: [4, 5]
         """
         tokenizer = AutoTokenizer.from_pretrained("gpt2")
         pd = LLMProfileData("temp_profile_export.json", tokenizer)
@@ -115,36 +118,46 @@ class TestLLMProfileData:
         assert stat.avg_time_to_first_token == 2
         assert stat.avg_inter_token_latency == 2.25
         assert stat.avg_output_token_throughput == pytest.approx(31 / 63)
+        assert stat.avg_num_output_token == 4
         assert stat.p50_time_to_first_token == 2
         assert stat.p50_inter_token_latency == 2
         assert stat.p50_output_token_throughput == pytest.approx(31 / 63)
+        assert stat.p50_num_output_token == 4
         assert stat.min_time_to_first_token == 2
         assert stat.min_inter_token_latency == 2
         assert stat.min_output_token_throughput == pytest.approx(3 / 7)
+        assert stat.min_num_output_token == 3
         assert stat.max_time_to_first_token == 2
         assert stat.max_inter_token_latency == 3
         assert stat.max_output_token_throughput == pytest.approx(5 / 9)
+        assert stat.max_num_output_token == 5
         assert stat.std_time_to_first_token == np.std([2, 2])
         assert stat.std_inter_token_latency == np.std([2, 3, 2, 2])
         assert stat.std_output_token_throughput == np.std([3 / 7, 5 / 9])
+        assert stat.std_num_output_token == np.std([3, 5])
 
         # experiment 2 statistics
         stat = pd.get_statistics(infer_mode="request_rate", load_level=2.0)
         assert stat.avg_time_to_first_token == 2.5
         assert stat.avg_inter_token_latency == 3
         assert stat.avg_output_token_throughput == pytest.approx(97 / 208)
+        assert stat.avg_num_output_token == 4.5
         assert stat.p50_time_to_first_token == 2.5
         assert stat.p50_inter_token_latency == 2
         assert stat.p50_output_token_throughput == pytest.approx(97 / 208)
+        assert stat.p50_num_output_token == 4.5
         assert stat.min_time_to_first_token == 2
         assert stat.min_inter_token_latency == 1
         assert stat.min_output_token_throughput == pytest.approx(4 / 13)
+        assert stat.min_num_output_token == 4
         assert stat.max_time_to_first_token == 3
         assert stat.max_inter_token_latency == 5
         assert stat.max_output_token_throughput == pytest.approx(5 / 8)
+        assert stat.max_num_output_token == 5
         assert stat.std_time_to_first_token == np.std([2, 3])
         assert stat.std_inter_token_latency == np.std([1, 5, 5, 2, 2])
         assert stat.std_output_token_throughput == np.std([4 / 13, 5 / 8])
+        assert stat.std_num_output_token == np.std([4, 5])
 
         # check non-existing profile data
         with pytest.raises(KeyError):
@@ -158,6 +171,7 @@ class TestLLMProfileData:
             time_to_first_tokens=[1, 2, 3],
             inter_token_latencies=[4, 5],
             output_token_throughputs=[7, 8, 9],
+            num_output_tokens=[3, 4],
         )
         assert metrics.get_base_name("time_to_first_tokens") == "time_to_first_token"
         assert metrics.get_base_name("inter_token_latencies") == "inter_token_latency"
@@ -165,5 +179,6 @@ class TestLLMProfileData:
             metrics.get_base_name("output_token_throughputs")
             == "output_token_throughput"
         )
+        assert metrics.get_base_name("num_output_tokens") == "num_output_token"
         with pytest.raises(KeyError):
             metrics.get_base_name("hello1234")

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_metrics.py
@@ -31,12 +31,12 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from genai_pa.llm_profile import LLMMetrics, LLMProfileDataParser
+from genai_pa.llm_metrics import LLMMetrics, LLMProfileDataParser
 from genai_pa.utils import remove_file
 from transformers import AutoTokenizer
 
 
-class TestLLMProfileData:
+class TestLLMProfileDataParser:
     @pytest.fixture
     def prepare_triton_profile_data(self) -> None:
         path = Path("triton_profile_export.json")

--- a/src/c++/perf_analyzer/genai-pa/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/tests/test_llm_metrics.py
@@ -31,16 +31,16 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from genai_pa.llm_metrics import LLMMetrics, LLMProfileData
+from genai_pa.llm_profile import LLMMetrics, LLMProfileDataParser
 from genai_pa.utils import remove_file
 from transformers import AutoTokenizer
 
 
 class TestLLMProfileData:
     @pytest.fixture
-    def prepare_profile_data(self) -> None:
-        self.path = Path("temp_profile_export.json")
-        self.profile_data = {
+    def prepare_triton_profile_data(self) -> None:
+        path = Path("triton_profile_export.json")
+        profile_data = {
             "experiments": [
                 {
                     "experiment": {
@@ -51,12 +51,20 @@ class TestLLMProfileData:
                         {
                             "timestamp": 1,
                             "response_timestamps": [3, 5, 8],
-                            "response_outputs": ["dogs", "are", "cool"],
+                            "response_outputs": [
+                                {"text_output": "dogs"},
+                                {"text_output": "are"},
+                                {"text_output": "cool"},
+                            ],
                         },
                         {
                             "timestamp": 2,
                             "response_timestamps": [4, 7, 11],
-                            "response_outputs": ["I", "don't", "cook food"],
+                            "response_outputs": [
+                                {"text_output": "I"},
+                                {"text_output": "don't"},
+                                {"text_output": "cook food"},
+                            ],
                         },
                     ],
                 },
@@ -69,27 +77,98 @@ class TestLLMProfileData:
                         {
                             "timestamp": 5,
                             "response_timestamps": [7, 8, 13, 18],
-                            "response_outputs": ["cats", "are", "cool", "too"],
+                            "response_outputs": [
+                                {"text_output": "cats"},
+                                {"text_output": "are"},
+                                {"text_output": "cool"},
+                                {"text_output": "too"},
+                            ],
                         },
                         {
                             "timestamp": 3,
                             "response_timestamps": [6, 8, 11],
-                            "response_outputs": ["it's", "very", "simple work"],
+                            "response_outputs": [
+                                {"text_output": "it's"},
+                                {"text_output": "very"},
+                                {"text_output": "simple work"},
+                            ],
                         },
                     ],
                 },
             ],
         }
 
-        with open(self.path, "w") as f:
-            json.dump(self.profile_data, f)
+        with open(path, "w") as f:
+            json.dump(profile_data, f)
 
         yield None
 
         # clean up
-        remove_file(self.path)
+        remove_file(path)
 
-    def test_llm_profile_data(self, prepare_profile_data) -> None:
+    @pytest.fixture
+    def prepare_openai_profile_data(self) -> None:
+        path = Path("openai_profile_export.json")
+        profile_data = {
+            "experiments": [
+                {
+                    "experiment": {
+                        "mode": "concurrency",
+                        "value": 10,
+                    },
+                    "requests": [
+                        {
+                            "timestamp": 1,
+                            "response_timestamps": [3, 5, 8, 12],
+                            "response_outputs": [
+                                {
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n'
+                                },
+                                {
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"dogs"},"finish_reason":null}]}\n\n'
+                                },
+                                {
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"are"},"finish_reason":null}]}\n\n'
+                                },
+                                {
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"cool"},"finish_reason":null}]}\n\n'
+                                },
+                                {"response": "data: [DONE]\n\n"},
+                            ],
+                        },
+                        {
+                            "timestamp": 2,
+                            "response_timestamps": [4, 7, 11, 15, 18],
+                            "response_outputs": [
+                                {
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n'
+                                },
+                                {
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"I"},"finish_reason":null}]}\n\n'
+                                },
+                                {
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"don\'t"},"finish_reason":null}]}\n\n'
+                                },
+                                {
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"cook food"},"finish_reason":null}]}\n\n'
+                                },
+                                {"response": "data: [DONE]\n\n"},
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+
+        with open(path, "w") as f:
+            json.dump(profile_data, f)
+
+        yield None
+
+        # clean up
+        remove_file(path)
+
+    def test_triton_llm_profile_data(self, prepare_triton_profile_data) -> None:
         """Collect LLM metrics from profile export data and check values.
 
         Metrics
@@ -111,26 +190,35 @@ class TestLLMProfileData:
             - experiment 2: [4, 5]
         """
         tokenizer = AutoTokenizer.from_pretrained("gpt2")
-        pd = LLMProfileData("temp_profile_export.json", tokenizer)
+        pd = LLMProfileDataParser(
+            filename="triton_profile_export.json",
+            service_kind="triton",
+            tokenizer=tokenizer,
+        )
 
         # experiment 1 statistics
         stat = pd.get_statistics(infer_mode="concurrency", load_level=10)
+
         assert stat.avg_time_to_first_token == 2
         assert stat.avg_inter_token_latency == 2.25
         assert stat.avg_output_token_throughput == pytest.approx(31 / 63)
         assert stat.avg_num_output_token == 4
+
         assert stat.p50_time_to_first_token == 2
         assert stat.p50_inter_token_latency == 2
         assert stat.p50_output_token_throughput == pytest.approx(31 / 63)
         assert stat.p50_num_output_token == 4
+
         assert stat.min_time_to_first_token == 2
         assert stat.min_inter_token_latency == 2
         assert stat.min_output_token_throughput == pytest.approx(3 / 7)
         assert stat.min_num_output_token == 3
+
         assert stat.max_time_to_first_token == 2
         assert stat.max_inter_token_latency == 3
         assert stat.max_output_token_throughput == pytest.approx(5 / 9)
         assert stat.max_num_output_token == 5
+
         assert stat.std_time_to_first_token == np.std([2, 2])
         assert stat.std_inter_token_latency == np.std([2, 3, 2, 2])
         assert stat.std_output_token_throughput == np.std([3 / 7, 5 / 9])
@@ -138,22 +226,27 @@ class TestLLMProfileData:
 
         # experiment 2 statistics
         stat = pd.get_statistics(infer_mode="request_rate", load_level=2.0)
+
         assert stat.avg_time_to_first_token == 2.5
         assert stat.avg_inter_token_latency == 3
         assert stat.avg_output_token_throughput == pytest.approx(97 / 208)
         assert stat.avg_num_output_token == 4.5
+
         assert stat.p50_time_to_first_token == 2.5
         assert stat.p50_inter_token_latency == 2
         assert stat.p50_output_token_throughput == pytest.approx(97 / 208)
         assert stat.p50_num_output_token == 4.5
+
         assert stat.min_time_to_first_token == 2
         assert stat.min_inter_token_latency == 1
         assert stat.min_output_token_throughput == pytest.approx(4 / 13)
         assert stat.min_num_output_token == 4
+
         assert stat.max_time_to_first_token == 3
         assert stat.max_inter_token_latency == 5
         assert stat.max_output_token_throughput == pytest.approx(5 / 8)
         assert stat.max_num_output_token == 5
+
         assert stat.std_time_to_first_token == np.std([2, 3])
         assert stat.std_inter_token_latency == np.std([1, 5, 5, 2, 2])
         assert stat.std_output_token_throughput == np.std([4 / 13, 5 / 8])
@@ -162,6 +255,59 @@ class TestLLMProfileData:
         # check non-existing profile data
         with pytest.raises(KeyError):
             pd.get_statistics(infer_mode="concurrency", load_level=30)
+
+    def test_openai_llm_profile_data(self, prepare_openai_profile_data) -> None:
+        """Collect LLM metrics from profile export data and check values.
+
+        Metrics
+        * time to first tokens
+            - experiment 1: [3 - 1, 4 - 2] = [2, 2]
+        * inter token latencies
+            - experiment 1: [5 - 3, 8 - 5, 12 - 8, 7 - 4, 11 - 7, 15 - 11, 18 - 15]
+                          : [2, 3, 4, 3, 4, 4, 3]
+        * output token throughputs
+            - experiment 1: [3/(12 - 1), 5/(18 - 2)] = [3/11, 5/16]
+        * num output tokens
+            - experiment 1: [3, 5]
+        """
+        tokenizer = AutoTokenizer.from_pretrained("gpt2")
+        pd = LLMProfileDataParser(
+            filename="openai_profile_export.json",
+            service_kind="openai",
+            tokenizer=tokenizer,
+        )
+
+        # experiment 1 statistics
+        stat = pd.get_statistics(infer_mode="concurrency", load_level=10)
+
+        assert stat.avg_time_to_first_token == 2
+        assert stat.avg_inter_token_latency == pytest.approx(23 / 7)
+        assert stat.avg_output_token_throughput == pytest.approx(103 / 352)
+        assert stat.avg_num_output_token == 4
+
+        assert stat.p50_time_to_first_token == 2
+        assert stat.p50_inter_token_latency == 3
+        assert stat.p50_output_token_throughput == pytest.approx(103 / 352)
+        assert stat.p50_num_output_token == 4
+
+        assert stat.min_time_to_first_token == 2
+        assert stat.min_inter_token_latency == 2
+        assert stat.min_output_token_throughput == pytest.approx(3 / 11)
+        assert stat.min_num_output_token == 3
+
+        assert stat.max_time_to_first_token == 2
+        assert stat.max_inter_token_latency == 4
+        assert stat.max_output_token_throughput == pytest.approx(5 / 16)
+        assert stat.max_num_output_token == 5
+
+        assert stat.std_time_to_first_token == np.std([2, 2])
+        assert stat.std_inter_token_latency == np.std([2, 3, 4, 3, 4, 4, 3])
+        assert stat.std_output_token_throughput == np.std([3 / 11, 5 / 16])
+        assert stat.std_num_output_token == np.std([3, 5])
+
+        # check non-existing profile data
+        with pytest.raises(KeyError):
+            pd.get_statistics(infer_mode="concurrency", load_level=40)
 
     def test_llm_metrics_get_base_name(self) -> None:
         """Test get_base_name method in LLMMetrics class."""


### PR DESCRIPTION
- Fix Triton response output parsing
- Support OpenAI chat completion response output (both stream and non-stream)
- Support legacy OpenAI completion response output
- Add test case for OpenAI chat completion response
- Add `num_output_tokens` metrics & statistics

**NOTE**: Currently everything is located at `llm_metrics.py` and a separate PR will handle properly locating these classes into different modules since it will hide the changes made in this PR.