### PR TITLE
Remove synthetic expected output tokens option

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/README.md
+++ b/src/c++/perf_analyzer/genai-perf/README.md
@@ -122,8 +122,6 @@ When the dataset is synthetic you can specify the following options:
 * `--synthetic-tokens-mean`: The mean number of tokens of synthetic input data.
 * `--synthetic-tokens-stddev`: The standard deviation number of tokens of synthetic
   input data.
-* `--synthetic-requested-output-tokens`: The number of output tokens to ask the model
-  to return in the response.
 * `--random-seed`: The seed used to generate random values.
 
 When the dataset is coming from HuggingFace you can specify the following
@@ -171,10 +169,6 @@ The source of the input prompts.
 ##### `--input-dataset {openorca,cnn_dailymail}`
 
 The HuggingFace dataset to use for prompts when prompt-source is dataset.
-
-##### `--synthetic-requested-output-tokens <int>`
-The number of tokens to request in the output. This is used when prompt-source
-is synthetic to tell the LLM how many output tokens to generate in each response.
 
 ##### `--synthetic-tokens-mean <int>`
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -226,7 +226,7 @@ class LlmInputs:
         dataset_json["features"] = [{"name": "text_input"}]
         dataset_json["rows"] = []
         for index in range(0, num_of_output_prompts):
-            synthetic_prompt, _ = LlmInputs._create_synthetic_prompt(
+            synthetic_prompt = LlmInputs._create_synthetic_prompt(
                 tokenizer,
                 prompt_tokens_mean,
                 prompt_tokens_stddev,
@@ -1006,7 +1006,7 @@ class LlmInputs:
         prompt_tokens_mean: int,
         prompt_tokens_stddev: int,
         random_seed: int,
-    ) -> Tuple[str, int]:
+    ) -> str:
         random.seed(random_seed)
         return SyntheticPromptGenerator.create_synthetic_prompt(
             tokenizer, prompt_tokens_mean, prompt_tokens_stddev

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -59,8 +59,6 @@ class LlmInputs:
     DEFAULT_RANDOM_SEED = 0
     DEFAULT_PROMPT_TOKENS_MEAN = 550
     DEFAULT_PROMPT_TOKENS_STDDEV = 0
-    # TODO: Remove requested output tokens from LlmInputs
-    DEFAULT_REQUESTED_OUTPUT_TOKENS = 150
     DEFAULT_OUTPUT_TOKENS_MEAN = -1
     DEFAULT_OUTPUT_TOKENS_STDDEV = 0
     DEFAULT_NUM_PROMPTS = 100
@@ -81,7 +79,6 @@ class LlmInputs:
         input_filename: str = "",
         starting_index: int = DEFAULT_STARTING_INDEX,
         length: int = DEFAULT_LENGTH,
-        expected_output_tokens: int = DEFAULT_REQUESTED_OUTPUT_TOKENS,
         output_tokens_mean: int = DEFAULT_OUTPUT_TOKENS_MEAN,
         output_tokens_stddev: int = DEFAULT_OUTPUT_TOKENS_STDDEV,
         prompt_tokens_mean: int = DEFAULT_PROMPT_TOKENS_MEAN,
@@ -136,10 +133,6 @@ class LlmInputs:
             The mean length of the prompt to generate
         prompt_tokens_stddev:
             The standard deviation of the length of the prompt to generate
-        expected_output_tokens:
-            The number of tokens to expect in the output. This is used to
-            determine the length of the prompt. The prompt will be generated such that the output
-            will be approximately this many tokens.
         num_of_output_prompts:
             The number of synthetic output prompts to generate
         random_seed:
@@ -163,7 +156,6 @@ class LlmInputs:
                 tokenizer,
                 prompt_tokens_mean,
                 prompt_tokens_stddev,
-                expected_output_tokens,
                 num_of_output_prompts,
                 random_seed,
             )
@@ -227,7 +219,6 @@ class LlmInputs:
         tokenizer: AutoTokenizer,
         prompt_tokens_mean: int,
         prompt_tokens_stddev: int,
-        expected_output_tokens: int,
         num_of_output_prompts: int,
         random_seed: int,
     ) -> Dict:
@@ -239,7 +230,6 @@ class LlmInputs:
                 tokenizer,
                 prompt_tokens_mean,
                 prompt_tokens_stddev,
-                expected_output_tokens,
                 random_seed + index,
             )
             dataset_json["rows"].append({"row": {"text_input": synthetic_prompt}})
@@ -1015,10 +1005,9 @@ class LlmInputs:
         tokenizer: AutoTokenizer,
         prompt_tokens_mean: int,
         prompt_tokens_stddev: int,
-        expected_output_tokens: int,
         random_seed: int,
     ) -> Tuple[str, int]:
         random.seed(random_seed)
         return SyntheticPromptGenerator.create_synthetic_prompt(
-            tokenizer, prompt_tokens_mean, prompt_tokens_stddev, expected_output_tokens
+            tokenizer, prompt_tokens_mean, prompt_tokens_stddev
         )

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_prompt_generator.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_prompt_generator.py
@@ -29,7 +29,6 @@ class SyntheticPromptGenerator:
         tokenizer: AutoTokenizer,
         prompt_tokens_mean: int = 550,
         prompt_tokens_stddev: int = 250,
