### PR TITLE
Remove final empty/null responses in OpenAI API

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -479,17 +479,17 @@ class LLMProfileDataParser(ProfileDataParser):
                 d["text_output"] = self._remove_leading_invalid_chars(d["text_output"])
         elif self._service_kind == "openai":
             # remove the null final response in streaming mode
-            response = res_outputs[-1]["response"]
-            response = remove_sse_prefix(response)
-            if response == "[DONE]":
+            last_response = res_outputs[-1]["response"]
+            last_response = remove_sse_prefix(last_response)
+            if last_response == "[DONE]":
                 res_timestamps.pop()
                 res_outputs.pop()
 
             # after removing the final null response, check if the last response
             # of the remaining responses is missing text/content and remove it
             # if it is an empty response.
-            response = res_outputs[-1]["response"]
-            text_output = self._extract_openai_text_output(response)
+            last_response = res_outputs[-1]["response"]
+            text_output = self._extract_openai_text_output(last_response)
             if text_output == "":
                 res_timestamps.pop()
                 res_outputs.pop()

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -471,20 +471,26 @@ class LLMProfileDataParser(ProfileDataParser):
     def _preprocess_response(
         self, res_timestamps: list[int], res_outputs: list[dict[str, str]]
     ) -> None:
+        """Helper function to preprocess responses of a request."""
         # FIXME -- remove this triton code once it is properly fixed in PA
         # (PA/triton will add junk to the start of the BYTES array. Remove it here)
         if self._service_kind == "triton":
             for d in res_outputs:
                 d["text_output"] = self._remove_leading_invalid_chars(d["text_output"])
+        elif self._service_kind == "openai":
+            # remove the null final response in streaming mode
+            response = res_outputs[-1]["response"]
+            response = remove_sse_prefix(response)
+            if response == "[DONE]":
+                res_timestamps.pop()
+                res_outputs.pop()
 
-        """Helper function to preprocess responses of a request."""
-        if self._service_kind == "openai":
-            openai_final_response = res_outputs[-1]["response"]
-            openai_final_response = remove_sse_prefix(openai_final_response)
-
-            # remove the null final response because this has no output token
-            # and will cause problems when calculating metrics/statistics.
-            if openai_final_response == "[DONE]":
+            # after removing the final null response, check if the last response
+            # of the remaining responses is missing text/content and remove it
+            # if it is an empty response.
+            response = res_outputs[-1]["response"]
+            text_output = self._extract_openai_text_output(response)
+            if text_output == "":
                 res_timestamps.pop()
                 res_outputs.pop()
 
@@ -508,21 +514,24 @@ class LLMProfileDataParser(ProfileDataParser):
         """Tokenize the OpenAI response output texts."""
         output_texts = []
         for output in res_outputs:
-            # extract payload and deserialize into dict object
-            openai_response = remove_sse_prefix(output["response"])
-            openai_response = json.loads(openai_response)
-            completions = openai_response["choices"][0]
-
-            if openai_response["object"] == "text_completion":  # legacy
-                output_texts.append(completions["text"])
-            elif openai_response["object"] == "chat.completion":  # non-streaming
-                text = completions["message"]["content"]
-                output_texts.append(text)
-            elif openai_response["object"] == "chat.completion.chunk":  # streaming
-                text = completions["delta"].get("content", "")
-                output_texts.append(text)
-            else:
-                obj_type = openai_response["object"]
-                raise ValueError(f"Unknown OpenAI response object type '{obj_type}'.")
-
+            text = self._extract_openai_text_output(output["response"])
+            output_texts.append(text)
         return self._tokenizer(output_texts)["input_ids"]
