### PR TITLE
Reorganize CLI args in GenAi-Perf

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -26,9 +26,8 @@ from requests import Response
 
 
 class InputType(Enum):
-    URL = auto()
-    FILE = auto()
     SYNTHETIC = auto()
+    URL = auto()
 
 
 class OutputFormat(Enum):

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -58,7 +58,7 @@ def generate_inputs(args):
     LlmInputs.create_llm_inputs(
         input_type=args.input_type,
         output_format=args.output_format,
-        dataset_name=args.dataset,
+        dataset_name=args.input_dataset,
         model_name=args.model,
         input_filename=input_file_name,
         starting_index=LlmInputs.DEFAULT_STARTING_INDEX,

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -200,17 +200,6 @@ def _add_profile_args(parser):
         "the requests completed within that time interval.",
     )
 
-    profile_group.add_argument(
-        "--profile-export-file",
-        type=Path,
-        default="profile_export.json",
-        help="Specifies the path where the perf_analyzer profile export will be "
-        "generated. By default, the profile export will be to profile_export.json. "
-        "The genai-perf file will be exported to <profile_export_file>_genai_perf.csv. "
-        "For example, if the profile export file is profile_export.json, the genai-perf file will be "
-        "exported to profile_export_genai_perf.csv.",
-    )
-
     load_management_group.add_argument(
         "--request-rate",
         type=float,
@@ -229,21 +218,6 @@ def _add_profile_args(parser):
         "measurement is considered as stable if the ratio of max / min "
         "from the recent 3 measurements is within (stability percentage) "
         "in terms of both infer per second and latency.",
-    )
-
-    profile_group.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        required=False,
-        help="Enables verbose mode.",
-    )
-
-    profile_group.add_argument(
-        "--version",
-        action="version",
-        version="%(prog)s " + __version__,
-        help=f"Prints the version and exits.",
     )
 
 
@@ -311,7 +285,22 @@ def _add_endpoint_args(parser):
 def _add_output_args(parser):
     output_group = parser.add_argument_group("Output")
 
-    # dataset_group.add_argument(
+    output_group.add_argument(
+        "--profile-export-file",
+        type=Path,
+        default="profile_export.json",
+        help="Specifies the path where the perf_analyzer profile export will be "
+        "generated. By default, the profile export will be to profile_export.json. "
+        "The genai-perf file will be exported to <profile_export_file>_genai_perf.csv. "
+        "For example, if the profile export file is profile_export.json, the genai-perf file will be "
+        "exported to profile_export_genai_perf.csv.",
+    )
+
+
+def _add_other_args(parser):
+    output_group = parser.add_argument_group("Output")
+
+    # output_group.add_argument(
     #     "--tokenizer",
     #     type=str,
     #     default="auto",
@@ -319,6 +308,21 @@ def _add_output_args(parser):
     #     required=False,
     #     help="The HuggingFace tokenizer to use to interpret token metrics from final text results",
     # )
+
+    output_group.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        required=False,
+        help="Enables verbose mode.",
+    )
+
+    output_group.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s " + __version__,
+        help=f"Prints the version and exits.",
+    )
 
 
 ### Entrypoint ###
@@ -338,7 +342,8 @@ def parse_args():
     _add_endpoint_args(parser)
     _add_input_args(parser)
     _add_profile_args(parser)
-    outputtput_args(Output)
+    _add_output_args(parser)
+    _add_other_args(parser)
 
     # Check for passthrough args
     if "--" in argv:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -301,7 +301,7 @@ def _add_output_args(parser):
 
 
 def _add_other_args(parser):
-    output_group = parser.add_argument_group("Output")
+    output_group = parser.add_argument_group("Other")
 
     # output_group.add_argument(
     #     "--tokenizer",

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(LOGGER_NAME)
 
 def _check_conditional_args(
     parser: argparse.ArgumentParser, args: argparse.ArgumentParser
-) -> None:
+) -> argparse.ArgumentParser:
     """
     Check for conditional args and raise an error if they are not set.
     """
@@ -134,7 +134,7 @@ def _add_input_args(parser):
         default=OPEN_ORCA,
         choices=[OPEN_ORCA, CNN_DAILY_MAIL],
         required=False,
