### PR TITLE
Extend Statistics and Metrics for visualization

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -148,9 +148,9 @@ class Statistics:
         # iterate through Metrics to calculate statistics and set attributes
         self._metrics = metrics
         for attr, data in metrics.data.items():
+            attr = metrics.get_base_name(attr)
+            data = self._preprocess_data(data, attr)
             if data:
-                attr = metrics.get_base_name(attr)
-                data = self._preprocess_data(data, attr)
                 self._calculate_mean(data, attr)
                 self._calculate_percentiles(data, attr)
                 self._calculate_minmax(data, attr)

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
@@ -28,12 +28,10 @@
 
 import json
 from io import StringIO
-from pathlib import Path
 
 import numpy as np
 import pytest
 from genai_perf.llm_metrics import LLMMetrics, LLMProfileDataParser
-from genai_perf.utils import remove_file
 from transformers import AutoTokenizer
 
 


### PR DESCRIPTION
- Store inter token latencies per request in Metrics object to reuse them in the plot generation
- Add accessor to underlying Metrics object and statistics data in Statistics class

```python
stats = Statistics(...)

print(stats.metrics)
# Metrics(time_to_first_tokens=[1,2,3], inter_token_latencies=[[4,5,6],[7,8]], ...)

print(stats.data)
# {'avg_time_to_first_token': 4, 'p50_time_to_first_token': 8, ...}
```