+
+    def _extract_openai_text_output(self, response: str) -> str:
+        """Extracts text/content of the OpenAI response object."""
+        response = remove_sse_prefix(response)
+        data = json.loads(response)
+        completions = data["choices"][0]
+
+        text_output = ""
+        if data["object"] == "text_completion":  # legacy
+            text_output = completions.get("text", "")
+        elif data["object"] == "chat.completion":  # non-streaming
+            text_output = completions["message"]["content"]
+        elif data["object"] == "chat.completion.chunk":  # streaming
+            text_output = completions["delta"].get("content", "")
+        else:
+            obj_type = data["object"]
+            raise ValueError(f"Unknown OpenAI response object type '{obj_type}'.")
+        return text_output

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
@@ -129,19 +129,19 @@ class TestLLMProfileDataParser:
                         {
                             "timestamp": 1,
                             # null final timestamp & output will be ignored
-                            "response_timestamps": [3, 5, 8, 12],
+                            "response_timestamps": [3, 5, 8, 12, 13],
                             "response_outputs": [
                                 {
-                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n'
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n'
                                 },
                                 {
-                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"dogs"},"finish_reason":null}]}\n\n'
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"content":"dogs"},"finish_reason":null}]}\n\n'
                                 },
                                 {
-                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"are"},"finish_reason":null}]}\n\n'
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"content":"are"},"finish_reason":null}]}\n\n'
                                 },
                                 {
-                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"cool"},"finish_reason":null}]}\n\n'
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"content":"cool"},"finish_reason":null}]}\n\n'
                                 },
                                 {"response": "data: [DONE]\n\n"},
                             ],
@@ -152,16 +152,16 @@ class TestLLMProfileDataParser:
                             "response_timestamps": [4, 7, 11, 15, 18],
                             "response_outputs": [
                                 {
-                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n'
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n'
                                 },
                                 {
-                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"I"},"finish_reason":null}]}\n\n'
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"content":"I"},"finish_reason":null}]}\n\n'
                                 },
                                 {
-                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"don\'t"},"finish_reason":null}]}\n\n'
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"content":"don\'t"},"finish_reason":null}]}\n\n'
                                 },
                                 {
-                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"mistralai/Mistral-7B-v0.1","choices":[{"index":0,"delta":{"content":"cook food"},"finish_reason":null}]}\n\n'
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"content":"cook food"},"finish_reason":null}]}\n\n'
                                 },
                                 {"response": "data: [DONE]\n\n"},
                             ],
@@ -215,34 +215,34 @@ class TestLLMProfileDataParser:
 
         assert stat.avg_time_to_first_token == 2
         assert stat.avg_inter_token_latency == 2.25
-        avg_rott = 31 / ns_to_sec(63)
-        assert stat.avg_output_token_throughput_per_request == pytest.approx(avg_rott)
+        avg_ottpr = 31 / ns_to_sec(63)
+        assert stat.avg_output_token_throughput_per_request == pytest.approx(avg_ottpr)
         assert stat.avg_num_output_token == 4
 
         assert stat.p50_time_to_first_token == 2
         assert stat.p50_inter_token_latency == 2
-        p50_rott = 31 / ns_to_sec(63)
-        assert stat.p50_output_token_throughput_per_request == pytest.approx(p50_rott)
+        p50_ottpr = 31 / ns_to_sec(63)
+        assert stat.p50_output_token_throughput_per_request == pytest.approx(p50_ottpr)
         assert stat.p50_num_output_token == 4
 
         assert stat.min_time_to_first_token == 2
         assert stat.min_inter_token_latency == 2
-        min_rott = 3 / ns_to_sec(7)
-        assert stat.min_output_token_throughput_per_request == pytest.approx(min_rott)
+        min_ottpr = 3 / ns_to_sec(7)
+        assert stat.min_output_token_throughput_per_request == pytest.approx(min_ottpr)
         assert stat.min_num_output_token == 3
 
         assert stat.max_time_to_first_token == 2
         assert stat.max_inter_token_latency == 3
-        max_rott = 5 / ns_to_sec(9)
-        assert stat.max_output_token_throughput_per_request == pytest.approx(max_rott)
+        max_ottpr = 5 / ns_to_sec(9)
+        assert stat.max_output_token_throughput_per_request == pytest.approx(max_ottpr)
         assert stat.max_num_output_token == 5
 
         assert stat.std_time_to_first_token == np.std([2, 2])
         assert stat.std_inter_token_latency == np.std([2, 3, 2, 2])
-        rott1 = 3 / ns_to_sec(7)
-        rott2 = 5 / ns_to_sec(9)
+        ottpr1 = 3 / ns_to_sec(7)
+        ottpr2 = 5 / ns_to_sec(9)
         assert stat.std_output_token_throughput_per_request == pytest.approx(
-            np.std([rott1, rott2])
+            np.std([ottpr1, ottpr2])
         )
         assert stat.std_num_output_token == np.std([3, 5])
 