-        help="HuggingFace dataset to use for benchmarking.",
+        help="The HuggingFace dataset to use for benchmarking.",
     )
 
     input_group.add_argument(
@@ -175,7 +175,7 @@ def _add_input_args(parser):
         type=int,
         default=LlmInputs.DEFAULT_RANDOM_SEED,
         required=False,
-        help="Seed used to generate random values.",
+        help="The seed used to generate random values.",
     )
 
 
@@ -187,7 +187,7 @@ def _add_profile_args(parser):
         "--concurrency",
         type=int,
         required=False,
-        help="Sets the concurrency value to benchmark.",
+        help="The concurrency value to benchmark.",
     )
 
     profile_group.add_argument(
@@ -196,9 +196,9 @@ def _add_profile_args(parser):
         type=int,
         default="10000",
         required=False,
-        help="Indicates the time interval used "
+        help="The time interval used "
         "for each measurement in milliseconds. The perf analyzer will "
-        "sample a time interval specified by -p and take measurement over "
+        "sample a time interval specified and take measurement over "
         "the requests completed within that time interval.",
     )
 
@@ -210,12 +210,12 @@ def _add_profile_args(parser):
     )
 
     profile_group.add_argument(
-        "--stability-percentage",
         "-s",
+        "--stability-percentage",
         type=float,
         default=999,
         required=False,
-        help="Indicates the allowed variation in "
+        help="The allowed variation in "
         "latency measurements when determining if a result is stable. The "
         "measurement is considered as stable if the ratio of max / min "
         "from the recent 3 measurements is within (stability percentage) "
@@ -230,7 +230,6 @@ def _add_endpoint_args(parser):
         "-m",
         "--model",
         type=str,
-        default="NoModel",
         required=True,
         help=f"The name of the model to benchmark.",
     )
@@ -241,7 +240,8 @@ def _add_endpoint_args(parser):
         choices=utils.get_enum_names(OutputFormat)[2:],
         default="trtllm",
         required=False,
-        help=f"When using Triton, the backend of the model. ",
+        help=f'When using the "triton" service-kind, '
+        "this is the backend of the model. ",
     )
 
     endpoint_group.add_argument(
@@ -249,8 +249,8 @@ def _add_endpoint_args(parser):
         type=str,
         choices=["v1/chat/completions", "v1/completions"],
         required=False,
-        help="Describes what endpoint to send requests to on the "
-        'server. This is required when using "openai" service-kind. '
+        help="The endpoint to send requests to on the "
+        'server. This is required when using the "openai" service-kind. '
         "This is ignored in other cases.",
     )
 
@@ -260,17 +260,16 @@ def _add_endpoint_args(parser):
         choices=["triton", "openai"],
         default="triton",
         required=False,
-        help="Describes the kind of service perf_analyzer will "
-        'generate load for. The options are "triton" and '
-        '"openai". Note in order to use "openai", you must specify '
-        "an endpoint via --endpoint.",
+        help="The kind of service perf_analyzer will "
+        'generate load for. In order to use "openai", '
+        "you must specify an endpoint via --endpoint.",
     )
 
     endpoint_group.add_argument(
         "--streaming",
         action="store_true",
         required=False,
-        help=f"Enables the use of the streaming API.",
+        help=f"An option to enable the use of the streaming API.",
     )
 
     endpoint_group.add_argument(
@@ -291,7 +290,7 @@ def _add_output_args(parser):
         "--profile-export-file",
         type=Path,
         default="profile_export.json",
-        help="Specifies the path where the perf_analyzer profile export will be "
+        help="The path where the perf_analyzer profile export will be "
         "generated. By default, the profile export will be to profile_export.json. "
         "The genai-perf file will be exported to <profile_export_file>_genai_perf.csv. "
         "For example, if the profile export file is profile_export.json, the genai-perf file will be "
@@ -316,14 +315,14 @@ def _add_other_args(parser):
         "--verbose",
         action="store_true",
         required=False,
-        help="Enables verbose mode.",
+        help="An option to enable verbose mode.",
     )
 
     output_group.add_argument(
         "--version",
         action="version",
         version="%(prog)s " + __version__,
-        help=f"Prints the version and exits.",
+        help=f"An option to print the version and exit.",
     )
 
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -55,15 +55,18 @@ def _check_conditional_args(
                 "The --endpoint option is required when using the 'openai' service-kind."
             )
         if args.endpoint == "v1/chat/completions":
