### PR TITLE
Adding concatenate_prompts option when creating openai completions

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -89,6 +89,7 @@ class LlmInputs:
         add_stream: bool = False,
         tokenizer: Tokenizer = get_tokenizer(DEFAULT_TOKENIZER),
         extra_inputs: Optional[Dict] = None,
+        concatenate_prompts: bool = True,
     ) -> Dict:
         """
         Given an input type, input format, and output type. Output a string of LLM Inputs
@@ -121,6 +122,8 @@ class LlmInputs:
             The mean length of the output to generate. If not using fixed output lengths, this should be set to -1.
         output_tokens_stddev:
             The standard deviation of the length of the output to generate. This is only used if output_tokens_mean is provided.
+        concatenate_prompts:
+            If true, create a single prompt string. Else, create a list of prompt strings
 
         Required Synthetic Prompt Generation Parameters
         -----------------------------------------------
@@ -178,6 +181,7 @@ class LlmInputs:
             output_tokens_mean,
             output_tokens_stddev,
             model_name,
+            concatenate_prompts,
         )
         cls._write_json_to_file(json_in_pa_format)
 
@@ -320,6 +324,7 @@ class LlmInputs:
         output_tokens_mean: int,
         output_tokens_stddev: int,
         model_name: str = "",
+        concatenate_prompts: bool = True,
     ) -> Dict:
         if output_format == OutputFormat.OPENAI_CHAT_COMPLETIONS:
             output_json = cls._convert_generic_json_to_openai_chat_completions_format(
@@ -340,6 +345,7 @@ class LlmInputs:
                 output_tokens_mean,
                 output_tokens_stddev,
                 model_name,
+                concatenate_prompts,
             )
         elif output_format == OutputFormat.VLLM:
             output_json = cls._convert_generic_json_to_vllm_format(
@@ -409,6 +415,7 @@ class LlmInputs:
         output_tokens_mean: int,
         output_tokens_stddev: int,
         model_name: str = "",
+        concatenate_prompts: bool = True,
     ) -> Dict:
         (
             system_role_headers,
@@ -426,6 +433,7 @@ class LlmInputs:
             output_tokens_mean,
             output_tokens_stddev,
             model_name,
+            concatenate_prompts,
         )
 
         return pa_json
@@ -580,6 +588,7 @@ class LlmInputs:
         output_tokens_mean: int,
         output_tokens_stddev: int,
         model_name: str = "",
+        concatenate_prompts: bool = True,
     ) -> Dict:
         pa_json = cls._create_empty_openai_pa_json()
 
@@ -596,7 +605,9 @@ class LlmInputs:
                     content,
                 )
 
-                pa_json = cls._add_new_prompt_to_json(pa_json, index, new_prompt)
+                pa_json = cls._add_new_prompt_to_json(
+                    pa_json, index, new_prompt, concatenate_prompts
+                )
 
             pa_json = cls._add_optional_tags_to_openai_json(
                 pa_json,
@@ -818,15 +829,26 @@ class LlmInputs:
 
     @classmethod
     def _add_new_prompt_to_json(
-        cls, pa_json: Dict, index: int, new_prompt: str
+        cls,
+        pa_json: Dict,
+        index: int,
+        new_prompt: str,
+        concatenate_prompts: bool = True,
     ) -> Dict:
         if new_prompt:
             if pa_json["data"][index]["payload"][0]["prompt"][0]:
-                pa_json["data"][index]["payload"][0]["prompt"][0] = (
-                    pa_json["data"][index]["payload"][0]["prompt"][0] + f" {new_prompt}"
-                )
+                if concatenate_prompts:
+                    pa_json["data"][index]["payload"][0]["prompt"][0] = (
+                        pa_json["data"][index]["payload"][0]["prompt"][0]
+                        + f" {new_prompt}"
+                    )
+                else:
+                    pa_json["data"][index]["payload"][0]["prompt"][0].append(new_prompt)
             else:
-                pa_json["data"][index]["payload"][0]["prompt"][0] = new_prompt
+                if concatenate_prompts:
+                    pa_json["data"][index]["payload"][0]["prompt"][0] = new_prompt
+                else:
+                    pa_json["data"][index]["payload"][0]["prompt"][0] = [new_prompt]
 
         return pa_json
 

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -242,7 +242,6 @@ class TestLlmInputs:
             dataset_name=OPEN_ORCA,
             add_model_name=False,
             add_stream=True,
-            concatenate_prompts=False,
         )
 
         os.remove(DEFAULT_INPUT_DATA_JSON)

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -242,6 +242,7 @@ class TestLlmInputs:
             dataset_name=OPEN_ORCA,
             add_model_name=False,
             add_stream=True,
+            concatenate_prompts=False,
         )
 
         os.remove(DEFAULT_INPUT_DATA_JSON)

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -248,6 +248,7 @@ class TestLlmInputs:
 
         assert pa_json is not None
         assert len(pa_json["data"]) == LlmInputs.DEFAULT_LENGTH
+        assert isinstance(pa_json["data"][0]["payload"][0]["prompt"], str)
 
     def test_create_openai_to_trtllm(self):
         """


### PR DESCRIPTION
Added a new option that will allow adds an option to either concatenate all prompts into a single string, or create a list of prompt strings.

