### PR TITLE
Use min_tokens instead of ignore_eos in vLLM for improved accuracy

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -886,10 +886,7 @@ class LlmInputs:
                 int(max(0, random.gauss(output_tokens_mean, output_tokens_stddev)))
             )
             sampling_parameters = {
-                # [TODO:TMA-1830] Once min_tokens is supported in the vLLM backend,
-                # switch from ignore_eos to min_tokens for improved accuracy.
-                # "min_tokens": number_of_tokens,
-                "ignore_eos": str(True),
+                "min_tokens": number_of_tokens,
                 "max_tokens": number_of_tokens,
             }
             sampling_parameters_str = json.dumps(sampling_parameters)

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -493,11 +493,11 @@ class TestLlmInputs:
                     output_tokens_mean
                 ), "max_tokens parameter is not properly set"
                 assert (
-                    "ignore_eos" in sampling_parameters
-                ), "ignore_eos parameter is missing in sampling_parameters"
-                assert sampling_parameters["ignore_eos"] == str(
-                    True
-                ), "ignore_eos parameter is not properly set"
+                    "min_tokens" in sampling_parameters
+                ), "min_tokens parameter is missing in sampling_parameters"
+                assert sampling_parameters["min_tokens"] == str(
+                    output_tokens_mean
+                ), "min_tokens parameter is not properly set"
             elif output_format == OutputFormat.TRTLLM:
                 assert (
                     "max_tokens" in entry


### PR DESCRIPTION
Now that [min_tokens](https://github.com/triton-inference-server/vllm_backend/pull/37) are supported in vLLM after the vLLM version [upgrade](https://github.com/triton-inference-server/vllm_backend/pull/38), switch to using them for more accurate token counts.