-            args.output_format = "openai_chat_completions"
+            args.output_format = OutputFormat.OPENAI_CHAT_COMPLETIONS
         elif args.endpoint == "v1/completions":
-            args.output_format = "openai_completions"
+            args.output_format = OutputFormat.OPENAI_COMPLETIONS
     elif args.endpoint is not None:
         logger.warning(
             "The --endpoint option is ignored when not using the 'openai' service-kind."
         )
     if args.service_kind == "triton":
+        args = _convert_str_to_enum_entry(args, "backend", OutputFormat)
         args.output_format = args.backend
+
+    return args
 
 
 def _prune_args(args: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -353,10 +356,9 @@ def parse_args():
         passthrough_index = len(argv)
 
     args = parser.parse_args(argv[1:passthrough_index])
-    _check_conditional_args(parser, args)
+    args = _check_conditional_args(parser, args)
     args = _update_load_manager_args(args)
     args = _convert_str_to_enum_entry(args, "input_type", InputType)
-    args = _convert_str_to_enum_entry(args, "backend", OutputFormat)
     args = _prune_args(args)
 
     return args, argv[passthrough_index + 1 :]

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -193,7 +193,6 @@ def _add_profile_args(parser):
     profile_group.add_argument(
         "--measurement-interval",
         "-p",
-        dest="p",
         type=int,
         default="10000",
         required=False,
@@ -211,8 +210,8 @@ def _add_profile_args(parser):
     )
 
     profile_group.add_argument(
-        "-s",
         "--stability-percentage",
+        "-s",
         type=float,
         default=999,
         required=False,
@@ -239,7 +238,7 @@ def _add_endpoint_args(parser):
     endpoint_group.add_argument(
         "--backend",
         type=str,
-        choices=utils.get_enum_names(OutputFormat)[1:],
+        choices=utils.get_enum_names(OutputFormat)[2:],
         default="trtllm",
         required=False,
         help=f"When using Triton, the backend of the model. ",
@@ -248,7 +247,7 @@ def _add_endpoint_args(parser):
     endpoint_group.add_argument(
         "--endpoint",
         type=str,
-        choices=["v1/completions", "v1/chat/completions"],
+        choices=["v1/chat/completions", "v1/completions"],
         required=False,
         help="Describes what endpoint to send requests to on the "
         'server. This is required when using "openai" service-kind. '

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -56,6 +56,7 @@ class Profiler:
             "input_type",
             "input_format",
             "model",
+            "backend",
             "output_format",
             # The 'streaming' passed in to this script is to determine if the
             # LLM response should be streaming. That is different than the

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -195,3 +195,24 @@ class TestCLIArguments:
         assert excinfo.value.code != 0
         captured = capsys.readouterr()
         assert expected_output in captured.err
+
+    @pytest.mark.parametrize(
+        "args, expected_format",
+        [
+            (
+                ["--service-kind", "openai", "--endpoint", "v1/chat/completions"],
+                OutputFormat.OPENAI_CHAT_COMPLETIONS,
+            ),
+            (
+                ["--service-kind", "openai", "--endpoint", "v1/completions"],
+                OutputFormat.OPENAI_COMPLETIONS,
+            ),
+            (["--service-kind", "triton", "--backend", "trtllm"], OutputFormat.TRTLLM),
+            (["--service-kind", "triton", "--backend", "vllm"], OutputFormat.VLLM),
+        ],
+    )
+    def test_inferred_output_format(self, monkeypatch, args, expected_format):
+        monkeypatch.setattr("sys.argv", ["genai-perf", "-m", "test_model"] + args)
+
+        parsed_args, _ = parser.parse_args()
+        assert parsed_args.output_format == expected_format

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -76,6 +76,7 @@ class TestCLIArguments:
                 {"endpoint": "v1/chat/completions"},
             ),
             (["--expected-output-tokens", "5"], {"expected_output_tokens": 5}),
+            (["--input-dataset", "openorca"], {"input_dataset": "openorca"}),
             (["--input-tokens-mean", "6"], {"input_tokens_mean": 6}),
             (["--input-tokens-stddev", "7"], {"input_tokens_stddev": 7}),
             (
@@ -86,8 +87,8 @@ class TestCLIArguments:
                 ["--input-type", "url"],
                 {"input_type": utils.get_enum_entry("url", InputType)},
             ),
-            (["--measurement-interval", "100"], {"p": 100}),
-            (["-p", "100"], {"p": 100}),
+            (["--measurement-interval", "100"], {"measurement_interval": 100}),
+            (["-p", "100"], {"measurement_interval": 100}),
             (["--num-of-output-prompts", "101"], {"num_of_output_prompts": 101}),
             (
                 ["--profile-export-file", "text.txt"],

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -79,10 +79,6 @@ class TestCLIArguments:
             (["--input-tokens-mean", "6"], {"input_tokens_mean": 6}),
             (["--input-tokens-stddev", "7"], {"input_tokens_stddev": 7}),
             (
-                ["--input-type", "file"],
-                {"input_type": utils.get_enum_entry("file", InputType)},
-            ),
-            (
                 ["--input-type", "synthetic"],
                 {"input_type": utils.get_enum_entry("synthetic", InputType)},
             ),
@@ -90,33 +86,9 @@ class TestCLIArguments:
                 ["--input-type", "url"],
                 {"input_type": utils.get_enum_entry("url", InputType)},
             ),
-            (["--measurement-interval", "100"], {"measurement_interval": 100}),
-            (["-p", "100"], {"measurement_interval": 100}),
+            (["--measurement-interval", "100"], {"p": 100}),
+            (["-p", "100"], {"p": 100}),
             (["--num-of-output-prompts", "101"], {"num_of_output_prompts": 101}),
-            (
-                ["--output-format", "openai_chat_completions"],
-                {
-                    "output_format": utils.get_enum_entry(
-                        "openai_chat_completions", OutputFormat
-                    )
-                },
-            ),
-            (
-                ["--output-format", "openai_completions"],
-                {
-                    "output_format": utils.get_enum_entry(
-                        "openai_completions", OutputFormat
-                    )
-                },
-            ),
-            (
-                ["--output-format", "trtllm"],
-                {"output_format": utils.get_enum_entry("trtllm", OutputFormat)},
-            ),
-            (
-                ["--output-format", "vllm"],
-                {"output_format": utils.get_enum_entry("vllm", OutputFormat)},
-            ),
             (
                 ["--profile-export-file", "text.txt"],
                 {"profile_export_file": Path("text.txt")},

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cmd_builder.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cmd_builder.py
@@ -65,7 +65,6 @@ class TestCmdBuilder:
         assert cmd_string.count(" -i grpc") == 1
         assert cmd_string.count(" --streaming") == 1
         assert cmd_string.count(f"-u {DEFAULT_GRPC_URL}") == 1
-        print(args.output_format)
         if arg[1] == "trtllm":
             assert cmd_string.count("--shape max_tokens:1") == 1
             assert cmd_string.count("--shape text_input:1") == 1

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -261,8 +261,8 @@ class TestLlmInputs:
             LlmInputs.DEFAULT_RANDOM_SEED,
         )
 
-        # 785 is the num of tokens returned for the default seed
-        assert synthetic_prompt_tokens == 785
+        # 550 is the num of tokens returned for the default seed
+        assert synthetic_prompt_tokens == 550
 
         synthetic_prompt, synthetic_prompt_tokens = LlmInputs._create_synthetic_prompt(
             LlmInputs.DEFAULT_PROMPT_TOKENS_MEAN,


### PR DESCRIPTION
Reorganize the CLI args to make the help menu easier to navigate.

Unit testing:
<img width="1313" alt="image" src="https://github.com/triton-inference-server/client/assets/58150256/3764573c-9fee-437e-860f-7d68cf86f0a4">

Updated help menu:
<img width="824" alt="image" src="https://github.com/triton-inference-server/client/assets/58150256/4abb41f5-731a-442a-b1b6-2e4bb95748a8">
