### PR TITLE
Export GenAi-PA results to CSV file

### DIFF
--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -246,10 +246,10 @@ class LLMProfileData:
             time_to_first_tokens.append(res_timestamps[0] - req_timestamp)
 
             # output token throughput
-            # output_tokens = tokenizer(res_outputs)["input_ids"]
-            # total_output_tokens = np.sum(list(map(len, output_tokens)))
-            # req_latency = res_timestamps[-1] - req_timestamp
-            # output_token_throughputs.append(total_output_tokens / req_latency)
+            output_tokens = tokenizer(res_outputs)["input_ids"]
+            total_output_tokens = np.sum(list(map(len, output_tokens)))
+            req_latency = res_timestamps[-1] - req_timestamp
+            output_token_throughputs.append(total_output_tokens / req_latency)
 
             # inter token latency
             for t1, t2 in pairwise(res_timestamps):

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -240,7 +240,7 @@ class LLMProfileData:
         for request in requests:
             req_timestamp = request["timestamp"]
             res_timestamps = request["response_timestamps"]
-            # res_outputs = request["response_outputs"]
+            res_outputs = request["response_outputs"]
 
             # time to first token
             time_to_first_tokens.append(res_timestamps[0] - req_timestamp)

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
@@ -77,8 +77,10 @@ def report_output(metrics: LLMProfileData, args):
             "Neither concurrency_range nor request_rate_range was found in args when reporting metrics"
         )
     stats = metrics.get_statistics(infer_mode, int(load_level))
-    if args.profile_export_file is not None:
-        stats.export_to_csv(args.profile_export_file)
+    export_csv_name = args.profile_export_file.with_name(
+        args.profile_export_file.stem + "_genai_pa" + args.profile_export_file.suffix
+    )
+    stats.export_to_csv(export_csv_name)
     stats.pretty_print()
 
 

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
@@ -77,6 +77,8 @@ def report_output(metrics: LLMProfileData, args):
             "Neither concurrency_range nor request_rate_range was found in args when reporting metrics"
         )
     stats = metrics.get_statistics(infer_mode, int(load_level))
+    if args.profile_export_file is not None:
+        stats.export_to_csv(args.profile_export_file)
     stats.pretty_print()
 
 

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/main.py
@@ -86,7 +86,7 @@ def report_output(metrics: LLMProfileDataParser, args):
         )
     stats = metrics.get_statistics(infer_mode, int(load_level))
     export_csv_name = args.profile_export_file.with_name(
-        args.profile_export_file.stem + "_genai_pa" + args.profile_export_file.suffix
+        args.profile_export_file.stem + "_genai_pa.csv"
     )
     stats.export_to_csv(export_csv_name)
     stats.pretty_print()

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/parser.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/parser.py
@@ -119,8 +119,8 @@ def _add_profile_args(parser):
         default="profile_export.json",
         help="Specifies the path where the perf_analyzer profile export will be "
         "generated. By default, the profile export will be to profile_export.json. "
-        "The GenAi-PA file will be exported to <profile_export_file>_genai_pa. For example,"
-        "if the profile export file is profile_export.json, the GenAi-PA file will be "
+        "The GenAi-PA file will be exported to <profile_export_file>_genai_pa.<file_extension>. "
+        "For example, if the profile export file is profile_export.json, the GenAi-PA file will be "
         "exported to profile_export_genai_pa.json.",
     )
     load_management_group.add_argument(

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/parser.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/parser.py
@@ -155,9 +155,9 @@ def _add_profile_args(parser):
         default="profile_export.json",
         help="Specifies the path where the perf_analyzer profile export will be "
         "generated. By default, the profile export will be to profile_export.json. "
-        "The GenAi-PA file will be exported to <profile_export_file>_genai_pa.<file_extension>. "
+        "The GenAi-PA file will be exported to <profile_export_file>_genai_pa.csv. "
         "For example, if the profile export file is profile_export.json, the GenAi-PA file will be "
-        "exported to profile_export_genai_pa.json.",
+        "exported to profile_export_genai_pa.csv.",
     )
     load_management_group.add_argument(
         "--request-rate",

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/parser.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/parser.py
@@ -117,9 +117,11 @@ def _add_profile_args(parser):
         "--profile-export-file",
         type=Path,
         default="profile_export.json",
-        help="Specifies the path where the profile export will be "
-        "generated. By default, the profile export will not be "
-        "generated.",
+        help="Specifies the path where the perf_analyzer profile export will be "
+        "generated. By default, the profile export will be to profile_export.json. "
+        "The GenAi-PA file will be exported to <profile_export_file>_genai_pa. For example,"
+        "if the profile export file is profile_export.json, the GenAi-PA file will be "
+        "exported to profile_export_genai_pa.json.",
     )
     load_management_group.add_argument(
         "--request-rate",


### PR DESCRIPTION
This pull request cleans up the GenAi-PA report table and exports the more detailed metrics to a CSV (e.g. more percentile options).

Since we are requiring the export file due to PA returning it, this clarifies the wording. For simplicity, since the PA export is being saved, the GenAi-PA one will be as well. If we remove the PA export file being written in the future, we can also look at making the GenAi-PA CSV being optional for users who want to disable the exports.

Report with highlights shown (excluding inter-token latency due to this being with streaming disabled):
![image](https://github.com/triton-inference-server/client/assets/58150256/540aadf0-84e3-458b-8962-076b1886ef7f)

CSV with all calculated percentiles shown (excluding inter-token latency due to this being with streaming disabled):
![image](https://github.com/triton-inference-server/client/assets/58150256/aceba2f4-e1d3-4341-bb96-453c24530666)
