### PR TITLE
Create unit tests for all CLI args for GenAi-Perf

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(LOGGER_NAME)
 
 
 def generate_inputs(args):
-    # TODO: remove once fale support is in
+    # TODO: remove once file support is implemented
     input_file_name = ""
     # TODO: review if always true
     add_model_name = True

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -171,7 +171,8 @@ def _add_profile_args(parser):
         required=False,
         help="Describes the kind of service perf_analyzer will "
         'generate load for. The options are "triton" and '
-        '"openai". The default value is "triton".',
+        '"openai". Note in order to use "openai" you must specify '
+        'an endpoint via --endpoint. The default value is "triton".',
     )
 
     profile_group.add_argument(
@@ -207,7 +208,13 @@ def _add_endpoint_args(parser):
     endpoint_group = parser.add_argument_group("Endpoint")
 
     endpoint_group.add_argument(
-        "--endpoint", type=str, required=False, help="Specify an endpoint."
+        "--endpoint",
+        type=str,
+        choices=["v1/completions", "v1/chat/completions"],
+        required=False,
+        help="Describes what endpoint to send requests to on the "
+        'server. This is required when using "openai" service-kind. '
+        "This is ignored in other cases.",
     )
 
     endpoint_group.add_argument(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -177,7 +177,7 @@ def _add_profile_args(parser):
     profile_group.add_argument(
         "-s",
         "--stability-percentage",
-        type=int,
+        type=float,
         default=999,
         required=False,
         help="Indicates the allowed variation in "
@@ -195,10 +195,7 @@ def _add_profile_args(parser):
     )
 
     profile_group.add_argument(
-        "-v", action="store_true", required=False, help="Enables verbose mode."
-    )
-
-    profile_group.add_argument(
+        "-v",
         "--version",
         action="store_true",
         required=False,

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -64,6 +64,11 @@ class TestCLIArguments:
         "arg, expected_attributes",
         [
             (["--concurrency", "3"], {"concurrency_range": "3"}),
+            (["--endpoint", "v1/completions"], {"endpoint": "v1/completions"}),
+            (
+                ["--endpoint", "v1/chat/completions"],
+                {"endpoint": "v1/chat/completions"},
+            ),
             (
                 ["--input-type", "file"],
                 {"input_type": utils.get_enum_entry("file", InputType)},
@@ -116,12 +121,9 @@ class TestCLIArguments:
             (["-v"], {"version": True}),
             (["--url", "test_url"], {"u": "test_url"}),
             (["-u", "test_url"], {"u": "test_url"}),
-            # Test default values, split into own test later
-            (["--concurrency", "2"], {"version": False}),
-            (["--concurrency", "2"], {"streaming": False}),
         ],
     )
-    def test_arguments_output(self, monkeypatch, arg, expected_attributes, capsys):
+    def test_all_flags_parsed(self, monkeypatch, arg, expected_attributes, capsys):
         combined_args = ["genai-perf", "--model", "test_model"] + arg
         if "--concurrency" != arg[0] and "--request-rate" != arg[0]:
             combined_args.extend(["--concurrency", "2"])
@@ -136,7 +138,7 @@ class TestCLIArguments:
         captured = capsys.readouterr()
         assert captured.out == ""
 
-    def test_arguments_model_not_provided(self, monkeypatch, capsys):
+    def test_model_not_provided(self, monkeypatch, capsys):
         monkeypatch.setattr("sys.argv", ["genai-perf", "--concurrency", "2"])
         expected_output = "the following arguments are required: -m/--model"
 


### PR DESCRIPTION
This updates the GenAi-perf parser unit tests to include all CLI args that have been added. Going forward, we should be updating these tests whenever there is a change in args parsed to cover all args.

This test also adds some small clarifications due to behavior found during testing, but additional testing of making args conditional or simpler would occur in a separate PR.