### PR TITLE
Add request input to profile export data

### DIFF
--- a/src/c++/library/common.cc
+++ b/src/c++/library/common.cc
@@ -185,7 +185,7 @@ InferInput::AppendFromString(const std::vector<std::string>& input)
 Error
 InferInput::RawData(const uint8_t** buf, size_t* byte_size)
 {
-  // TODO - handle multi-batch case
+  // TMA-1775 - handle multi-batch case
   *buf = bufs_[0];
   *byte_size = buf_byte_sizes_[0];
   return Error::Success;

--- a/src/c++/library/common.cc
+++ b/src/c++/library/common.cc
@@ -183,6 +183,15 @@ InferInput::AppendFromString(const std::vector<std::string>& input)
 }
 
 Error
+InferInput::RawData(const uint8_t** buf, size_t* byte_size)
+{
+  // TODO - handle multi-batch case
+  *buf = bufs_[0];
+  *byte_size = buf_byte_sizes_[0];
+  return Error::Success;
+}
+
+Error
 InferInput::ByteSize(size_t* byte_size) const
 {
   *byte_size = byte_size_;

--- a/src/c++/library/common.cc
+++ b/src/c++/library/common.cc
@@ -185,9 +185,14 @@ InferInput::AppendFromString(const std::vector<std::string>& input)
 Error
 InferInput::RawData(const uint8_t** buf, size_t* byte_size)
 {
-  // TMA-1775 - handle multi-batch case
-  *buf = bufs_[0];
-  *byte_size = buf_byte_sizes_[0];
+  if (bufs_.size()) {
+    // TMA-1775 - handle multi-batch case
+    *buf = bufs_[0];
+    *byte_size = buf_byte_sizes_[0];
+  } else {
+    *buf = nullptr;
+    *byte_size = 0;
+  }
   return Error::Success;
 }
 

--- a/src/c++/library/common.h
+++ b/src/c++/library/common.h
@@ -334,6 +334,15 @@ class InferInput {
   /// \return Error object indicating success or failure.
   Error AppendFromString(const std::vector<std::string>& input);
 
+  /// Get access to the buffer holding raw input. Note the buffer is owned by
+  /// InferInput instance. Users can copy out the data if required to extend
+  /// the lifetime.
+  /// \param buf Returns the pointer to the start of the buffer.
+  /// \param byte_size Returns the size of buffer in bytes.
+  /// \return Error object indicating success or failure of the
+  /// request.
+  Error RawData(const uint8_t** buf, size_t* byte_size);
+
   /// Gets the size of data added into this input in bytes.
   /// \param byte_size The size of data added in bytes.
   /// \return Error object indicating success or failure.

--- a/src/c++/perf_analyzer/client_backend/client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/client_backend.cc
@@ -505,6 +505,14 @@ InferInput::SetSharedMemory(
       pa::GENERIC_ERROR);
 }
 
+Error
+InferInput::RawData(const uint8_t** buf, size_t* byte_size)
+{
+  return Error(
+      "client backend of kind " + BackendKindToString(kind_) +
+          " does not support RawData() for InferInput",
+      pa::GENERIC_ERROR);
+}
 
 InferInput::InferInput(
     const BackendKind kind, const std::string& name,

--- a/src/c++/perf_analyzer/client_backend/client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/client_backend.h
@@ -558,6 +558,15 @@ class InferInput {
   virtual Error SetSharedMemory(
       const std::string& name, size_t byte_size, size_t offset = 0);
 
+  /// Get access to the buffer holding raw input. Note the buffer is owned by
+  /// InferInput instance. Users can copy out the data if required to extend
+  /// the lifetime.
+  /// \param buf Returns the pointer to the start of the buffer.
+  /// \param byte_size Returns the size of buffer in bytes.
+  /// \return Error object indicating success or failure of the
+  /// request.
+  virtual Error RawData(const uint8_t** buf, size_t* byte_size);
+
  protected:
   InferInput(
       const BackendKind kind, const std::string& name,

--- a/src/c++/perf_analyzer/client_backend/openai/openai_infer_input.cc
+++ b/src/c++/perf_analyzer/client_backend/openai/openai_infer_input.cc
@@ -74,7 +74,7 @@ OpenAiInferInput::AppendRaw(const uint8_t* input, size_t input_byte_size)
 Error
 OpenAiInferInput::RawData(const uint8_t** buf, size_t* byte_size)
 {
-  // TODO - handle multi-batch case
+  // TMA-1775 - handle multi-batch case
   *buf = bufs_[0];
   *byte_size = buf_byte_sizes_[0];
   return Error::Success;

--- a/src/c++/perf_analyzer/client_backend/openai/openai_infer_input.cc
+++ b/src/c++/perf_analyzer/client_backend/openai/openai_infer_input.cc
@@ -72,6 +72,15 @@ OpenAiInferInput::AppendRaw(const uint8_t* input, size_t input_byte_size)
 }
 
 Error
+OpenAiInferInput::RawData(const uint8_t** buf, size_t* byte_size)
+{
+  // TODO - handle multi-batch case
+  *buf = bufs_[0];
+  *byte_size = buf_byte_sizes_[0];
+  return Error::Success;
+}
+
+Error
 OpenAiInferInput::PrepareForRequest()
 {
   // Reset position so request sends entire input.

--- a/src/c++/perf_analyzer/client_backend/openai/openai_infer_input.h
+++ b/src/c++/perf_analyzer/client_backend/openai/openai_infer_input.h
@@ -51,6 +51,8 @@ class OpenAiInferInput : public InferInput {
   Error Reset() override;
   /// See InferInput::AppendRaw()
   Error AppendRaw(const uint8_t* input, size_t input_byte_size) override;
+  /// See InferInput::RawData()
+  Error RawData(const uint8_t** buf, size_t* byte_size) override;
   /// Prepare the input to be in the form expected by an OpenAI client,
   /// must call before accessing the data.
   Error PrepareForRequest();

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.cc
@@ -756,6 +756,13 @@ TritonInferInput::SetSharedMemory(
   return Error::Success;
 }
 
+Error
+TritonInferInput::RawData(const uint8_t** buf, size_t* byte_size)
+{
+  RETURN_IF_TRITON_ERROR(input_->RawData(buf, byte_size));
+  return Error::Success;
+}
+
 TritonInferInput::TritonInferInput(
     const std::string& name, const std::string& datatype)
     : InferInput(BackendKind::TRITON, name, datatype)

--- a/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -283,6 +283,8 @@ class TritonInferInput : public InferInput {
   /// See InferInput::SetSharedMemory()
   Error SetSharedMemory(
       const std::string& name, size_t byte_size, size_t offset = 0) override;
+  /// See InferInput::RawData()
+  Error RawData(const uint8_t** buf, size_t* byte_size) override;
 
  private:
   explicit TritonInferInput(

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -195,6 +195,14 @@ InferContext::GetInputs()
     size_t byte_size{0};
     std::string data_type{request_input->Datatype()};
     request_input->RawData(&buf, &byte_size);
+
+    // The first 4 bytes of BYTES data is a 32-bit integer to indicate the size
+    // of the rest of the data (which we already know based on byte_size). It
+    // should be ignored here, as it isn't part of the actual request
+    if (data_type == "BYTES") {
+      buf += 4;
+      byte_size -= 4;
+    }
     input.emplace(request_input->Name(), RecordData(buf, byte_size, data_type));
   }
   return input;

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -114,8 +114,7 @@ InferContext::SendRequest(
   thread_stat_->num_sent_requests_++;
 
   // Parse the request inputs to save in the profile export file
-  RequestRecord::RequestInput request_inputs{};
-  request_inputs = GetInputs(infer_data_);
+  RequestRecord::RequestInput request_inputs{GetInputs()};
 
   if (async_) {
     uint64_t unique_request_id{(thread_id_ << 48) | ((request_id << 16) >> 16)};
@@ -188,7 +187,7 @@ InferContext::SendRequest(
 }
 
 const RequestRecord::RequestInput
-InferContext::GetInputs(const InferData& infer_data)
+InferContext::GetInputs()
 {
   RequestRecord::RequestInput input{};
   for (const auto& request_input : infer_data_.valid_inputs_) {

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -199,7 +199,7 @@ InferContext::GetInputs()
     // The first 4 bytes of BYTES data is a 32-bit integer to indicate the size
     // of the rest of the data (which we already know based on byte_size). It
     // should be ignored here, as it isn't part of the actual request
-    if (data_type == "BYTES") {
+    if (data_type == "BYTES" && byte_size >= 4) {
       buf += 4;
       byte_size -= 4;
     }

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -194,8 +194,9 @@ InferContext::GetInputs(const InferData& infer_data)
   for (const auto& request_input : infer_data_.valid_inputs_) {
     const uint8_t* buf{nullptr};
     size_t byte_size{0};
-    // TODO: read input data
-    input.emplace(request_input->Name(), "Hello World!");
+    std::string data_type{request_input->Datatype()};
+    request_input->RawData(&buf, &byte_size);
+    input.emplace(request_input->Name(), RecordData(buf, byte_size, data_type));
   }
   return input;
 }

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -186,7 +186,7 @@ class InferContext {
 
  private:
   // Get all the request inputs that are being sent to the server.
-  const RequestRecord::RequestInput GetInputs(const InferData& infer_data);
+  const RequestRecord::RequestInput GetInputs();
 
   const RequestRecord::ResponseOutput GetOutputs(
       const cb::InferResult& infer_result);

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -185,7 +185,10 @@ class InferContext {
   std::function<void(uint32_t)> async_callback_finalize_func_ = nullptr;
 
  private:
-  const RequestRecord::ResponseOutput GetOutput(
+  // Get all the request inputs that are being sent to the server.
+  const RequestRecord::RequestInput GetInputs(const InferData& infer_data);
+
+  const RequestRecord::ResponseOutput GetOutputs(
       const cb::InferResult& infer_result);
 
   const uint32_t id_{0};

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -185,7 +185,6 @@ class InferContext {
   std::function<void(uint32_t)> async_callback_finalize_func_ = nullptr;
 
  private:
-  // Get all the request inputs that are being sent to the server.
   const RequestRecord::RequestInput GetInputs();
 
   const RequestRecord::ResponseOutput GetOutputs(

--- a/src/c++/perf_analyzer/profile_data_exporter.cc
+++ b/src/c++/perf_analyzer/profile_data_exporter.cc
@@ -169,6 +169,7 @@ ProfileDataExporter::AddRequestInputs(
       const auto& data_type{input.second.data_type_};
       rapidjson::Value name_json(name.c_str(), document_.GetAllocator());
       rapidjson::Value input_json{};
+      // TMA-1777: support other data types
       if (buf != nullptr) {
         if (data_type == "BYTES" || data_type == "JSON") {
           input_json.SetString(
@@ -180,6 +181,10 @@ ProfileDataExporter::AddRequestInputs(
         } else if (data_type == "BOOL") {
           bool is_true = (*buf > 0);
           input_json.SetBool(is_true);
+        } else {
+          std::cerr << "WARNING: data type '" + data_type +
+                           "' is not supported with JSON."
+                    << std::endl;
         }
       } else {
         input_json.SetString("", 0, document_.GetAllocator());
@@ -203,6 +208,7 @@ ProfileDataExporter::AddResponseOutputs(
       const auto& byte_size{output.second.size_};
       rapidjson::Value name_json(name.c_str(), document_.GetAllocator());
       rapidjson::Value output_json{};
+      // TMA-1777: support other data types
       if (buf != nullptr) {
         output_json.SetString(
             reinterpret_cast<const char*>(buf), byte_size,

--- a/src/c++/perf_analyzer/profile_data_exporter.cc
+++ b/src/c++/perf_analyzer/profile_data_exporter.cc
@@ -156,7 +156,6 @@ ProfileDataExporter::AddResponseTimestamps(
   }
 }
 
-// TODO: refactor
 void
 ProfileDataExporter::AddRequestInputs(
     rapidjson::Value& request_inputs_json,

--- a/src/c++/perf_analyzer/profile_data_exporter.cc
+++ b/src/c++/perf_analyzer/profile_data_exporter.cc
@@ -170,17 +170,18 @@ ProfileDataExporter::AddRequestInputs(
       const auto& data_type{input.second.data_type_};
       rapidjson::Value name_json(name.c_str(), document_.GetAllocator());
       rapidjson::Value input_json{};
-      std::cout << "DTYPE: " << data_type << std::endl;
       if (buf != nullptr) {
         if (data_type == "BYTES" || data_type == "JSON") {
           input_json.SetString(
               reinterpret_cast<const char*>(buf), byte_size,
               document_.GetAllocator());
+        } else if (data_type == "INT32") {
+          auto* val = reinterpret_cast<int32_t*>(buf);
+          input_json.SetInt(*val);
         } else if (data_type == "BOOL") {
           bool is_true = (*buf > 0);
           input_json.SetBool(is_true);
         }
-        // TODO
       } else {
         input_json.SetString("", 0, document_.GetAllocator());
       }

--- a/src/c++/perf_analyzer/profile_data_exporter.cc
+++ b/src/c++/perf_analyzer/profile_data_exporter.cc
@@ -122,6 +122,11 @@ ProfileDataExporter::AddRequests(
       request.AddMember("sequence_id", sequence_id, document_.GetAllocator());
     }
 
+    rapidjson::Value request_inputs(rapidjson::kObjectType);
+    AddRequestInputs(request_inputs, raw_request.request_inputs_);
+    request.AddMember(
+        "request_inputs", request_inputs, document_.GetAllocator());
+
     rapidjson::Value response_timestamps(rapidjson::kArrayType);
     AddResponseTimestamps(
         response_timestamps, raw_request.response_timestamps_);
@@ -148,6 +153,35 @@ ProfileDataExporter::AddResponseTimestamps(
     rapidjson::Value timestamp_json;
     timestamp_json.SetUint64(timestamp.time_since_epoch().count());
     timestamps_json.PushBack(timestamp_json, document_.GetAllocator());
+  }
+}
+
+// TODO: refactor
+void
+ProfileDataExporter::AddRequestInputs(
+    rapidjson::Value& request_inputs_json,
+    const std::vector<RequestRecord::RequestInput>& request_inputs)
+{
+  for (const auto& request_input : request_inputs) {
+    for (const auto& input : request_input) {
+      const std::string& name{input.first};
+      const auto& content{input.second};
+      // TODO: uncomment
+      // const auto& buf{input.second.data_.get()};
+      // const auto& byte_size{input.second.size_};
+      rapidjson::Value name_json(name.c_str(), document_.GetAllocator());
+      rapidjson::Value input_json{};
+      input_json.SetString(content.c_str(), document_.GetAllocator());
+      // if (buf != nullptr) {
+      //   output_json.SetString(
+      //       reinterpret_cast<const char*>(buf), byte_size,
+      //       document_.GetAllocator());
+      // } else {
+      //   output_json.SetString("", 0, document_.GetAllocator());
+      // }
+      request_inputs_json.AddMember(
+          name_json, input_json, document_.GetAllocator());
+    }
   }
 }
 

--- a/src/c++/perf_analyzer/profile_data_exporter.cc
+++ b/src/c++/perf_analyzer/profile_data_exporter.cc
@@ -164,21 +164,26 @@ ProfileDataExporter::AddRequestInputs(
 {
   for (const auto& request_input : request_inputs) {
     for (const auto& input : request_input) {
-      const std::string& name{input.first};
-      const auto& content{input.second};
-      // TODO: uncomment
-      // const auto& buf{input.second.data_.get()};
-      // const auto& byte_size{input.second.size_};
+      const auto& name{input.first};
+      const auto& buf{input.second.data_.get()};
+      const auto& byte_size{input.second.size_};
+      const auto& data_type{input.second.data_type_};
       rapidjson::Value name_json(name.c_str(), document_.GetAllocator());
       rapidjson::Value input_json{};
-      input_json.SetString(content.c_str(), document_.GetAllocator());
-      // if (buf != nullptr) {
-      //   output_json.SetString(
-      //       reinterpret_cast<const char*>(buf), byte_size,
-      //       document_.GetAllocator());
-      // } else {
-      //   output_json.SetString("", 0, document_.GetAllocator());
-      // }
+      std::cout << "DTYPE: " << data_type << std::endl;
+      if (buf != nullptr) {
+        if (data_type == "BYTES" || data_type == "JSON") {
+          input_json.SetString(
+              reinterpret_cast<const char*>(buf), byte_size,
+              document_.GetAllocator());
+        } else if (data_type == "BOOL") {
+          bool is_true = (*buf > 0);
+          input_json.SetBool(is_true);
+        }
+        // TODO
+      } else {
+        input_json.SetString("", 0, document_.GetAllocator());
+      }
       request_inputs_json.AddMember(
           name_json, input_json, document_.GetAllocator());
     }

--- a/src/c++/perf_analyzer/profile_data_exporter.h
+++ b/src/c++/perf_analyzer/profile_data_exporter.h
@@ -69,6 +69,9 @@ class ProfileDataExporter {
   void AddRequests(
       rapidjson::Value& entry, rapidjson::Value& requests,
       const Experiment& raw_experiment);
+  void AddRequestInputs(
+      rapidjson::Value& inputs_json,
+      const std::vector<RequestRecord::RequestInput>& inputs);
   void AddResponseTimestamps(
       rapidjson::Value& timestamps_json,
       const std::vector<std::chrono::time_point<std::chrono::system_clock>>&

--- a/src/c++/perf_analyzer/request_record.h
+++ b/src/c++/perf_analyzer/request_record.h
@@ -33,9 +33,9 @@
 
 namespace triton { namespace perfanalyzer {
 
-/// A record containing the data of a single response
-struct ResponseData {
-  ResponseData(const uint8_t* buf, size_t size)
+/// A record containing the data of a single request input or response output
+struct RecordData {
+  RecordData(const uint8_t* buf, size_t size)
   {
     uint8_t* array = new uint8_t[size];
     std::memcpy(array, buf, size);
@@ -44,7 +44,7 @@ struct ResponseData {
   }
 
   // Define equality comparison operator so it can be inserted into maps
-  bool operator==(const ResponseData& other) const
+  bool operator==(const RecordData& other) const
   {
     if (size_ != other.size_)
       return false;
@@ -59,19 +59,24 @@ struct ResponseData {
 
 /// A record of an individual request
 struct RequestRecord {
-  using ResponseOutput = std::unordered_map<std::string, ResponseData>;
+  // TODO: uncomment
+  // using RequestInput = std::unordered_map<std::string, RecordData>;
+  using RequestInput = std::unordered_map<std::string, std::string>;
+  using ResponseOutput = std::unordered_map<std::string, RecordData>;
 
   RequestRecord(
       std::chrono::time_point<std::chrono::system_clock> start_time =
           std::chrono::time_point<std::chrono::system_clock>(),
       std::vector<std::chrono::time_point<std::chrono::system_clock>>
           response_timestamps = {},
+      std::vector<RequestInput> request_inputs = {},
       std::vector<ResponseOutput> response_outputs = {},
       bool sequence_end = true, bool delayed = false, uint64_t sequence_id = 0,
       bool has_null_last_response = false)
       : start_time_(start_time), response_timestamps_(response_timestamps),
-        response_outputs_(response_outputs), sequence_end_(sequence_end),
-        delayed_(delayed), sequence_id_(sequence_id),
+        request_inputs_(request_inputs), response_outputs_(response_outputs),
+        sequence_end_(sequence_end), delayed_(delayed),
+        sequence_id_(sequence_id),
         has_null_last_response_(has_null_last_response)
   {
   }
@@ -81,6 +86,8 @@ struct RequestRecord {
   std::vector<std::chrono::time_point<std::chrono::system_clock>>
       response_timestamps_;
 
+  // Collection of request inputs
+  std::vector<RequestInput> request_inputs_;
   // Collection of response outputs
   std::vector<ResponseOutput> response_outputs_;
   // Whether or not the request is at the end of a sequence.

--- a/src/c++/perf_analyzer/request_record.h
+++ b/src/c++/perf_analyzer/request_record.h
@@ -86,9 +86,7 @@ struct RequestRecord {
   std::vector<std::chrono::time_point<std::chrono::system_clock>>
       response_timestamps_;
 
-  // Collection of request inputs
   std::vector<RequestInput> request_inputs_;
-  // Collection of response outputs
   std::vector<ResponseOutput> response_outputs_;
   // Whether or not the request is at the end of a sequence.
   bool sequence_end_;

--- a/src/c++/perf_analyzer/request_record.h
+++ b/src/c++/perf_analyzer/request_record.h
@@ -35,12 +35,13 @@ namespace triton { namespace perfanalyzer {
 
 /// A record containing the data of a single request input or response output
 struct RecordData {
-  RecordData(const uint8_t* buf, size_t size)
+  RecordData(const uint8_t* buf, size_t size, std::string data_type = "")
   {
     uint8_t* array = new uint8_t[size];
     std::memcpy(array, buf, size);
     data_ = std::shared_ptr<uint8_t>(array, [](uint8_t* p) { delete[] p; });
     size_ = size;
+    data_type_ = data_type;
   }
 
   // Define equality comparison operator so it can be inserted into maps
@@ -54,14 +55,13 @@ struct RecordData {
 
   std::shared_ptr<uint8_t> data_;
   size_t size_;
+  std::string data_type_;
 };
 
 
 /// A record of an individual request
 struct RequestRecord {
-  // TODO: uncomment
-  // using RequestInput = std::unordered_map<std::string, RecordData>;
-  using RequestInput = std::unordered_map<std::string, std::string>;
+  using RequestInput = std::unordered_map<std::string, RecordData>;
   using ResponseOutput = std::unordered_map<std::string, RecordData>;
 
   RequestRecord(

--- a/src/c++/perf_analyzer/test_inference_profiler.cc
+++ b/src/c++/perf_analyzer/test_inference_profiler.cc
@@ -178,33 +178,33 @@ TEST_CASE("testing the ValidLatencyMeasurement function")
       // in the vector of requests, but if it is, we exclude it: not included in
       // current window
       RequestRecord(
-          time_point(ns(1)), std::vector<time_point>{time_point(ns(2))}, {}, 0,
-          false, 0, false),
+          time_point(ns(1)), std::vector<time_point>{time_point(ns(2))}, {}, {},
+          0, false, 0, false),
 
       // request starts before window starts and ends inside window: included in
       // current window
       RequestRecord(
-          time_point(ns(3)), std::vector<time_point>{time_point(ns(5))}, {}, 0,
-          false, 0, false),
+          time_point(ns(3)), std::vector<time_point>{time_point(ns(5))}, {}, {},
+          0, false, 0, false),
 
       // requests start and end inside window: included in current window
       RequestRecord(
-          time_point(ns(6)), std::vector<time_point>{time_point(ns(9))}, {}, 0,
-          false, 0, false),
+          time_point(ns(6)), std::vector<time_point>{time_point(ns(9))}, {}, {},
+          0, false, 0, false),
       RequestRecord(
           time_point(ns(10)), std::vector<time_point>{time_point(ns(14))}, {},
-          0, false, 0, false),
+          {}, 0, false, 0, false),
 
       // request starts before window ends and ends after window ends: not
       // included in current window
       RequestRecord(
           time_point(ns(15)), std::vector<time_point>{time_point(ns(20))}, {},
-          0, false, 0, false),
+          {}, 0, false, 0, false),
 
       // request starts after window ends: not included in current window
       RequestRecord(
           time_point(ns(21)), std::vector<time_point>{time_point(ns(27))}, {},
-          0, false, 0, false)};
+          {}, 0, false, 0, false)};
 
   TestInferenceProfiler::ValidLatencyMeasurement(
       window, valid_sequence_count, delayed_request_count, &latencies,
@@ -882,7 +882,7 @@ TEST_CASE(
         request1_timestamp,
         std::vector<std::chrono::time_point<std::chrono::system_clock>>{
             response1_timestamp, response2_timestamp},
-        {}, 0, false, 0, false)};
+        {}, {}, 0, false, 0, false)};
 
     auto request2_timestamp{clock_epoch + std::chrono::nanoseconds(4)};
     RequestRecord request_record2{};
@@ -897,7 +897,7 @@ TEST_CASE(
           request2_timestamp,
           std::vector<std::chrono::time_point<std::chrono::system_clock>>{
               response3_timestamp, response4_timestamp, response5_timestamp},
-          {}, 0, false, 0, false);
+          {}, {}, 0, false, 0, false);
       expected_response_count = 5;
     }
     SUBCASE("second request has two data responses and one null response")
@@ -909,7 +909,7 @@ TEST_CASE(
           request2_timestamp,
           std::vector<std::chrono::time_point<std::chrono::system_clock>>{
               response3_timestamp, response4_timestamp, response5_timestamp},
-          {}, 0, false, 0, true);
+          {}, {}, 0, false, 0, true);
       expected_response_count = 4;
     }
     SUBCASE("second request has one null response")
@@ -917,7 +917,7 @@ TEST_CASE(
       request_record2 = RequestRecord(
           request2_timestamp,
           std::vector<std::chrono::time_point<std::chrono::system_clock>>{}, {},
-          0, false, 0, true);
+          {}, 0, false, 0, true);
       expected_response_count = 2;
     }
 
@@ -948,7 +948,7 @@ TEST_CASE(
         request1_timestamp,
         std::vector<std::chrono::time_point<std::chrono::system_clock>>{
             response1_timestamp},
-        {}, 0, false, 0, false)};
+        {}, {}, 0, false, 0, false)};
 
     auto request2_timestamp{clock_epoch + std::chrono::nanoseconds(3)};
     auto response2_timestamp{clock_epoch + std::chrono::nanoseconds(4)};
@@ -956,7 +956,7 @@ TEST_CASE(
         request2_timestamp,
         std::vector<std::chrono::time_point<std::chrono::system_clock>>{
             response2_timestamp},
-        {}, 0, false, 0, false)};
+        {}, {}, 0, false, 0, false)};
 
     auto request3_timestamp{clock_epoch + std::chrono::nanoseconds(5)};
     auto response3_timestamp{clock_epoch + std::chrono::nanoseconds(6)};
@@ -964,7 +964,7 @@ TEST_CASE(
         request3_timestamp,
         std::vector<std::chrono::time_point<std::chrono::system_clock>>{
             response3_timestamp},
-        {}, 0, false, 0, false)};
+        {}, {}, 0, false, 0, false)};
 
     mock_inference_profiler.all_request_records_ = {
         request_record1, request_record2, request_record3};

--- a/src/c++/perf_analyzer/test_load_manager.cc
+++ b/src/c++/perf_analyzer/test_load_manager.cc
@@ -39,13 +39,13 @@ bool
 operator==(const RequestRecord& lhs, const RequestRecord& rhs)
 {
   return std::tie(
-             lhs.start_time_, lhs.response_timestamps_, lhs.response_outputs_,
-             lhs.sequence_end_, lhs.delayed_, lhs.sequence_id_,
-             lhs.has_null_last_response_) ==
+             lhs.start_time_, lhs.response_timestamps_, lhs.request_inputs_,
+             lhs.response_outputs_, lhs.sequence_end_, lhs.delayed_,
+             lhs.sequence_id_, lhs.has_null_last_response_) ==
          std::tie(
-             rhs.start_time_, rhs.response_timestamps_, rhs.response_outputs_,
-             rhs.sequence_end_, rhs.delayed_, rhs.sequence_id_,
-             rhs.has_null_last_response_);
+             rhs.start_time_, rhs.response_timestamps_, rhs.request_inputs_,
+             rhs.response_outputs_, rhs.sequence_end_, rhs.delayed_,
+             rhs.sequence_id_, rhs.has_null_last_response_);
 }
 
 }  // namespace
@@ -136,14 +136,14 @@ class TestLoadManager : public TestLoadManagerBase, public LoadManager {
     using time_point = std::chrono::time_point<std::chrono::system_clock>;
     using ns = std::chrono::nanoseconds;
     auto request_record1 = RequestRecord(
-        time_point(ns(1)), std::vector<time_point>{time_point(ns(2))}, {}, 0,
-        false, 0, false);
+        time_point(ns(1)), std::vector<time_point>{time_point(ns(2))}, {}, {},
+        0, false, 0, false);
     auto request_record2 = RequestRecord(
-        time_point(ns(3)), std::vector<time_point>{time_point(ns(4))}, {}, 0,
-        false, 0, false);
+        time_point(ns(3)), std::vector<time_point>{time_point(ns(4))}, {}, {},
+        0, false, 0, false);
     auto request_record3 = RequestRecord(
-        time_point(ns(5)), std::vector<time_point>{time_point(ns(6))}, {}, 0,
-        false, 0, false);
+        time_point(ns(5)), std::vector<time_point>{time_point(ns(6))}, {}, {},
+        0, false, 0, false);
 
     std::vector<RequestRecord> source_request_records;
 
@@ -297,14 +297,14 @@ class TestLoadManager : public TestLoadManagerBase, public LoadManager {
     using time_point = std::chrono::time_point<std::chrono::system_clock>;
     using ns = std::chrono::nanoseconds;
     auto request_record1 = RequestRecord(
-        time_point(ns(1)), std::vector<time_point>{time_point(ns(2))}, {}, 0,
-        false, 0, false);
+        time_point(ns(1)), std::vector<time_point>{time_point(ns(2))}, {}, {},
+        0, false, 0, false);
     auto request_record2 = RequestRecord(
-        time_point(ns(3)), std::vector<time_point>{time_point(ns(4))}, {}, 0,
-        false, 0, false);
+        time_point(ns(3)), std::vector<time_point>{time_point(ns(4))}, {}, {},
+        0, false, 0, false);
     auto request_record3 = RequestRecord(
-        time_point(ns(5)), std::vector<time_point>{time_point(ns(6))}, {}, 0,
-        false, 0, false);
+        time_point(ns(5)), std::vector<time_point>{time_point(ns(6))}, {}, {},
+        0, false, 0, false);
 
     SUBCASE("No threads")
     {

--- a/src/c++/perf_analyzer/test_profile_data_collector.cc
+++ b/src/c++/perf_analyzer/test_profile_data_collector.cc
@@ -65,16 +65,15 @@ TEST_CASE("profile_data_collector: AddData")
   auto request1_response2_timestamp{clock_epoch + std::chrono::nanoseconds(3)};
   uint8_t fake_data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
   RequestRecord::ResponseOutput request1_response1_output{
-      {"key1", ResponseData(fake_data, 1)},
-      {"key2", ResponseData(fake_data, 2)}};
+      {"key1", RecordData(fake_data, 1)}, {"key2", RecordData(fake_data, 2)}};
   RequestRecord::ResponseOutput request1_response2_output{
-      {"key3", ResponseData(fake_data, 3)},
-      {"key4", ResponseData(fake_data, 4)}};
+      {"key3", RecordData(fake_data, 3)}, {"key4", RecordData(fake_data, 4)}};
 
   RequestRecord request_record1{
       request1_timestamp,
       std::vector<std::chrono::time_point<std::chrono::system_clock>>{
           request1_response1_timestamp, request1_response2_timestamp},
+      {},
       {request1_response1_output, request1_response2_output},
       0,
       false,
@@ -86,16 +85,15 @@ TEST_CASE("profile_data_collector: AddData")
   auto request2_response1_timestamp{clock_epoch + std::chrono::nanoseconds(5)};
   auto request2_response2_timestamp{clock_epoch + std::chrono::nanoseconds(6)};
   RequestRecord::ResponseOutput request2_response1_output{
-      {"key5", ResponseData(fake_data, 5)},
-      {"key6", ResponseData(fake_data, 6)}};
+      {"key5", RecordData(fake_data, 5)}, {"key6", RecordData(fake_data, 6)}};
   RequestRecord::ResponseOutput request2_response2_output{
-      {"key7", ResponseData(fake_data, 7)},
-      {"key8", ResponseData(fake_data, 8)}};
+      {"key7", RecordData(fake_data, 7)}, {"key8", RecordData(fake_data, 8)}};
 
   RequestRecord request_record2{
       request2_timestamp,
       std::vector<std::chrono::time_point<std::chrono::system_clock>>{
           request2_response1_timestamp, request2_response2_timestamp},
+      {},
       {request2_response1_output, request2_response2_output},
       0,
       false,

--- a/src/c++/perf_analyzer/test_profile_data_exporter.cc
+++ b/src/c++/perf_analyzer/test_profile_data_exporter.cc
@@ -32,32 +32,57 @@ namespace triton { namespace perfanalyzer {
 
 TEST_CASE("profile_data_exporter: ConvertToJson")
 {
+  using std::chrono::nanoseconds;
+  using std::chrono::system_clock;
+  using std::chrono::time_point;
+
   MockProfileDataExporter exporter{};
 
   InferenceLoadMode infer_mode{4, 0.0};
   uint64_t sequence_id{1};
 
-  auto clock_epoch{std::chrono::time_point<std::chrono::system_clock>()};
-  auto request_timestamp{clock_epoch + std::chrono::nanoseconds(1)};
-  auto response_timestamp1{clock_epoch + std::chrono::nanoseconds(2)};
-  auto response_timestamp2{clock_epoch + std::chrono::nanoseconds(3)};
-  std::vector<std::string> bufs{"abc", "def", "ghi", "jkl"};
+  auto clock_epoch{time_point<system_clock>()};
+  auto request_timestamp{clock_epoch + nanoseconds(1)};
+  auto response_timestamp1{clock_epoch + nanoseconds(2)};
+  auto response_timestamp2{clock_epoch + nanoseconds(3)};
+
+  // Request inputs
+  std::vector<std::string> in_bufs{"123", "456", "true"};
+  RequestRecord::RequestInput request_input{
+      {"in_key1",
+       {reinterpret_cast<const uint8_t*>(in_bufs[0].data()), in_bufs[0].size(),
+        "BYTES"}},
+      {"in_key2",
+       {reinterpret_cast<const uint8_t*>(in_bufs[1].data()), in_bufs[1].size(),
+        "INT32"}},
+      {"in_key3",
+       {reinterpret_cast<const uint8_t*>(in_bufs[2].data()), in_bufs[2].size(),
+        "BOOL"}},
+  };
+
+
+  // Response outputs
+  std::vector<std::string> out_bufs{"abc", "def", "ghi", "jkl"};
   RequestRecord::ResponseOutput response_output1{
-      {"key1",
-       {reinterpret_cast<const uint8_t*>(bufs[0].data()), bufs[0].size()}},
-      {"key2",
-       {reinterpret_cast<const uint8_t*>(bufs[1].data()), bufs[1].size()}}};
+      {"out_key1",
+       {reinterpret_cast<const uint8_t*>(out_bufs[0].data()),
+        out_bufs[0].size()}},
+      {"out_key2",
+       {reinterpret_cast<const uint8_t*>(out_bufs[1].data()),
+        out_bufs[1].size()}}};
   RequestRecord::ResponseOutput response_output2{
-      {"key3",
-       {reinterpret_cast<const uint8_t*>(bufs[2].data()), bufs[2].size()}},
-      {"key4",
-       {reinterpret_cast<const uint8_t*>(bufs[3].data()), bufs[3].size()}}};
+      {"out_key3",
+       {reinterpret_cast<const uint8_t*>(out_bufs[2].data()),
+        out_bufs[2].size()}},
+      {"out_key4",
+       {reinterpret_cast<const uint8_t*>(out_bufs[3].data()),
+        out_bufs[3].size()}}};
 
   RequestRecord request_record{
       request_timestamp,
-      std::vector<std::chrono::time_point<std::chrono::system_clock>>{
+      std::vector<time_point<system_clock>>{
           response_timestamp1, response_timestamp2},
-      {},
+      {request_input},
       {response_output1, response_output2},
       0,
       false,
@@ -88,8 +113,9 @@ TEST_CASE("profile_data_exporter: ConvertToJson")
               {
                 "timestamp" : 1,
                 "sequence_id" : 1,
+                "request_inputs" : {"in_key1":"123","in_key2":456,"in_key3":true},
                 "response_timestamps" : [ 2, 3 ],
-                "response_outputs" : [ {"key1":"abc","key2":"def"}, {"key3":"ghi","key4":"jkl"} ]
+                "response_outputs" : [ {"out_key1":"abc","out_key2":"def"}, {"out_key3":"ghi","out_key4":"jkl"} ]
               }
             ],
             "window_boundaries" : [ 1, 5, 6 ]

--- a/src/c++/perf_analyzer/test_profile_data_exporter.cc
+++ b/src/c++/perf_analyzer/test_profile_data_exporter.cc
@@ -57,6 +57,7 @@ TEST_CASE("profile_data_exporter: ConvertToJson")
       request_timestamp,
       std::vector<std::chrono::time_point<std::chrono::system_clock>>{
           response_timestamp1, response_timestamp2},
+      {},
       {response_output1, response_output2},
       0,
       false,


### PR DESCRIPTION
Example:
```json
{
    "experiments": [
        {
            "experiment": {
                "mode": "concurrency",
                "value": 1
            },
            "requests": [
                {
                    "timestamp": 10,
                    "request_input": {
	                    "text_input": "o\u0000\u0000\u0000Randomly stream lines from the following text with 150 output tokens. Don't generate eos tokens:\n\nappertaining ",
	                    "stream": true,
                    },
                    "response_timestamps": [ 1, 2 ],
                    "response_outputs": [
                        {"text_output": "..."},
                        {"text_output": "..."}
                    ]
                },
            ],
            "window_boundaries": [ ... ]
        }
    ],
    "version": "0.0.0"
}
```