### PR TITLE
add tokenizer option

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -24,7 +24,7 @@ import requests
 from genai_perf.constants import CNN_DAILY_MAIL, DEFAULT_INPUT_DATA_JSON, OPEN_ORCA
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.llm_inputs.synthetic_prompt_generator import SyntheticPromptGenerator
-from genai_perf.tokenizer import AutoTokenizer
+from genai_perf.tokenizer import DEFAULT_TOKENIZER, AutoTokenizer
 from requests import Response
 
 
@@ -87,7 +87,7 @@ class LlmInputs:
         num_of_output_prompts: int = DEFAULT_NUM_OF_OUTPUT_PROMPTS,
         add_model_name: bool = False,
         add_stream: bool = False,
-        tokenizer: AutoTokenizer = None,
+        tokenizer: AutoTokenizer = DEFAULT_TOKENIZER,
     ) -> Dict:
         """
         Given an input type, input format, and output type. Output a string of LLM Inputs

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -24,13 +24,14 @@ import requests
 from genai_perf.constants import CNN_DAILY_MAIL, DEFAULT_INPUT_DATA_JSON, OPEN_ORCA
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.llm_inputs.synthetic_prompt_generator import SyntheticPromptGenerator
+from genai_perf.tokenizer import AutoTokenizer
 from requests import Response
 
-# Silence tokenizer warning on import
-with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
-    io.StringIO()
-) as stderr:
-    from transformers import LlamaTokenizerFast
+# # Silence tokenizer warning on import
+# with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
+#     io.StringIO()
+# ) as stderr:
+#     from transformers import LlamaTokenizerFast
 
 
 class InputType(Enum):
@@ -92,7 +93,7 @@ class LlmInputs:
         num_of_output_prompts: int = DEFAULT_NUM_OF_OUTPUT_PROMPTS,
         add_model_name: bool = False,
         add_stream: bool = False,
-        tokenizer: LlamaTokenizerFast = None,
+        tokenizer: AutoTokenizer = None,
     ) -> Dict:
         """
         Given an input type, input format, and output type. Output a string of LLM Inputs
@@ -184,7 +185,7 @@ class LlmInputs:
         dataset_name: str,
         starting_index: int,
         length: int,