-        expected_output_tokens: int = 150,
     ) -> Tuple[str, int]:
         """
         Generate a prompt that randomly samples lines from
@@ -40,58 +39,22 @@ class SyntheticPromptGenerator:
                 The mean length of the prompt to generate
             prompt_tokens_stddev:
                 The standard deviation of the length of the prompt to generate
-            expected_output_tokens:
-                The number of tokens to expect in the output. This is used to
-                determine the length of the prompt. The prompt will be generated such that the output
-                will be approximately this many tokens.
 
         Returns:
             A tuple of the prompt and the length of the prompt.
         """
+        ## TODO: Since the number of tokens is just used for testing, can we remove it and use length in the test?
 
-        prompt = (
-            "Randomly stream lines from the following text "
-            f"with {expected_output_tokens} output tokens. "
-            "Don't generate eos tokens:\n\n"
+        num_prompt_tokens = SyntheticPromptGenerator._sample_random_positive_int(
+            prompt_tokens_mean, prompt_tokens_stddev
         )
-
-        prompt_token_length = SyntheticPromptGenerator._get_prompt_token_length(
-            prompt, tokenizer
-        )
-        num_prompt_tokens = SyntheticPromptGenerator._get_num_prompt_tokens(
-            prompt_tokens_mean, prompt_tokens_stddev, prompt_token_length
-        )
-        remaining_prompt_tokens = num_prompt_tokens - prompt_token_length
 
         farewell_lines = SyntheticPromptGenerator._create_farewell_lines()
         prompt = SyntheticPromptGenerator._create_prompt_from_farewell_lines(
-            prompt, remaining_prompt_tokens, farewell_lines, tokenizer
+            num_prompt_tokens, farewell_lines, tokenizer
         )
 
         return (prompt, num_prompt_tokens)
-
-    @classmethod
-    def _get_prompt_token_length(cls, prompt: str, tokenizer: AutoTokenizer) -> int:
-        get_token_length = lambda text: len(tokenizer.encode(text))
-
-        prompt_token_length = get_token_length(prompt)
-
-        return prompt_token_length
-
-    @classmethod
-    def _get_num_prompt_tokens(
-        cls, mean: int, stddev: int, prompt_token_length: int
-    ) -> int:
-        num_prompt_tokens = SyntheticPromptGenerator._sample_random_positive_int(
-            mean, stddev
-        )
-        # Ensure prompt length is at least as long as the base
-        while num_prompt_tokens < prompt_token_length:
-            num_prompt_tokens = SyntheticPromptGenerator._sample_random_positive_int(
-                mean, stddev
-            )
-
-        return num_prompt_tokens
 
     @classmethod
     def _create_farewell_lines(cls) -> List[str]:
@@ -105,11 +68,11 @@ class SyntheticPromptGenerator:
     @classmethod
     def _create_prompt_from_farewell_lines(
         cls,
-        prompt: str,
         remaining_prompt_tokens: int,
         farewell_lines: List[str],
         tokenizer: AutoTokenizer,
     ) -> str:
+        prompt = ""
         get_token_length = lambda text: len(tokenizer.encode(text))
 
         sampling_lines = True

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_prompt_generator.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_prompt_generator.py
@@ -29,7 +29,7 @@ class SyntheticPromptGenerator:
         tokenizer: AutoTokenizer,
         prompt_tokens_mean: int = 550,
         prompt_tokens_stddev: int = 250,
-    ) -> Tuple[str, int]:
+    ) -> str:
         """
         Generate a prompt that randomly samples lines from
         Washington's farewell address at farewell.txt.
@@ -43,7 +43,6 @@ class SyntheticPromptGenerator:
         Returns:
             A tuple of the prompt and the length of the prompt.
         """
-        ## TODO: Since the number of tokens is just used for testing, can we remove it and use length in the test?
 
         num_prompt_tokens = SyntheticPromptGenerator._sample_random_positive_int(
             prompt_tokens_mean, prompt_tokens_stddev
@@ -54,7 +53,7 @@ class SyntheticPromptGenerator:
             num_prompt_tokens, farewell_lines, tokenizer
         )
 
-        return (prompt, num_prompt_tokens)
+        return prompt
 
     @classmethod
     def _create_farewell_lines(cls) -> List[str]:
@@ -68,7 +67,7 @@ class SyntheticPromptGenerator:
     @classmethod
     def _create_prompt_from_farewell_lines(
         cls,
-        remaining_prompt_tokens: int,
+        prompt_tokens: int,
         farewell_lines: List[str],
         tokenizer: AutoTokenizer,
     ) -> str:
@@ -87,7 +86,7 @@ class SyntheticPromptGenerator:
                     prompt += line_to_add
                     break
                 prompt += line_to_add
