### PR TITLE
Fix passthrough arg handling and testing

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -94,7 +94,6 @@ def report_output(metrics: LLMProfileDataParser, args):
 
 # Separate function that can raise exceptions used for testing
 # to assert correct errors and messages.
-# Optional argv used for testing - will default to sys.argv if None.
 def run(argv=None):
     try:
         args, extra_args = parser.parse_args(argv)

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -94,9 +94,9 @@ def report_output(metrics: LLMProfileDataParser, args):
 
 # Separate function that can raise exceptions used for testing
 # to assert correct errors and messages.
-def run(argv=None):
+def run():
     try:
-        args, extra_args = parser.parse_args(argv)
+        args, extra_args = parser.parse_args()
         generate_inputs(args)
         args.func(args, extra_args)
         metrics = calculate_metrics(args.profile_export_file, args.service_kind)

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -276,7 +276,7 @@ def parse_args():
     # Check for passthrough args
     if "--" in argv:
         passthrough_index = argv.index("--")
-        print("Detected passthrough args: ", argv[passthrough_index + 1 :])
+        logger.info(f"Detected passthrough args: {argv[passthrough_index + 1:]}")
     else:
         passthrough_index = len(argv)
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -258,9 +258,8 @@ def _add_dataset_args(parser):
 ### Entrypoint ###
 
 
-def parse_args(argv=None):
-    if argv is None:
-        argv = sys.argv
+def parse_args():
+    argv = sys.argv
 
     parser = argparse.ArgumentParser(
         prog="genai-perf",

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -26,6 +26,7 @@
 
 import argparse
 import logging
+import sys
 from pathlib import Path
 
 import genai_perf.utils as utils
@@ -257,8 +258,10 @@ def _add_dataset_args(parser):
 ### Entrypoint ###
 
 
-# Optional argv used for testing - will default to sys.argv if None.
 def parse_args(argv=None):
+    if argv is None:
+        argv = sys.argv
+
     parser = argparse.ArgumentParser(
         prog="genai-perf",
         description="CLI to profile LLMs and Generative AI models with Perf Analyzer",
@@ -271,15 +274,17 @@ def parse_args(argv=None):
     _add_endpoint_args(parser)
     _add_dataset_args(parser)
 
-    args, extra_args = parser.parse_known_args(argv)
-    if extra_args:
-        # strip off the "--" demarking the pass through arguments
-        extra_args = extra_args[1:]
-        logger.info(f"Additional pass through args: {extra_args}")
+    # Check for passthrough args
+    if "--" in argv:
+        passthrough_index = argv.index("--")
+        print("Detected passthrough args: ", argv[passthrough_index + 1 :])
+    else:
+        passthrough_index = len(argv)
 
+    args = parser.parse_args(argv[1:passthrough_index])
     args = _update_load_manager_args(args)
     args = _convert_str_to_enum_entry(args, "input_type", InputType)
     args = _convert_str_to_enum_entry(args, "output_format", OutputFormat)
     args = _prune_args(args)
 
-    return args, extra_args
+    return args, argv[passthrough_index + 1 :]

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -46,7 +46,7 @@ class TestCLIArguments:
     def test_help_arguments_output_and_exit(
         self, monkeypatch, arg, expected_output, capsys
     ):
-        monkeypatch.setattr("sys.argv", ["genai-pa", "--help"])
+        monkeypatch.setattr("sys.argv", ["genai-perf", "--help"])
 
         with pytest.raises(SystemExit) as excinfo:
             _ = parser.parse_args()
@@ -76,7 +76,7 @@ class TestCLIArguments:
     )
     def test_arguments_output(self, monkeypatch, arg, expected_attributes, capsys):
         combined_args = [
-            "genai-pa",
+            "genai-perf",
             "--model",
             "test_model",
             "--concurrency",
@@ -94,7 +94,7 @@ class TestCLIArguments:
         assert captured.out == ""
 
     def test_arguments_model_not_provided(self, monkeypatch):
-        monkeypatch.setattr("sys.argv", "genai-pa")
+        monkeypatch.setattr("sys.argv", "genai-perf")
         with pytest.raises(SystemExit) as exc_info:
             _ = parser.parse_args()
 
@@ -103,24 +103,36 @@ class TestCLIArguments:
 
     def test_exception_on_nonzero_exit(self, monkeypatch):
         monkeypatch.setattr(
-            "sys.argv", ["genai-pa", "-m", "nonexistent_model", "--concurrency", "3"]
+            "sys.argv", ["genai-perf", "-m", "nonexistent_model", "--concurrency", "3"]
         )
         with pytest.raises(GenAIPerfException) as e:
             run()
 
     def test_pass_through_args(self, monkeypatch):
-        args = ["genai-pa", "-m", "test_model", "--concurrency", "1"]
+        args = ["genai-perf", "-m", "test_model", "--concurrency", "1"]
         other_args = ["--", "With", "great", "power"]
         monkeypatch.setattr("sys.argv", args + other_args)
         _, pass_through_args = parser.parse_args()
 
         assert pass_through_args == other_args[1:]
 
-    def test_wrong_args(self, monkeypatch):
+    def test_wrong_args(self, monkeypatch, capsys):
         monkeypatch.setattr(
             "sys.argv",
-            ["genai-pa", "-m", "nonexisten_model", "--concurrency", "2", "--wrong-arg"],
+            [
+                "genai-perf",
+                "-m",
+                "nonexistent_model",
+                "--concurrency",
+                "2",
+                "--wrong-arg",
+            ],
         )
-        with pytest.raises(GenAiPAException) as e:
-            run(["genai-pa", "-m", "nonexistent_model", "--concurrency", "3"])
-            assert "unrecognized arguments: --wrong-arg" in e
+        expected_output = "unrecognized arguments: --wrong-arg"
+
+        with pytest.raises(SystemExit) as excinfo:
+            run()
+
+        assert excinfo.value.code != 0
+        captured = capsys.readouterr()
+        assert expected_output in captured.err


### PR DESCRIPTION
- Require passthrough args to follow separator ("--")
- Use parse_args instead of parse_known_args to avoid hiding errors
- Use monkeypatch to mock CLI args in testing

Tests passing:
<img width="1322" alt="image" src="https://github.com/triton-inference-server/client/assets/58150256/020543d6-f8e9-46de-b963-376c0eb35bf9">