@@ -254,34 +254,34 @@ class TestLLMProfileDataParser:
 
         assert stat.avg_time_to_first_token == 2.5
         assert stat.avg_inter_token_latency == 3
-        avg_rott = 97 / ns_to_sec(208)
-        assert stat.avg_output_token_throughput_per_request == pytest.approx(avg_rott)
+        avg_ottpr = 97 / ns_to_sec(208)
+        assert stat.avg_output_token_throughput_per_request == pytest.approx(avg_ottpr)
         assert stat.avg_num_output_token == 4.5
 
         assert stat.p50_time_to_first_token == 2.5
         assert stat.p50_inter_token_latency == 2
-        p50_rott = 97 / ns_to_sec(208)
-        assert stat.p50_output_token_throughput_per_request == pytest.approx(p50_rott)
+        p50_ottpr = 97 / ns_to_sec(208)
+        assert stat.p50_output_token_throughput_per_request == pytest.approx(p50_ottpr)
         assert stat.p50_num_output_token == 4.5
 
         assert stat.min_time_to_first_token == 2
         assert stat.min_inter_token_latency == 1
-        min_rott = 4 / ns_to_sec(13)
-        assert stat.min_output_token_throughput_per_request == pytest.approx(min_rott)
+        min_ottpr = 4 / ns_to_sec(13)
+        assert stat.min_output_token_throughput_per_request == pytest.approx(min_ottpr)
         assert stat.min_num_output_token == 4
 
         assert stat.max_time_to_first_token == 3
         assert stat.max_inter_token_latency == 5
-        max_rott = 5 / ns_to_sec(8)
-        assert stat.max_output_token_throughput_per_request == pytest.approx(max_rott)
+        max_ottpr = 5 / ns_to_sec(8)
+        assert stat.max_output_token_throughput_per_request == pytest.approx(max_ottpr)
         assert stat.max_num_output_token == 5
 
         assert stat.std_time_to_first_token == np.std([2, 3])
         assert stat.std_inter_token_latency == np.std([1, 5, 5, 2, 2])
-        rott1 = 4 / ns_to_sec(13)
-        rott2 = 5 / ns_to_sec(8)
+        ottpr1 = 4 / ns_to_sec(13)
+        ottpr2 = 5 / ns_to_sec(8)
         assert stat.std_output_token_throughput_per_request == pytest.approx(
-            np.std([rott1, rott2])
+            np.std([ottpr1, ottpr2])
         )
         assert stat.std_num_output_token == np.std([4, 5])
 
@@ -299,10 +299,10 @@ class TestLLMProfileDataParser:
         * time to first tokens
             - experiment 1: [3 - 1, 4 - 2] = [2, 2]
         * inter token latencies
-            - experiment 1: [(5 - 3)/1, (8 - 5)/1, (7 - 4)/1, (11 - 7)/2, (15 - 11)/2]
-                          : [2, 3, 3, 2, 2]
+            - experiment 1: [(5 - 3)/1, (8 - 5)/1, (12 - 8)/1, (7 - 4)/1, (11 - 7)/2, (15 - 11)/2]
+                          : [2, 3, 4, 3, 2, 2]
         * output token throughputs per request
-            - experiment 1: [3/(8 - 1), 5/(15 - 2)] = [3/7, 5/13]
+            - experiment 1: [3/(12 - 1), 5/(15 - 2)] = [3/11, 5/13]
         * output token throughputs
             - experiment 1: [(3 + 5)/(15 - 1)] = [4/7]
         * num output tokens
@@ -319,35 +319,35 @@ class TestLLMProfileDataParser:
         stat = pd.get_statistics(infer_mode="concurrency", load_level="10")
 
         assert stat.avg_time_to_first_token == 2
-        assert stat.avg_inter_token_latency == 2.4
-        avg_rott = 37 / ns_to_sec(91)
-        assert stat.avg_output_token_throughput_per_request == pytest.approx(avg_rott)
+        assert stat.avg_inter_token_latency == 8 / 3
+        avg_ottpr = 47 / ns_to_sec(143)
+        assert stat.avg_output_token_throughput_per_request == pytest.approx(avg_ottpr)
         assert stat.avg_num_output_token == 4
 
         assert stat.p50_time_to_first_token == 2
