### PR TITLE
LlmInputs - Ignoring blank content

### DIFF
--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_inputs/llm_inputs.py
@@ -545,6 +545,10 @@ class LlmInputs:
         user_role_headers: List[str],
         content: str,
     ) -> Optional[Dict]:
+        # Do not add messages with blank content
+        if not content:
+            return {}
+
         if header in system_role_headers:
             new_message = {
                 "role": "system",


### PR DESCRIPTION
Do not add message if the content is blank when generation OpenAI chat completions.