### PR TITLE
Make TRT-LLM max_tokens behavior explicit in GenAi-Perf

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -608,6 +608,7 @@ class LlmInputs:
         extra_inputs: Dict = {},
     ) -> Dict:
         pa_json = LlmInputs._create_empty_trtllm_pa_json()
+        include_max_tokens = "max_tokens" not in extra_inputs
 
         for index, entry in enumerate(dataset_json["rows"]):
             pa_json["data"].append({"text_input": [""]})
@@ -625,7 +626,9 @@ class LlmInputs:
                     pa_json, index, new_text_input
                 )
 
-            pa_json = LlmInputs._add_required_tags_to_trtllm_json(pa_json, index)
+            pa_json = LlmInputs._add_required_tags_to_trtllm_json(
+                pa_json, index, include_max_tokens
+            )
             pa_json = LlmInputs._add_optional_tags_to_trtllm_json(
                 pa_json, index, add_model_name, add_stream, model_name, extra_inputs
             )
@@ -816,8 +819,10 @@ class LlmInputs:
         cls,
         pa_json: Dict,
         index: int,
+        include_max_tokens: bool,
     ) -> Dict:
-        pa_json["data"][index]["max_tokens"] = [LlmInputs.DEFAULT_TRTLLM_MAX_TOKENS]
+        if include_max_tokens:
+            pa_json["data"][index]["max_tokens"] = [LlmInputs.DEFAULT_TRTLLM_MAX_TOKENS]
 
         return pa_json
 

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -409,3 +409,25 @@ class TestLlmInputs:
                 ], f"The value of {input_name} is incorrect"
         else:
             assert False, f"Unsupported output format: {output_format}"
+
+    def test_trtllm_default_max_tokens(self, default_tokenizer) -> None:
+        input_name = "max_tokens"
+        input_value = 256
+
+        pa_json = LlmInputs.create_llm_inputs(
+            input_type=PromptSource.SYNTHETIC,
+            output_format=OutputFormat.TRTLLM,
+            num_of_output_prompts=5,
+            add_model_name=False,
+            add_stream=True,
+            tokenizer=default_tokenizer,
+        )
+
+        assert len(pa_json["data"]) == 5
+        for entry in pa_json["data"]:
+            assert (
+                input_name in entry
+            ), f"The {input_name} is not present in the request"
+            assert entry[input_name] == [
+                input_value
+            ], f"The value of {input_name} is incorrect"

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -368,8 +368,10 @@ class TestLlmInputs:
             (OutputFormat.VLLM),
         ],
     )
-    def test_llm_inputs_extra_inputs(self, default_tokenizer, output_format) -> None:
-        request_inputs = {"additional_key": "additional_value"}
+    def test_extra_inputs(self, default_tokenizer, output_format) -> None:
+        input_name = "max_tokens"
+        input_value = 5
+        request_inputs = {input_name: input_value}
 
         pa_json = LlmInputs.create_llm_inputs(
             input_type=PromptSource.SYNTHETIC,
@@ -392,18 +394,18 @@ class TestLlmInputs:
                 payload = entry["payload"]
                 for item in payload:
                     assert (
-                        "additional_key" in item
-                    ), "The additional_key is not present in the request"
+                        input_name in item
+                    ), f"The input name {input_name} is not present in the request"
                     assert (
-                        item["additional_key"] == "additional_value"
-                    ), "The value of additional_key is incorrect"
+                        item[input_name] == input_value
+                    ), f"The value of {input_name} is incorrect"
         elif output_format == OutputFormat.TRTLLM or output_format == OutputFormat.VLLM:
             for entry in pa_json["data"]:
                 assert (
-                    "additional_key" in entry
-                ), "The additional_key is not present in the request"
-                assert entry["additional_key"] == [
-                    "additional_value"
-                ], "The value of additional_key is incorrect"
+                    input_name in entry
+                ), f"The {input_name} is not present in the request"
+                assert entry[input_name] == [
+                    input_value
+                ], f"The value of {input_name} is incorrect"
         else:
             assert False, f"Unsupported output format: {output_format}"


### PR DESCRIPTION
The behavior of max-tokens in TRT-LLM was correct (if the user passes in `--extra-inputs max_tokens:<number_of_tokens>`, that value is used), but this was not explicit and would break if someone switched the order of adding required and optional JSON inputs. This PR makes this behavior explicit and clear, plus it adds testing to ensure the correct value is parsed for max_tokens.