-        tokenizer: LlamaTokenizerFast,
+        tokenizer: AutoTokenizer,
     ) -> None:
         try:
             LlmInputs._check_for_dataset_name_if_input_type_is_url(
@@ -212,7 +213,7 @@ class LlmInputs:
     @classmethod
     def _get_input_dataset_from_synthetic(
         cls,
-        tokenizer: LlamaTokenizerFast,
+        tokenizer: AutoTokenizer,
         prompt_tokens_mean: int,
         prompt_tokens_stddev: int,
         expected_output_tokens: int,
@@ -805,7 +806,7 @@ class LlmInputs:
 
     @classmethod
     def _check_for_tokenzier_if_input_type_is_synthetic(
-        cls, input_type: InputType, tokenizer: LlamaTokenizerFast
+        cls, input_type: InputType, tokenizer: AutoTokenizer
     ) -> None:
         if input_type == InputType.SYNTHETIC and not tokenizer:
             raise GenAIPerfException(
@@ -861,7 +862,7 @@ class LlmInputs:
     @classmethod
     def _create_synthetic_prompt(
         cls,
-        tokenizer: LlamaTokenizerFast,
+        tokenizer: AutoTokenizer,
         prompt_tokens_mean: int,
         prompt_tokens_stddev: int,
         expected_output_tokens: int,

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -27,12 +27,6 @@ from genai_perf.llm_inputs.synthetic_prompt_generator import SyntheticPromptGene
 from genai_perf.tokenizer import AutoTokenizer
 from requests import Response
 
-# # Silence tokenizer warning on import
-# with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
-#     io.StringIO()
-# ) as stderr:
-#     from transformers import LlamaTokenizerFast
-
 
 class InputType(Enum):
     SYNTHETIC = auto()

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_prompt_generator.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_prompt_generator.py
@@ -19,23 +19,25 @@ import pathlib
 import random
 from typing import List, Tuple
 
-# Silence tokenizer warning on import
-with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
-    io.StringIO()
-) as stderr:
-    # TODO (TMA-1718): This should be passed in (and should not be in bare code)
-    from transformers import LlamaTokenizerFast
+from genai_perf.tokenizer import AutoTokenizer
 
-    tokenizer = LlamaTokenizerFast.from_pretrained(
-        "hf-internal-testing/llama-tokenizer"
-    )
+# # Silence tokenizer warning on import
+# with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
+#     io.StringIO()
+# ) as stderr:
+#     # TODO (TMA-1718): This should be passed in (and should not be in bare code)
+#     from transformers import LlamaTokenizerFast
+
+#     tokenizer = LlamaTokenizerFast.from_pretrained(
+#         "hf-internal-testing/llama-tokenizer"
+#     )
 
 
 class SyntheticPromptGenerator:
     @classmethod
     def create_synthetic_prompt(
         cls,
-        tokenizer: LlamaTokenizerFast,
+        tokenizer: AutoTokenizer,
         prompt_tokens_mean: int = 550,
         prompt_tokens_stddev: int = 250,
         expected_output_tokens: int = 150,
@@ -80,9 +82,7 @@ class SyntheticPromptGenerator:
         return (prompt, num_prompt_tokens)
 
     @classmethod
-    def _get_prompt_token_length(
-        cls, prompt: str, tokenizer: LlamaTokenizerFast
-    ) -> int:
+    def _get_prompt_token_length(cls, prompt: str, tokenizer: AutoTokenizer) -> int:
         get_token_length = lambda text: len(tokenizer.encode(text))
 
         prompt_token_length = get_token_length(prompt)
@@ -119,7 +119,7 @@ class SyntheticPromptGenerator:
         prompt: str,
         remaining_prompt_tokens: int,
         farewell_lines: List[str],
-        tokenizer: LlamaTokenizerFast,
+        tokenizer: AutoTokenizer,
     ) -> str:
         get_token_length = lambda text: len(tokenizer.encode(text))
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_prompt_generator.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_prompt_generator.py
@@ -21,17 +21,6 @@ from typing import List, Tuple
 
 from genai_perf.tokenizer import AutoTokenizer
 
-# # Silence tokenizer warning on import
-# with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
-#     io.StringIO()
-# ) as stderr:
-#     # TODO (TMA-1718): This should be passed in (and should not be in bare code)
-#     from transformers import LlamaTokenizerFast
-
-#     tokenizer = LlamaTokenizerFast.from_pretrained(
-#         "hf-internal-testing/llama-tokenizer"
-#     )
-
 
 class SyntheticPromptGenerator:
     @classmethod

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -38,12 +38,6 @@ from genai_perf.utils import load_json, remove_sse_prefix
 from rich.console import Console
 from rich.table import Table
 
-# # Silence tokenizer warning on import
-# with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
-#     io.StringIO()
-# ) as stderr:
-#     from transformers import AutoTokenizer
-
 
 class Metrics:
     """A base class for all the metrics class that contains common metrics."""

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -33,15 +33,16 @@ import json
 from itertools import pairwise
 
 import numpy as np
+from genai_perf.tokenizer import AutoTokenizer
 from genai_perf.utils import load_json, remove_sse_prefix
 from rich.console import Console
 from rich.table import Table
 
-# Silence tokenizer warning on import
-with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
-    io.StringIO()
-) as stderr:
-    from transformers import AutoTokenizer
+# # Silence tokenizer warning on import
+# with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
+#     io.StringIO()
+# ) as stderr:
+#     from transformers import AutoTokenizer
 
 
 class Metrics:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -94,7 +94,9 @@ def run():
         tokenizer = t.get_tokenizer(args.tokenizer)
         generate_inputs(args, tokenizer)
         args.func(args, extra_args)
-        metrics = calculate_metrics(args.profile_export_file, args.service_kind)
+        metrics = calculate_metrics(
+            args.profile_export_file, args.service_kind, tokenizer
+        )
         report_output(metrics, args)
     except Exception as e:
         raise GenAIPerfException(e)

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -37,16 +37,6 @@ from genai_perf.exceptions import GenAIPerfException
 from genai_perf.llm_inputs.llm_inputs import LlmInputs
 from genai_perf.llm_metrics import LLMProfileDataParser
 
-# # Silence tokenizer warning on import
-# with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
-#     io.StringIO()
-# ) as stderr:
-#     from transformers import AutoTokenizer as tokenizer
-#     from transformers import logging as token_logger
-
-#     token_logger.set_verbosity_error()
-
-
 logging.basicConfig(level=logging.INFO, format="%(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(LOGGER_NAME)
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -25,23 +25,22 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import contextlib
-import io
 import logging
 import sys
+from argparse import ArgumentParser
 
 from genai_perf import parser
-from genai_perf import tokenizer as t
 from genai_perf.constants import LOGGER_NAME
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.llm_inputs.llm_inputs import LlmInputs
 from genai_perf.llm_metrics import LLMProfileDataParser
+from genai_perf.tokenizer import AutoTokenizer, get_tokenizer
 
 logging.basicConfig(level=logging.INFO, format="%(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(LOGGER_NAME)
 
 
-def generate_inputs(args, tokenizer):
+def generate_inputs(args: ArgumentParser, tokenizer: AutoTokenizer) -> None:
     # TODO (TMA-1758): remove once file support is implemented
     input_file_name = ""
     # TODO (TMA-1759): review if add_model_name is always true
@@ -66,7 +65,7 @@ def generate_inputs(args, tokenizer):
 
 
 def calculate_metrics(
-    file: str, service_kind: str, tokenizer: t.AutoTokenizer
+    file: str, service_kind: str, tokenizer: AutoTokenizer
 ) -> LLMProfileDataParser:
     return LLMProfileDataParser(file, service_kind, tokenizer)
 
@@ -91,7 +90,7 @@ def report_output(metrics: LLMProfileDataParser, args):
 def run():
     try:
         args, extra_args = parser.parse_args()
-        tokenizer = t.get_tokenizer(args.tokenizer)
+        tokenizer = get_tokenizer(args.tokenizer)
         generate_inputs(args, tokenizer)
         args.func(args, extra_args)
         metrics = calculate_metrics(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -30,12 +30,7 @@ import sys
 from pathlib import Path
 
 import genai_perf.utils as utils
-from genai_perf.constants import (
-    CNN_DAILY_MAIL,
-    DEFAULT_INPUT_DATA_JSON,
-    LOGGER_NAME,
-    OPEN_ORCA,
-)
+from genai_perf.constants import CNN_DAILY_MAIL, LOGGER_NAME, OPEN_ORCA
 from genai_perf.llm_inputs.llm_inputs import InputType, LlmInputs, OutputFormat
 from genai_perf.tokenizer import DEFAULT_TOKENIZER
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -37,6 +37,7 @@ from genai_perf.constants import (
     OPEN_ORCA,
 )
 from genai_perf.llm_inputs.llm_inputs import InputType, LlmInputs, OutputFormat
+from genai_perf.tokenizer import DEFAULT_TOKENIZER
 
 from . import __version__
 
@@ -301,14 +302,13 @@ def _add_output_args(parser):
 def _add_other_args(parser):
     output_group = parser.add_argument_group("Other")
 
-    # output_group.add_argument(
-    #     "--tokenizer",
-    #     type=str,
-    #     default="auto",
-    #     choices=["auto"],
-    #     required=False,
-    #     help="The HuggingFace tokenizer to use to interpret token metrics from final text results",
-    # )
+    output_group.add_argument(
+        "--tokenizer",
+        type=str,
+        default=DEFAULT_TOKENIZER,
+        required=False,
+        help="The HuggingFace tokenizer to use to interpret token metrics from prompts and responses",
+    )
 
     output_group.add_argument(
         "-v",

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/tokenizer.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/tokenizer.py
@@ -36,9 +36,6 @@ def get_tokenizer(tokenizer_model: str) -> AutoTokenizer:
     """
     try:
         tokenizer = AutoTokenizer.from_pretrained(tokenizer_model)
-        # if tokenizer_model is not None:
-        # else:
-        #     tokenizer = AutoTokenizer.from_pretrained(DEFAULT_TOKENIZER)
     except Exception as e:
         raise GenAIPerfException(e)
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/tokenizer.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/tokenizer.py
@@ -1,0 +1,45 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import io
+
+from genai_perf.exceptions import GenAIPerfException
+
+# Silence tokenizer warning on import
+with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
+    io.StringIO()
+) as stderr:
+    from transformers import AutoTokenizer
+    from transformers import logging as token_logger
+
+    token_logger.set_verbosity_error()
+
+
+DEFAULT_TOKENIZER = "hf-internal-testing/llama-tokenizer"
+
+
+def get_tokenizer(tokenizer_model: str) -> AutoTokenizer:
+    """
+    Download the tokenizer from Huggingface.co
+    """
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_model)
+        # if tokenizer_model is not None:
+        # else:
+        #     tokenizer = AutoTokenizer.from_pretrained(DEFAULT_TOKENIZER)
+    except Exception as e:
+        raise GenAIPerfException(e)
+
+    return tokenizer

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -68,6 +68,7 @@ class Profiler:
             "expected_output_tokens",
             "num_of_output_prompts",
             "random_seed",
+            "tokenizer",
         ]
 
         utils.remove_file(args.profile_export_file)

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -16,7 +16,6 @@ import contextlib
 import io
 import json
 import os
-import token
 
 import pytest
 from genai_perf import tokenizer

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -24,12 +24,6 @@ from genai_perf.constants import CNN_DAILY_MAIL, DEFAULT_INPUT_DATA_JSON, OPEN_O
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.llm_inputs.llm_inputs import InputType, LlmInputs, OutputFormat
 
-# # Silence tokenizer warning on import
-# with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
-#     io.StringIO()
-# ) as stderr:
-#     from transformers import LlamaTokenizerFast
-
 
 class TestLlmInputs:
     @pytest.fixture

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -38,7 +38,6 @@ class TestLlmInputs:
     # TODO (TMA-1754): Add tests that verify json schemas
     @pytest.fixture
     def default_tokenizer(self):
-        # yield LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
         yield tokenizer.get_tokenizer(tokenizer.DEFAULT_TOKENIZER)
 
     def test_input_type_url_no_dataset_name(self):

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -16,17 +16,19 @@ import contextlib
 import io
 import json
 import os
+import token
 
 import pytest
+from genai_perf import tokenizer
 from genai_perf.constants import CNN_DAILY_MAIL, DEFAULT_INPUT_DATA_JSON, OPEN_ORCA
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.llm_inputs.llm_inputs import InputType, LlmInputs, OutputFormat
 
-# Silence tokenizer warning on import
-with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
-    io.StringIO()
-) as stderr:
-    from transformers import LlamaTokenizerFast
+# # Silence tokenizer warning on import
+# with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
+#     io.StringIO()
+# ) as stderr:
+#     from transformers import LlamaTokenizerFast
 
 
 class TestLlmInputs:
@@ -43,7 +45,8 @@ class TestLlmInputs:
     # TODO (TMA-1754): Add tests that verify json schemas
     @pytest.fixture
     def default_tokenizer(self):
-        yield LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
+        # yield LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
+        yield tokenizer.get_tokenizer(tokenizer.DEFAULT_TOKENIZER)
 
     def test_input_type_url_no_dataset_name(self):
         """

--- a/src/c++/perf_analyzer/genai-perf/tests/test_tokenizer.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_tokenizer.py
@@ -1,0 +1,43 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import genai_perf.tokenizer as t
+import pytest
+from genai_perf.exceptions import GenAIPerfException
+
+
+class TestTokenizer:
+    def test_default_tokenizer(self):
+        tokenizer_model = t.DEFAULT_TOKENIZER
+        t.get_tokenizer(tokenizer_model)
+
+    def test_non_default_tokenizer(self):
+        tokenizer_model = "gpt2"
+        t.get_tokenizer(tokenizer_model)
+
+    def test_bad_tokenizer(self):
+        with pytest.raises(GenAIPerfException):
+            t.get_tokenizer("bad_tokenizer")

--- a/src/c++/perf_analyzer/genai-perf/tests/test_tokenizer.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_tokenizer.py
@@ -24,20 +24,20 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import genai_perf.tokenizer as t
 import pytest
 from genai_perf.exceptions import GenAIPerfException
+from genai_perf.tokenizer import DEFAULT_TOKENIZER, get_tokenizer
 
 
 class TestTokenizer:
     def test_default_tokenizer(self):
-        tokenizer_model = t.DEFAULT_TOKENIZER
-        t.get_tokenizer(tokenizer_model)
+        tokenizer_model = DEFAULT_TOKENIZER
+        get_tokenizer(tokenizer_model)
 
     def test_non_default_tokenizer(self):
         tokenizer_model = "gpt2"
-        t.get_tokenizer(tokenizer_model)
+        get_tokenizer(tokenizer_model)
 
     def test_bad_tokenizer(self):
         with pytest.raises(GenAIPerfException):
-            t.get_tokenizer("bad_tokenizer")
+            get_tokenizer("bad_tokenizer")


### PR DESCRIPTION
User can add --tokenizer to the command line and the string is used to pull down a tokenizer from huggingface's autotokenizer module.

On success, the tokenizer is passed around as an object.
On failure, an error message is raised showing that the model is not available.

Default is set to llama via
 `DEFAULT_TOKENIZER = "hf-internal-testing/llama-tokenizer"`

Testing ensures that the default and a second valid non default tokenizer work, while an incorrect model name, raises an error.