### PR TITLE
Make load level optional for GenAi-PA

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -356,7 +356,7 @@ class ProfileDataParser:
         """Parse each request in profile data to extract core metrics."""
         raise NotImplementedError
 
-    def get_statistics(self, infer_mode: str, load_level: int | float) -> Statistics:
+    def get_statistics(self, infer_mode: str, load_level: str) -> Statistics:
         """Return profile statistics if it exists."""
         if (infer_mode, load_level) not in self._profile_results:
             raise KeyError(f"Profile with {infer_mode}={load_level} does not exist.")

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -85,9 +85,6 @@ def report_output(metrics: LLMProfileDataParser, args):
     elif "request_rate_range" in args:
         infer_mode = "request_rate"
         load_level = args.request_rate_range
-    else:
-        infer_mode = "concurrency"
-        load_level = "1"
     stats = metrics.get_statistics(infer_mode, load_level)
     export_csv_name = args.profile_export_file.with_name(
         args.profile_export_file.stem + "_genai_perf.csv"

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -86,9 +86,8 @@ def report_output(metrics: LLMProfileDataParser, args):
         infer_mode = "request_rate"
         load_level = args.request_rate_range
     else:
-        raise GenAIPerfException(
-            "Neither concurrency_range nor request_rate_range was found in args when reporting metrics"
-        )
+        infer_mode = "concurrency"
+        load_level = "1"
     stats = metrics.get_statistics(infer_mode, load_level)
     export_csv_name = args.profile_export_file.with_name(
         args.profile_export_file.stem + "_genai_perf.csv"

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -56,7 +56,11 @@ def _update_load_manager_args(args: argparse.ArgumentParser) -> argparse.Argumen
         attr_val = getattr(args, attr_key)
         if attr_val is not None:
             setattr(args, f"{attr_key}_range", f"{attr_val}")
-        delattr(args, attr_key)
+            delattr(args, attr_key)
+            return args
+
+    # If no concurrency or request rate is set, default to 1
+    setattr(args, "concurrency_range", "1")
     return args
 
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -157,7 +157,7 @@ def _add_model_args(parser):
 
 def _add_profile_args(parser):
     profile_group = parser.add_argument_group("Profiling")
-    load_management_group = profile_group.add_mutually_exclusive_group(required=True)
+    load_management_group = profile_group.add_mutually_exclusive_group(required=False)
 
     load_management_group.add_argument(
         "--concurrency",

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -142,6 +142,13 @@ class TestCLIArguments:
         captured = capsys.readouterr()
         assert captured.out == ""
 
+    def test_default_load_level(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["genai-perf", "--model", "test_model"])
+        args, extra_args = parser.parse_args()
+        assert getattr(args, "concurrency_range") == "1"
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
     def test_load_level_mutually_exclusive(self, monkeypatch, capsys):
         monkeypatch.setattr(
             "sys.argv", ["genai-perf", "--concurrency", "3", "--request-rate", "9.0"]

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -131,8 +131,6 @@ class TestCLIArguments:
     )
     def test_all_flags_parsed(self, monkeypatch, arg, expected_attributes, capsys):
         combined_args = ["genai-perf", "--model", "test_model"] + arg
-        if "--concurrency" != arg[0] and "--request-rate" != arg[0]:
-            combined_args.extend(["--concurrency", "2"])
         monkeypatch.setattr("sys.argv", combined_args)
         args, _ = parser.parse_args()
 
@@ -145,7 +143,7 @@ class TestCLIArguments:
         assert captured.out == ""
 
     def test_model_not_provided(self, monkeypatch, capsys):
-        monkeypatch.setattr("sys.argv", ["genai-perf", "--concurrency", "2"])
+        monkeypatch.setattr("sys.argv", ["genai-perf"])
         expected_output = "the following arguments are required: -m/--model"
 
         with pytest.raises(SystemExit) as excinfo:
@@ -155,21 +153,8 @@ class TestCLIArguments:
         captured = capsys.readouterr()
         assert expected_output in captured.err
 
-    def test_arguments_load_level_not_provided(self, monkeypatch, capsys):
-        monkeypatch.setattr("sys.argv", ["genai-perf", "--model", "test_model"])
-        expected_output = (
-            "one of the arguments --concurrency --request-rate is required"
-        )
-
-        with pytest.raises(SystemExit) as excinfo:
-            parser.parse_args()
-
-        assert excinfo.value.code != 0
-        captured = capsys.readouterr()
-        assert expected_output in captured.err
-
     def test_pass_through_args(self, monkeypatch):
-        args = ["genai-perf", "-m", "test_model", "--concurrency", "1"]
+        args = ["genai-perf", "-m", "test_model"]
         other_args = ["--", "With", "great", "power"]
         monkeypatch.setattr("sys.argv", args + other_args)
         _, pass_through_args = parser.parse_args()
@@ -183,8 +168,6 @@ class TestCLIArguments:
                 "genai-perf",
                 "-m",
                 "nonexistent_model",
-                "--concurrency",
-                "2",
                 "--wrong-arg",
             ],
         )

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -142,6 +142,21 @@ class TestCLIArguments:
         captured = capsys.readouterr()
         assert captured.out == ""
 
+    def test_load_level_mutually_exclusive(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "sys.argv", ["genai-perf", "--concurrency", "3", "--request-rate", "9.0"]
+        )
+        expected_output = (
+            "argument --request-rate: not allowed with argument --concurrency"
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            parser.parse_args()
+
+        assert excinfo.value.code != 0
+        captured = capsys.readouterr()
+        assert expected_output in captured.err
+
     def test_model_not_provided(self, monkeypatch, capsys):
         monkeypatch.setattr("sys.argv", ["genai-perf"])
         expected_output = "the following arguments are required: -m/--model"
@@ -161,7 +176,7 @@ class TestCLIArguments:
 
         assert pass_through_args == other_args[1:]
 
-    def test_expected_errors(self, monkeypatch, capsys):
+    def test_unrecognized_arg(self, monkeypatch, capsys):
         monkeypatch.setattr(
             "sys.argv",
             [


### PR DESCRIPTION
Use the default load level in PA (concurrency 1) if load level is not provided in GenAi-PA.

Tested with:
![image](https://github.com/triton-inference-server/client/assets/58150256/649d926d-b4f8-4049-98a6-547f71c857fb)
Result:
![image](https://github.com/triton-inference-server/client/assets/58150256/1d56de3c-4f03-4ad1-bd12-8235a0b45de4)

Unit testing passed:
![image](https://github.com/triton-inference-server/client/assets/58150256/9e3accc7-4aa3-4f04-aaf1-0a5df41cdd45)
