### PR TITLE
Add number of input tokens metric

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -465,6 +465,11 @@ class LLMProfileDataParser(ProfileDataParser):
 
             self._preprocess_response(res_timestamps, res_outputs)
 
+            # Skip requests with empty response. This happens sometimes when the
+            # model returns a single response with empty string.
+            if not res_timestamps:
+                continue
+
             # track entire benchmark duration
             min_req_timestamp = min(min_req_timestamp, req_timestamp)
             max_res_timestamp = max(max_res_timestamp, res_timestamps[-1])

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -28,19 +28,14 @@
 
 import csv
 import json
-import logging
 from itertools import pairwise
 
 import numpy as np
-from genai_perf.constants import LOGGER_NAME
 from genai_perf.llm_inputs.llm_inputs import OutputFormat
 from genai_perf.tokenizer import AutoTokenizer
 from genai_perf.utils import load_json, remove_sse_prefix
 from rich.console import Console
 from rich.table import Table
-
-logging.basicConfig(level=logging.INFO, format="%(name)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(LOGGER_NAME)
 
 _OPENAI_CHAT_COMPLETIONS = OutputFormat.OPENAI_CHAT_COMPLETIONS
 _OPENAI_COMPLETIONS = OutputFormat.OPENAI_COMPLETIONS

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -549,8 +549,7 @@ class LLMProfileDataParser(ProfileDataParser):
 
     def _tokenize_triton_request_input(self, req_inputs: dict) -> list[list[int]]:
         """Tokenize the Triton request input texts."""
-        # TODO
-        return []
+        return self._tokenizer(req_inputs["text_input"])["input_ids"]
 
     def _tokenize_openai_request_input(self, req_inputs: dict) -> list[list[int]]:
         """Tokenize the OpenAI request input texts."""

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -71,9 +71,14 @@ def generate_inputs(args: ArgumentParser, tokenizer: AutoTokenizer) -> None:
 
 
 def calculate_metrics(
-    file: str, service_kind: str, tokenizer: AutoTokenizer
+    args: ArgumentParser, tokenizer: AutoTokenizer
 ) -> LLMProfileDataParser:
-    return LLMProfileDataParser(file, service_kind, tokenizer)
+    return LLMProfileDataParser(
+        filename=args.profile_export_file,
+        service_kind=args.service_kind,
+        output_format=args.output_format,
+        tokenizer=tokenizer,
+    )
 
 
 def report_output(metrics: LLMProfileDataParser, args):
@@ -99,9 +104,7 @@ def run():
         tokenizer = get_tokenizer(args.tokenizer)
         generate_inputs(args, tokenizer)
         args.func(args, extra_args)
-        metrics = calculate_metrics(
-            args.profile_export_file, args.service_kind, tokenizer
-        )
+        metrics = calculate_metrics(args, tokenizer)
         report_output(metrics, args)
     except Exception as e:
         raise GenAIPerfException(e)

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
@@ -102,7 +102,7 @@ class TestLLMProfileDataParser:
             "Inter Token Latency (ns),2,2,3,3,3,3,2,2,2\r\n",
             "Request Latency (ns),8,7,9,9,9,9,8,8,8\r\n",
             "Num Output Token,4,3,5,5,5,5,4,4,4\r\n",
-            "Num Input Token,-1,-1,-1,-1,-1,-1,-1,-1,-1\r\n",
+            "Num Input Token,4,3,4,4,4,4,4,4,3\r\n",
             "\r\n",
             "Metric,Value\r\n",
             "Output Token Throughput (per sec),800000000.00\r\n",
@@ -139,8 +139,8 @@ class TestLLMProfileDataParser:
             - experiment 1: [3, 5]
             - experiment 2: [4, 5]
         * num input tokens
-            - experiment 1: [3, 5]
-            - experiment 2: [4, 5]
+            - experiment 1: [3, 4]
+            - experiment 2: [3, 4]
         """
         tokenizer = AutoTokenizer.from_pretrained("gpt2")
         pd = LLMProfileDataParser(
@@ -161,31 +161,35 @@ class TestLLMProfileDataParser:
         ott = [8 / ns_to_sec(10)]
         assert metrics.output_token_throughputs == pytest.approx(ott)
         assert metrics.num_output_tokens == [3, 5]
-        assert metrics.num_input_tokens == []
+        assert metrics.num_input_tokens == [3, 4]
 
         assert stat.avg_time_to_first_token == 2
         assert stat.avg_inter_token_latency == 2.25
         avg_ottpr = 31 / ns_to_sec(63)
         assert stat.avg_output_token_throughput_per_request == pytest.approx(avg_ottpr)
         assert stat.avg_num_output_token == 4
+        assert stat.avg_num_input_token == 3.5
 
         assert stat.p50_time_to_first_token == 2
         assert stat.p50_inter_token_latency == 2
         p50_ottpr = 31 / ns_to_sec(63)
         assert stat.p50_output_token_throughput_per_request == pytest.approx(p50_ottpr)
         assert stat.p50_num_output_token == 4
+        assert stat.p50_num_input_token == 3.5
 
         assert stat.min_time_to_first_token == 2
         assert stat.min_inter_token_latency == 2
         min_ottpr = 3 / ns_to_sec(7)
         assert stat.min_output_token_throughput_per_request == pytest.approx(min_ottpr)
         assert stat.min_num_output_token == 3
+        assert stat.min_num_input_token == 3
 
         assert stat.max_time_to_first_token == 2
         assert stat.max_inter_token_latency == 3
         max_ottpr = 5 / ns_to_sec(9)
         assert stat.max_output_token_throughput_per_request == pytest.approx(max_ottpr)
         assert stat.max_num_output_token == 5
+        assert stat.max_num_input_token == 4
 
         assert stat.std_time_to_first_token == np.std([2, 2])
         assert stat.std_inter_token_latency == np.std([2, 3, 2, 2])
@@ -195,6 +199,7 @@ class TestLLMProfileDataParser:
             np.std([ottpr1, ottpr2])
         )
         assert stat.std_num_output_token == np.std([3, 5])
+        assert stat.std_num_input_token == np.std([3, 4])
 
         oott = 8 / ns_to_sec(10)
         assert stat.avg_output_token_throughput == pytest.approx(oott)
@@ -210,31 +215,35 @@ class TestLLMProfileDataParser:
         ott = [3 / ns_to_sec(5)]
         assert metrics.output_token_throughputs == pytest.approx(ott)
         assert metrics.num_output_tokens == [4, 5]
-        assert metrics.num_input_tokens == []
+        assert metrics.num_input_tokens == [3, 4]
 
         assert stat.avg_time_to_first_token == 2.5
         assert stat.avg_inter_token_latency == 3
         avg_ottpr = 97 / ns_to_sec(208)
         assert stat.avg_output_token_throughput_per_request == pytest.approx(avg_ottpr)
         assert stat.avg_num_output_token == 4.5
+        assert stat.avg_num_input_token == 3.5
 
         assert stat.p50_time_to_first_token == 2.5
         assert stat.p50_inter_token_latency == 2
         p50_ottpr = 97 / ns_to_sec(208)
         assert stat.p50_output_token_throughput_per_request == pytest.approx(p50_ottpr)
         assert stat.p50_num_output_token == 4.5
+        assert stat.p50_num_input_token == 3.5
 
         assert stat.min_time_to_first_token == 2
         assert stat.min_inter_token_latency == 1
         min_ottpr = 4 / ns_to_sec(13)
         assert stat.min_output_token_throughput_per_request == pytest.approx(min_ottpr)
         assert stat.min_num_output_token == 4
+        assert stat.min_num_input_token == 3
 
         assert stat.max_time_to_first_token == 3
         assert stat.max_inter_token_latency == 5
         max_ottpr = 5 / ns_to_sec(8)
         assert stat.max_output_token_throughput_per_request == pytest.approx(max_ottpr)
         assert stat.max_num_output_token == 5
+        assert stat.max_num_input_token == 4
 
         assert stat.std_time_to_first_token == np.std([2, 3])
         assert stat.std_inter_token_latency == np.std([1, 5, 5, 2, 2])
@@ -244,6 +253,7 @@ class TestLLMProfileDataParser:
             np.std([ottpr1, ottpr2])
         )
         assert stat.std_num_output_token == np.std([4, 5])
+        assert stat.std_num_input_token == np.std([3, 4])
 
         oott = 6 / ns_to_sec(10)
         assert stat.avg_output_token_throughput == pytest.approx(oott)
@@ -268,7 +278,7 @@ class TestLLMProfileDataParser:
         * num output tokens
             - experiment 1: [3, 5]
         * num input tokens
-            - experiment 1: [2, 2]
+            - experiment 1: [3, 4]
         """
         tokenizer = AutoTokenizer.from_pretrained("gpt2")
         pd = LLMProfileDataParser(
@@ -289,31 +299,35 @@ class TestLLMProfileDataParser:
         ott = [4 / ns_to_sec(7)]
         assert metrics.output_token_throughputs == pytest.approx(ott)
         assert metrics.num_output_tokens == [3, 5]
-        assert metrics.num_input_tokens == [2, 2]
+        assert metrics.num_input_tokens == [3, 4]
 
         assert stat.avg_time_to_first_token == 2
         assert stat.avg_inter_token_latency == 8 / 3
         avg_ottpr = 47 / ns_to_sec(143)
         assert stat.avg_output_token_throughput_per_request == pytest.approx(avg_ottpr)
         assert stat.avg_num_output_token == 4
+        assert stat.avg_num_input_token == 3.5
 
         assert stat.p50_time_to_first_token == 2
         assert stat.p50_inter_token_latency == 2.5
         p50_ottpr = 47 / ns_to_sec(143)
         assert stat.p50_output_token_throughput_per_request == pytest.approx(p50_ottpr)
         assert stat.p50_num_output_token == 4
+        assert stat.p50_num_input_token == 3.5
 
         assert stat.min_time_to_first_token == 2
         assert stat.min_inter_token_latency == 2
         min_ottpr = 3 / ns_to_sec(11)
         assert stat.min_output_token_throughput_per_request == pytest.approx(min_ottpr)
         assert stat.min_num_output_token == 3
+        assert stat.min_num_input_token == 3
 
         assert stat.max_time_to_first_token == 2
         assert stat.max_inter_token_latency == 4
         max_ottpr = 5 / ns_to_sec(13)
         assert stat.max_output_token_throughput_per_request == pytest.approx(max_ottpr)
         assert stat.max_num_output_token == 5
+        assert stat.max_num_input_token == 4
 
         assert stat.std_time_to_first_token == np.std([2, 2])
         assert stat.std_inter_token_latency == np.std([2, 3, 4, 3, 2, 2])
@@ -323,6 +337,7 @@ class TestLLMProfileDataParser:
             np.std([ottpr1, ottpr2])
         )
         assert stat.std_num_output_token == np.std([3, 5])
+        assert stat.std_num_input_token == np.std([3, 4])
 
         oott = 4 / ns_to_sec(7)
         assert stat.avg_output_token_throughput == pytest.approx(oott)
@@ -366,7 +381,7 @@ class TestLLMProfileDataParser:
                     {
                         "timestamp": 1,
                         "request_inputs": {
-                            "payload": '{"messages":[{"role":"user","content":"Hello world"}],"model":"llama-2-7b","stream":true}',
+                            "payload": '{"messages":[{"role":"user","content":"This is test"}],"model":"llama-2-7b","stream":true}',
                         },
                         # last two empty/null responses will be ignored
                         "response_timestamps": [3, 5, 8, 12, 13, 14],
@@ -392,7 +407,7 @@ class TestLLMProfileDataParser:
                     {
                         "timestamp": 2,
                         "request_inputs": {
-                            "payload": '{"messages":[{"role":"user","content":"Hello world"}],"model":"llama-2-7b","stream":true}',
+                            "payload": '{"messages":[{"role":"user","content":"This is test too"}],"model":"llama-2-7b","stream":true}',
                         },
                         # last two empty/null responses will be ignored
                         "response_timestamps": [4, 7, 11, 15, 18, 19],
@@ -430,7 +445,7 @@ class TestLLMProfileDataParser:
                 "requests": [
                     {
                         "timestamp": 1,
-                        "request_inputs": {},
+                        "request_inputs": {"text_input": "This is test"},
                         "response_timestamps": [3, 5, 8],
                         "response_outputs": [
                             {"text_output": "dogs"},
@@ -440,7 +455,7 @@ class TestLLMProfileDataParser:
                     },
                     {
                         "timestamp": 2,
-                        "request_inputs": {},
+                        "request_inputs": {"text_input": "This is test too"},
                         "response_timestamps": [4, 7, 11],
                         "response_outputs": [
                             {"text_output": "I"},
@@ -458,7 +473,7 @@ class TestLLMProfileDataParser:
                 "requests": [
                     {
                         "timestamp": 5,
-                        "request_inputs": {},
+                        "request_inputs": {"text_input": "This is test"},
                         "response_timestamps": [7, 8, 13, 18],
                         "response_outputs": [
                             {"text_output": "cats"},
@@ -469,7 +484,7 @@ class TestLLMProfileDataParser:
                     },
                     {
                         "timestamp": 3,
-                        "request_inputs": {},
+                        "request_inputs": {"text_input": "This is test too"},
                         "response_timestamps": [6, 8, 11],
                         "response_outputs": [
                             {"text_output": "it's"},


### PR DESCRIPTION
Passed e2e tests for both triton (trtllm, vllm) and openai endpoints.

Sample std output:
<img width="967" alt="image" src="https://github.com/triton-inference-server/client/assets/107147848/570e1ce0-6b4b-47e5-a708-3f7d0146a2dc">

Sample csv output:
```
Metric,avg,min,max,p99,p95,p90,p75,p50,p25
Time To First Token (ns),11520474,7129972,31636530,25133016,21681889,19220078,12972134,11192398,7543069
Inter Token Latency (ns),948192,39108,8515906,2678516,1496222,1387632,1017759,912862,672564
Request Latency (ns),49809627,13591020,88391910,83426245,74369309,66837708,57967980,51241493,37371832
Num Output Token,45,4,63,53,50,49,47,46,44
Num Input Token,44,40,52,51,50,49,44,43,42

Metric,Value
Output Token Throughput (per sec),899.94
Request Throughput (per sec),19.97
```