### PR TITLE
Update GenAi-PA formatting for throughput and streaming metrics 

### DIFF
--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -260,8 +260,6 @@ class Statistics:
                 formatted_metric = metric
 
                 is_throughput_field = self._is_throughput_field(metric)
-
-                is_throughput_field = self._is_throughput_field(metric)
                 is_time_field = self._is_time_field(metric)
 
                 if is_time_field:

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -209,7 +209,7 @@ class Statistics:
 
             for stat in stats:
                 value = self.__dict__.get(f"{stat}_{metric}", -1)
-                row_values.append(f"{value:.0f}")
+                row_values.append(f"{value:,.0f}")
 
             # Without streaming, there is no inter-token latency available, so do not print it.
             if metric == "inter_token_latency":
@@ -271,7 +271,6 @@ class Statistics:
 
                 row_values = [formatted_metric]
 
-                # Throughput fields are printed after the table
                 if is_throughput_field:
                     value = self.__dict__.get(f"{header[1]}_{metric}", -1)
                     row_values.append(f"{value:.2f}")

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -180,6 +180,9 @@ class Statistics:
         return field in Metrics.time_fields
 
     def pretty_print(self):
+        """Prints the statistics in a tabular format."""
+
+        singular_metric_rows = []
         table = Table(title="PA LLM Metrics")
 
         table.add_column("Statistic", justify="right", style="cyan", no_wrap=True)
@@ -189,28 +192,51 @@ class Statistics:
 
         for metric in Metrics.metric_labels:
             formatted_metric = metric.replace("_", " ").capitalize()
-            if self._is_time_field(metric):
+
+            # Throughput fields are printed after the table
+            is_throughput_field = self._is_throughput_field(metric)
+            if is_throughput_field:
+                value = self.__dict__.get(f"{stats[0]}_{metric}", -1)
+                formatted_metric += f" (per sec): {value:.2f}"
+                singular_metric_rows.append(formatted_metric)
+                continue
+
+            is_time_field = self._is_time_field(metric)
+            if is_time_field:
                 formatted_metric += " (ns)"
-            elif self._is_throughput_field(metric):
-                formatted_metric += " (per sec)"
 
             row_values = [formatted_metric]
 
             for stat in stats:
                 value = self.__dict__.get(f"{stat}_{metric}", -1)
-                row_values.append("{:,.0f}".format(value))
+                row_values.append(f"{value:.0f}")
 
-            # Without streaming, there is no inter-token latency available.
+            # Without streaming, there is no inter-token latency available, so do not print it.
             if metric == "inter_token_latency":
-                if all(value == -1 for value in row_values[1:]):
+                if all(int(value) == -1 for value in row_values[1:]):
                     continue
-            else:
-                table.add_row(*row_values)
+            # Without streaming, TTFT and request latency are the same, so do not print TTFT.
+            elif metric == "time_to_first_token":
+                unique_values = True
+                for stat in stats:
+                    value_ttft = self.__dict__.get(f"{stat}_{metric}", -1)
+                    value_req_latency = self.__dict__.get(f"{stat}_request_latency", -1)
+                    if value_ttft != value_req_latency:
+                        unique_values = False
+                        break
+                continue
+
+            table.add_row(*row_values)
 
         console = Console()
         console.print(table)
 
+        for row in singular_metric_rows:
+            print(row)
+
     def export_to_csv(self, csv_filename: str):
+        """Exports the statistics to a CSV file."""
+
         header = [
             "Statistic",
             "avg",
@@ -225,28 +251,58 @@ class Statistics:
         ]
 
         with open(csv_filename, mode="w", newline="") as csvfile:
+            singular_metric_rows = []
+
             csv_writer = csv.writer(csvfile)
             csv_writer.writerow(header)
 
             for metric in Metrics.metric_labels:
                 formatted_metric = metric
-                if self._is_time_field(metric):
+
+                is_throughput_field = self._is_throughput_field(metric)
+
+                is_throughput_field = self._is_throughput_field(metric)
+                is_time_field = self._is_time_field(metric)
+
+                if is_time_field:
                     formatted_metric += "(ns)"
