### PR TITLE
Switch TRT-LLM to use min_length instead of ignore_eos

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -922,7 +922,7 @@ class LlmInputs:
             number_of_tokens = int(
                 random.gauss(output_tokens_mean, output_tokens_stddev)
             )
-            row["min_tokens"] = [number_of_tokens]
+            row["min_length"] = [number_of_tokens]
             row["max_tokens"] = [number_of_tokens]
         for key, value in extra_inputs.items():
             row[key] = [value]

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -919,10 +919,11 @@ class LlmInputs:
         if add_stream:
             row["stream"] = [True]
         if output_tokens_mean != LlmInputs.DEFAULT_OUTPUT_TOKENS_MEAN:
-            row["max_tokens"] = [
-                int(random.gauss(output_tokens_mean, output_tokens_stddev))
-            ]
-            row["ignore_eos"] = [True]
+            number_of_tokens = int(
+                random.gauss(output_tokens_mean, output_tokens_stddev)
+            )
+            row["min_tokens"] = [number_of_tokens]
+            row["max_tokens"] = [number_of_tokens]
         for key, value in extra_inputs.items():
             row[key] = [value]
 

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -506,11 +506,11 @@ class TestLlmInputs:
                     entry["max_tokens"][0] == output_tokens_mean
                 ), "max_tokens parameter is not properly set"
                 assert (
-                    "ignore_eos" in entry
-                ), "ignore_eos parameter is missing in llm_inputs.json"
+                    "min_length" in entry
+                ), "min_length parameter is missing in llm_inputs.json"
                 assert (
-                    entry["ignore_eos"][0] == True
-                ), "ignore_eos parameter is not properly set"
+                    entry["min_length"][0] == output_tokens_mean
+                ), "min_length parameter is not properly set"
             else:
                 assert False, f"Unsupported output format: {output_format}"
 


### PR DESCRIPTION
TRT-LLM does not support ignore_eos. Using min_length guarantees that the requested number of tokens is generated.