### PR TITLE
If verbose flag is not passed to GenAi-Perf, do not print PA output

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -102,4 +102,7 @@ class Profiler:
     def run(args=None, extra_args=None):
         cmd = Profiler.build_cmd(args, extra_args)
         logger.info(f"Running Perf Analyzer : '{cmd}'")
-        subprocess.run(cmd, shell=True, check=True)
+        if args.verbose:
+            subprocess.run(cmd, shell=True, check=True)
+        else:
+            subprocess.run(cmd, shell=True, check=True, stdout=subprocess.DEVNULL)

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -103,6 +103,6 @@ class Profiler:
         cmd = Profiler.build_cmd(args, extra_args)
         logger.info(f"Running Perf Analyzer : '{cmd}'")
         if args.verbose:
-            subprocess.run(cmd, shell=True, check=True)
+            subprocess.run(cmd, shell=True, check=True, stdout=None)
         else:
             subprocess.run(cmd, shell=True, check=True, stdout=subprocess.DEVNULL)

--- a/src/c++/perf_analyzer/genai-perf/tests/test_wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_wrapper.py
@@ -25,7 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import subprocess
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from genai_perf import parser


### PR DESCRIPTION
This pull request makes it so that GenAi-perf no longer prints perf_analyzer output if the verbose flag is not passed.

Verbose flag not supplied:
<img width="1320" alt="image" src="https://github.com/triton-inference-server/client/assets/58150256/36f26d60-2c9b-4ba0-936c-3a060304a840">

Verbose flag supplied (`-v`):
<img width="1486" alt="image" src="https://github.com/triton-inference-server/client/assets/58150256/a4a088f6-43d5-49d4-a7d0-be97360fbdf0">

Verbose flag supplied (`--verbose`):
<img width="1485" alt="image" src="https://github.com/triton-inference-server/client/assets/58150256/522a0ca1-1c3a-4cc3-bd62-f19575742e4c">