-                remaining_prompt_tokens -= get_token_length(line_to_add)
+                remaining_prompt_tokens = prompt_tokens - get_token_length(prompt)
 
         return prompt
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_prompt_generator.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_prompt_generator.py
@@ -67,7 +67,7 @@ class SyntheticPromptGenerator:
     @classmethod
     def _create_prompt_from_farewell_lines(
         cls,
-        prompt_tokens: int,
+        remaining_prompt_tokens: int,
         farewell_lines: List[str],
         tokenizer: AutoTokenizer,
     ) -> str:
@@ -86,7 +86,7 @@ class SyntheticPromptGenerator:
                     prompt += line_to_add
                     break
                 prompt += line_to_add
-                remaining_prompt_tokens = prompt_tokens - get_token_length(prompt)
+                remaining_prompt_tokens -= get_token_length(line_to_add)
 
         return prompt
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -175,14 +175,6 @@ def _add_input_args(parser):
     )
 
     input_group.add_argument(
-        "--synthetic-requested-output-tokens",
-        type=int,
-        default=LlmInputs.DEFAULT_REQUESTED_OUTPUT_TOKENS,
-        required=False,
-        help="The number of tokens to request in the output. This is used when prompt-source is synthetic to tell the LLM how many output tokens to generate in each response.",
-    )
-
-    input_group.add_argument(
         "--synthetic-input-tokens-mean",
         type=int,
         default=LlmInputs.DEFAULT_PROMPT_TOKENS_MEAN,

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -66,7 +66,6 @@ class Profiler:
             "streaming",
             "synthetic_input_tokens_mean",
             "synthetic_input_tokens_stddev",
-            "synthetic_requested_output_tokens",
             "output_tokens_mean",
             "output_tokens_stddev",
             "num_prompts",

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -90,10 +90,6 @@ class TestCLIArguments:
                 ],
                 {"extra_inputs": ["test_key:5", "another_test_key:6"]},
             ),
-            (
-                ["--synthetic-requested-output-tokens", "5"],
-                {"synthetic_requested_output_tokens": 5},
-            ),
             (["--input-dataset", "openorca"], {"input_dataset": "openorca"}),
             (
                 ["--synthetic-input-tokens-mean", "6"],

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -274,7 +274,6 @@ class TestLlmInputs:
             default_tokenizer,
             LlmInputs.DEFAULT_PROMPT_TOKENS_MEAN,
             LlmInputs.DEFAULT_PROMPT_TOKENS_STDDEV,
-            LlmInputs.DEFAULT_REQUESTED_OUTPUT_TOKENS,
             LlmInputs.DEFAULT_RANDOM_SEED,
         )
 
@@ -285,7 +284,6 @@ class TestLlmInputs:
             default_tokenizer,
             LlmInputs.DEFAULT_PROMPT_TOKENS_MEAN,
             LlmInputs.DEFAULT_PROMPT_TOKENS_STDDEV + 250,
-            LlmInputs.DEFAULT_REQUESTED_OUTPUT_TOKENS,
             LlmInputs.DEFAULT_RANDOM_SEED + 1,
         )
         assert synthetic_prompt_tokens != 785

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -172,7 +172,7 @@ class TestLlmInputs:
             add_model_name=False,
             add_stream=False,
             extra_inputs={},
-            output_tokens_mean=LlmInputs.DEFAULT_REQUESTED_OUTPUT_TOKENS,
+            output_tokens_mean=LlmInputs.DEFAULT_OUTPUT_TOKENS_MEAN,
             output_tokens_stddev=LlmInputs.DEFAULT_OUTPUT_TOKENS_STDDEV,
         )
 
@@ -270,7 +270,7 @@ class TestLlmInputs:
         """
         Test that we can produce deterministic random synthetic prompts
         """
-        synthetic_prompt, synthetic_prompt_tokens = LlmInputs._create_synthetic_prompt(
+        synthetic_prompt = LlmInputs._create_synthetic_prompt(
             default_tokenizer,
             LlmInputs.DEFAULT_PROMPT_TOKENS_MEAN,
             LlmInputs.DEFAULT_PROMPT_TOKENS_STDDEV,
@@ -278,7 +278,8 @@ class TestLlmInputs:
         )
 
         # 550 is the num of tokens returned for the default seed
-        assert synthetic_prompt_tokens == 550
+        token_length = len(default_tokenizer.encode(synthetic_prompt))
+        assert token_length == 550
 
         synthetic_prompt, synthetic_prompt_tokens = LlmInputs._create_synthetic_prompt(
             default_tokenizer,


### PR DESCRIPTION
The synthetic expected output tokens option helped provide a way for users to recommend an output token length to GenAi-Perf via prompt engineering. However, it did not guarantee a set number of expected output tokens will be generated.

Now that we are adding a way to precisely set the output token count mean and standard deviation, a user can always just set the output token mean to be the number of output tokens they want and the standard deviation to 0 for the same effect. As a result, we can remove the expected output tokens option to remove overlap and provide an option with increased accuracy.