### PR TITLE
Construct PA command as a list of strings

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -852,9 +852,7 @@ class LlmInputs:
             row["max_tokens"] = int(
                 random.gauss(output_tokens_mean, output_tokens_stddev)
             )
-            # TODO: undo comment before merge. Official fix will come from the
-            # dyas-output-tokens branch.
-            # row["ignore_eos"] = True
+            row["ignore_eos"] = True
         for key, value in extra_inputs.items():
             row[key] = value
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -852,7 +852,9 @@ class LlmInputs:
             row["max_tokens"] = int(
                 random.gauss(output_tokens_mean, output_tokens_stddev)
             )
-            row["ignore_eos"] = True
+            # TODO: undo comment before merge. Official fix will come from the
+            # dyas-output-tokens branch.
+            # row["ignore_eos"] = True
         for key, value in extra_inputs.items():
             row[key] = value
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -37,15 +37,15 @@ logger = logging.getLogger(LOGGER_NAME)
 class Profiler:
     @staticmethod
     def add_protocol_args(args):
-        cmd = ""
+        cmd = [""]
         if args.service_kind == "triton":
-            cmd += f"-i grpc --streaming "
+            cmd += ["-i", "grpc", "--streaming"]
             if "u" not in vars(args).keys():
-                cmd += f"-u {DEFAULT_GRPC_URL} "
+                cmd += ["-u", f"{DEFAULT_GRPC_URL}"]
             if args.output_format == OutputFormat.TRTLLM:
-                cmd += f"--shape max_tokens:1 --shape text_input:1 "
+                cmd += ["--shape", "max_tokens:1", "--shape", "text_input:1"]
         elif args.service_kind == "openai":
-            cmd += f"-i http "
+            cmd += ["-i", "http"]
         return cmd
 
     @staticmethod
@@ -76,7 +76,14 @@ class Profiler:
 
         utils.remove_file(args.profile_export_file)
 
-        cmd = f"perf_analyzer -m {args.model} --async --input-data {DEFAULT_INPUT_DATA_JSON} "
+        cmd = [
+            f"perf_analyzer",
+            "-m",
+            f"{args.model}",
+            "--async",
+            "--input-data",
+            f"{DEFAULT_INPUT_DATA_JSON}",
+        ]
         for arg, value in vars(args).items():
             if arg in skip_args:
                 pass
@@ -84,28 +91,28 @@ class Profiler:
                 pass
             elif value is True:
                 if len(arg) == 1:
-                    cmd += f"-{arg} "
+                    cmd += [f"-{arg}"]
                 else:
-                    cmd += f"--{arg} "
+                    cmd += [f"--{arg}"]
             else:
                 if len(arg) == 1:
-                    cmd += f"-{arg} {value} "
+                    cmd += [f"-{arg}", f"{value}"]
                 else:
                     arg = utils.convert_option_name(arg)
-                    cmd += f"--{arg} {value} "
+                    cmd += [f"--{arg}", f"{value}"]
 
         cmd += Profiler.add_protocol_args(args)
 
         if extra_args is not None:
             for arg in extra_args:
-                cmd += f"{arg} "
+                cmd += [f"{arg}"]
         return cmd
 
     @staticmethod
     def run(args=None, extra_args=None):
         cmd = Profiler.build_cmd(args, extra_args)
-        logger.info(f"Running Perf Analyzer : '{cmd}'")
+        logger.info(f"Running Perf Analyzer : '{' '.join(cmd)}'")
         if args and args.verbose:
-            subprocess.run(cmd, shell=True, check=True, stdout=None)
+            subprocess.run(cmd, check=True, stdout=None)
         else:
-            subprocess.run(cmd, shell=True, check=True, stdout=subprocess.DEVNULL)
+            subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL)

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -78,11 +78,11 @@ class Profiler:
         utils.remove_file(args.profile_export_file)
 
         cmd = [
-            "perf_analyzer",
-            "-m",
+            f"perf_analyzer",
+            f"-m",
             f"{args.model}",
-            "--async",
-            "--input-data",
+            f"--async",
+            f"--input-data",
             f"{DEFAULT_INPUT_DATA_JSON}",
         ]
         for arg, value in vars(args).items():

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -78,7 +78,7 @@ class Profiler:
         utils.remove_file(args.profile_export_file)
 
         cmd = [
-            f"perf_analyzer",
+            "perf_analyzer",
             "-m",
             f"{args.model}",
             "--async",

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -26,6 +26,7 @@
 
 import logging
 import subprocess
+from argparse import Namespace
 
 import genai_perf.utils as utils
 from genai_perf.constants import DEFAULT_GRPC_URL, DEFAULT_INPUT_DATA_JSON, LOGGER_NAME
@@ -36,7 +37,7 @@ logger = logging.getLogger(LOGGER_NAME)
 
 class Profiler:
     @staticmethod
-    def add_protocol_args(args):
+    def add_protocol_args(args: Namespace):
         cmd = [""]
         if args.service_kind == "triton":
             cmd += ["-i", "grpc", "--streaming"]
@@ -49,7 +50,7 @@ class Profiler:
         return cmd
 
     @staticmethod
-    def build_cmd(args, extra_args):
+    def build_cmd(args: Namespace, extra_args: list[str] | None = None) -> list[str]:
         skip_args = [
             "func",
             "input_dataset",
@@ -109,7 +110,7 @@ class Profiler:
         return cmd
 
     @staticmethod
-    def run(args=None, extra_args=None):
+    def run(args: Namespace, extra_args: list[str] | None) -> None:
         cmd = Profiler.build_cmd(args, extra_args)
         logger.info(f"Running Perf Analyzer : '{' '.join(cmd)}'")
         if args and args.verbose:

--- a/src/c++/perf_analyzer/genai-perf/tests/test_wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_wrapper.py
@@ -46,7 +46,8 @@ class TestWrapper:
         args = ["genai-perf", "-m", "test_model", "--service-kind", "triton"] + arg
         monkeypatch.setattr("sys.argv", args)
         args, extra_args = parser.parse_args()
-        cmd_string = Profiler.build_cmd(args, extra_args)
+        cmd = Profiler.build_cmd(args, extra_args)
+        cmd_string = " ".join(cmd)
 
         number_of_url_args = cmd_string.count(" -u ") + cmd_string.count(" --url ")
         assert number_of_url_args == 1
@@ -62,7 +63,8 @@ class TestWrapper:
         args = ["genai-perf", "-m", "test_model", "--service-kind", "triton"] + arg
         monkeypatch.setattr("sys.argv", args)
         args, extra_args = parser.parse_args()
-        cmd_string = Profiler.build_cmd(args, extra_args)
+        cmd = Profiler.build_cmd(args, extra_args)
+        cmd_string = " ".join(cmd)
 
         # Ensure the correct arguments are appended.
         assert cmd_string.count(" -i grpc") == 1
@@ -89,7 +91,8 @@ class TestWrapper:
         ] + arg
         monkeypatch.setattr("sys.argv", args)
         args, extra_args = parser.parse_args()
-        cmd_string = Profiler.build_cmd(args, extra_args)
+        cmd = Profiler.build_cmd(args, extra_args)
+        cmd_string = " ".join(cmd)
 
         # Ensure the correct arguments are appended.
         assert cmd_string.count(" -i http") == 1


### PR DESCRIPTION
Constructing a single command string to run PA becomes problem when one of the args is a string that contains a space. This causes the string content after the space to be missing from the final string. To avoid this problem, we can collect each args as a list of strings and pass that as an arg to subprocess call to run PA.