-        assert stat.p50_inter_token_latency == 2
-        p50_rott = 37 / ns_to_sec(91)
-        assert stat.p50_output_token_throughput_per_request == pytest.approx(p50_rott)
+        assert stat.p50_inter_token_latency == 2.5
+        p50_ottpr = 47 / ns_to_sec(143)
+        assert stat.p50_output_token_throughput_per_request == pytest.approx(p50_ottpr)
         assert stat.p50_num_output_token == 4
 
         assert stat.min_time_to_first_token == 2
         assert stat.min_inter_token_latency == 2
-        min_rott = 5 / ns_to_sec(13)
-        assert stat.min_output_token_throughput_per_request == pytest.approx(min_rott)
+        min_ottpr = 3 / ns_to_sec(11)
+        assert stat.min_output_token_throughput_per_request == pytest.approx(min_ottpr)
         assert stat.min_num_output_token == 3
 
         assert stat.max_time_to_first_token == 2
-        assert stat.max_inter_token_latency == 3
-        max_rott = 3 / ns_to_sec(7)
-        assert stat.max_output_token_throughput_per_request == pytest.approx(max_rott)
+        assert stat.max_inter_token_latency == 4
+        max_ottpr = 5 / ns_to_sec(13)
+        assert stat.max_output_token_throughput_per_request == pytest.approx(max_ottpr)
         assert stat.max_num_output_token == 5
 
         assert stat.std_time_to_first_token == np.std([2, 2])
-        assert stat.std_inter_token_latency == np.std([2, 3, 3, 2, 2])
-        rott1 = 3 / ns_to_sec(7)
-        rott2 = 5 / ns_to_sec(13)
+        assert stat.std_inter_token_latency == np.std([2, 3, 4, 3, 2, 2])
+        ottpr1 = 3 / ns_to_sec(11)
+        ottpr2 = 5 / ns_to_sec(13)
         assert stat.std_output_token_throughput_per_request == pytest.approx(
-            np.std([rott1, rott2])
+            np.std([ottpr1, ottpr2])
         )
         assert stat.std_num_output_token == np.std([3, 5])
 

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
@@ -128,8 +128,8 @@ class TestLLMProfileDataParser:
                     "requests": [
                         {
                             "timestamp": 1,
-                            # null final timestamp & output will be ignored
-                            "response_timestamps": [3, 5, 8, 12, 13],
+                            # last two empty/null responses will be ignored
+                            "response_timestamps": [3, 5, 8, 12, 13, 14],
                             "response_outputs": [
                                 {
                                     "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n'
@@ -143,13 +143,16 @@ class TestLLMProfileDataParser:
                                 {
                                     "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"content":"cool"},"finish_reason":null}]}\n\n'
                                 },
+                                {
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{},"finish_reason":null}]}\n\n'
+                                },
                                 {"response": "data: [DONE]\n\n"},
                             ],
                         },
                         {
                             "timestamp": 2,
-                            # null final timestamp & output will be ignored
-                            "response_timestamps": [4, 7, 11, 15, 18],
+                            # last two empty/null responses will be ignored
+                            "response_timestamps": [4, 7, 11, 15, 18, 19],
                             "response_outputs": [
                                 {
                                     "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n'
@@ -162,6 +165,9 @@ class TestLLMProfileDataParser:
                                 },
                                 {
                                     "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{"content":"cook food"},"finish_reason":null}]}\n\n'
+                                },
+                                {
+                                    "response": 'data: {"id":"abc","object":"chat.completion.chunk","created":123,"model":"llama-2-7b","choices":[{"index":0,"delta":{},"finish_reason":null}]}\n\n'
                                 },
                                 {"response": "data: [DONE]\n\n"},
                             ],


### PR DESCRIPTION
Removes last one or two responses of chat completion API that has either empty `delta` or null response:

Empty `delta`:
```
data: {"id":"chatcmpl-92iz6RYuQb8FcGT2QrpQ6vQyRfWUA","object":"chat.completion.chunk","created":1710436604,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_4f2ebda25a","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"length"}]}
```

Null response:
```
data: [DONE]
```