-                elif self._is_throughput_field(metric):
+                elif is_throughput_field:
                     formatted_metric += "(per sec)"
 
                 row_values = [formatted_metric]
+
+                # Throughput fields are printed after the table
+                if is_throughput_field:
+                    value = self.__dict__.get(f"{header[1]}_{metric}", -1)
+                    row_values.append(f"{value:.2f}")
+                    singular_metric_rows.append(row_values)
+                    continue
 
                 for stat in header[1:]:
                     value = self.__dict__.get(f"{stat}_{metric}", -1)
                     row_values.append(f"{value:.0f}")
 
-                # Without streaming, there is no inter-token latency available.
+                # Without streaming, there is no inter-token latency available, so do not print it.
                 if metric == "inter_token_latency":
-                    if all(value == -1 for value in row_values[1:]):
+                    if all(int(value) == -1 for value in row_values[1:]):
                         continue
-                else:
-                    csv_writer.writerow(row_values)
+                # Without streaming, TTFT and request latency are the same, so do not print TTFT.
+                elif metric == "time_to_first_token":
+                    unique_values = True
+                    for stat in header[1:]:
+                        value_ttft = self.__dict__.get(f"{stat}_{metric}", -1)
+                        value_req_latency = self.__dict__.get(
+                            f"{stat}_request_latency", -1
+                        )
+                        if value_ttft != value_req_latency:
+                            unique_values = False
+                            break
+                    continue
+
+                csv_writer.writerow(row_values)
+
+            for row in singular_metric_rows:
+                csv_writer.writerow(row)
 
 
 class ProfileDataParser:

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -224,7 +224,8 @@ class Statistics:
                     if value_ttft != value_req_latency:
                         unique_values = False
                         break
-                continue
+                if not unique_values:
+                    continue
 
             table.add_row(*row_values)
 
@@ -294,7 +295,8 @@ class Statistics:
                         if value_ttft != value_req_latency:
                             unique_values = False
                             break
-                    continue
+                    if not unique_values:
+                        continue
 
                 csv_writer.writerow(row_values)
 

--- a/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-pa/genai_pa/llm_metrics.py
@@ -217,12 +217,12 @@ class Statistics:
                     continue
             # Without streaming, TTFT and request latency are the same, so do not print TTFT.
             elif metric == "time_to_first_token":
-                unique_values = True
+                unique_values = False
                 for stat in stats:
                     value_ttft = self.__dict__.get(f"{stat}_{metric}", -1)
                     value_req_latency = self.__dict__.get(f"{stat}_request_latency", -1)
                     if value_ttft != value_req_latency:
-                        unique_values = False
+                        unique_values = True
                         break
                 if not unique_values:
                     continue
@@ -286,14 +286,14 @@ class Statistics:
                         continue
                 # Without streaming, TTFT and request latency are the same, so do not print TTFT.
                 elif metric == "time_to_first_token":
-                    unique_values = True
+                    unique_values = False
                     for stat in header[1:]:
                         value_ttft = self.__dict__.get(f"{stat}_{metric}", -1)
                         value_req_latency = self.__dict__.get(
                             f"{stat}_request_latency", -1
                         )
                         if value_ttft != value_req_latency:
-                            unique_values = False
+                            unique_values = True
                             break
                     if not unique_values:
                         continue


### PR DESCRIPTION
Updates the formatting for GenAi-PA:
1. For throughput metrics, show 2 significant figures.
2. For throughput metrics, only one value matters. Take these metrics out of the main table.
3. For the streaming case, time to first token and response latency are the same, so do not show time to first token.

New format for output table:
<img width="726" alt="image" src="https://github.com/triton-inference-server/client/assets/58150256/1ff90e1f-1a47-487e-b1e4-bf6ff26516c4">

New format for CSV export:
<img width="721" alt="image" src="https://github.com/triton-inference-server/client/assets/58150256/b0217be3-d45a-4232-b278-d5945ca2d19c">
