### PR TITLE
Make request output determinism optional

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/README.md
+++ b/src/c++/perf_analyzer/genai-perf/README.md
@@ -138,6 +138,9 @@ options:
 
 For any dataset, you can specify the following options:
 * `--output-tokens-mean`: The mean number of tokens to request from the model.
+* `--output-tokens-mean-deterministic`: If an output token mean is supplied,
+this will make the token count distribution set the max and min lengths equal.
+This is supported for the Triton service-kind.
 * `--output-tokens-stddev`: The standard deviation of the number of tokens to
 request from the model. input data.
 
@@ -198,6 +201,12 @@ The standard deviation of the number of tokens of synthetic input data.
 ##### `--output-tokens-mean <int>`
 
 The mean of the number of output tokens to request from the model.
+
+##### `--output-tokens-mean-deterministic`
+
+Sets the output token distribution to add a minimum token length input
+(in addition to the maximum token length) to more deterministically
+request the number of output tokens from the model.
 
 ##### `--output-tokens-stddev <int>`
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -81,6 +81,7 @@ class LlmInputs:
         length: int = DEFAULT_LENGTH,
         output_tokens_mean: int = DEFAULT_OUTPUT_TOKENS_MEAN,
         output_tokens_stddev: int = DEFAULT_OUTPUT_TOKENS_STDDEV,
+        output_tokens_deterministic: bool = False,
         prompt_tokens_mean: int = DEFAULT_PROMPT_TOKENS_MEAN,
         prompt_tokens_stddev: int = DEFAULT_PROMPT_TOKENS_STDDEV,
         random_seed: int = DEFAULT_RANDOM_SEED,
@@ -121,6 +122,8 @@ class LlmInputs:
             The mean length of the output to generate. If not using fixed output lengths, this should be set to -1.
         output_tokens_stddev:
             The standard deviation of the length of the output to generate. This is only used if output_tokens_mean is provided.
+        output_tokens_deterministic:
+            If true, the output tokens will set the minimum and maximum tokens to be equivalent.
 
         Required Synthetic Prompt Generation Parameters
         -----------------------------------------------
@@ -177,6 +180,7 @@ class LlmInputs:
             extra_inputs,
             output_tokens_mean,
             output_tokens_stddev,
+            output_tokens_deterministic,
             model_name,
         )
         cls._write_json_to_file(json_in_pa_format)
@@ -319,6 +323,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         if output_format == OutputFormat.OPENAI_CHAT_COMPLETIONS:
@@ -329,6 +334,7 @@ class LlmInputs:
                 extra_inputs,
                 output_tokens_mean,
                 output_tokens_stddev,
+                output_tokens_deterministic,
                 model_name,
             )
         elif output_format == OutputFormat.OPENAI_COMPLETIONS:
@@ -339,6 +345,7 @@ class LlmInputs:
                 extra_inputs,
                 output_tokens_mean,
                 output_tokens_stddev,
+                output_tokens_deterministic,
                 model_name,
             )
         elif output_format == OutputFormat.VLLM:
@@ -349,6 +356,7 @@ class LlmInputs:
                 extra_inputs,
                 output_tokens_mean,
                 output_tokens_stddev,
+                output_tokens_deterministic,
                 model_name,
             )
         elif output_format == OutputFormat.TRTLLM:
@@ -359,6 +367,7 @@ class LlmInputs:
                 extra_inputs,
                 output_tokens_mean,
                 output_tokens_stddev,
+                output_tokens_deterministic,
                 model_name,
             )
         else:
@@ -377,6 +386,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         # TODO (TMA-1757): Implement a way to select a role for `text_input`
@@ -394,6 +404,7 @@ class LlmInputs:
             extra_inputs,
             output_tokens_mean,
             output_tokens_stddev,
+            output_tokens_deterministic,
             model_name,
         )
 
@@ -408,6 +419,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         (
@@ -425,6 +437,7 @@ class LlmInputs:
             extra_inputs,
             output_tokens_mean,
             output_tokens_stddev,
+            output_tokens_deterministic,
             model_name,
         )
 
@@ -439,6 +452,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         (
@@ -457,6 +471,7 @@ class LlmInputs:
             extra_inputs,
             output_tokens_mean,
             output_tokens_stddev,
+            output_tokens_deterministic,
             model_name,
         )
 
@@ -471,6 +486,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         (
@@ -489,6 +505,7 @@ class LlmInputs:
             extra_inputs,
             output_tokens_mean,
             output_tokens_stddev,
+            output_tokens_deterministic,
             model_name,
         )
 
@@ -539,6 +556,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         pa_json = cls._create_empty_openai_pa_json()
@@ -562,6 +580,7 @@ class LlmInputs:
                 extra_inputs,
                 output_tokens_mean,
                 output_tokens_stddev,
+                output_tokens_deterministic,
                 model_name,
             )
 
@@ -579,6 +598,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         pa_json = cls._create_empty_openai_pa_json()
@@ -606,6 +626,7 @@ class LlmInputs:
                 extra_inputs,
                 output_tokens_mean,
                 output_tokens_stddev,
+                output_tokens_deterministic,
                 model_name,
             )
 
@@ -623,6 +644,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         pa_json = cls._create_empty_vllm_pa_json()
@@ -651,6 +673,7 @@ class LlmInputs:
                 extra_inputs,
                 output_tokens_mean,
                 output_tokens_stddev,
+                output_tokens_deterministic,
                 model_name,
             )
 
@@ -668,6 +691,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         pa_json = cls._create_empty_trtllm_pa_json()
@@ -703,6 +727,7 @@ class LlmInputs:
                 extra_inputs,
                 output_tokens_mean,
                 output_tokens_stddev,
+                output_tokens_deterministic,
                 model_name,
             )
 
@@ -840,6 +865,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         row = pa_json["data"][index]["payload"][0]
@@ -851,7 +877,6 @@ class LlmInputs:
             row["max_tokens"] = int(
                 random.gauss(output_tokens_mean, output_tokens_stddev)
             )
-            row["ignore_eos"] = True
         for key, value in extra_inputs.items():
             row[key] = value
 
@@ -867,6 +892,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         row = pa_json["data"][index]
@@ -879,9 +905,10 @@ class LlmInputs:
                 int(max(0, random.gauss(output_tokens_mean, output_tokens_stddev)))
             )
             sampling_parameters = {
-                "min_tokens": number_of_tokens,
                 "max_tokens": number_of_tokens,
             }
+            if output_tokens_deterministic:
+                sampling_parameters["min_tokens"] = number_of_tokens
             sampling_parameters_str = json.dumps(sampling_parameters)
             row["sampling_parameters"] = [sampling_parameters_str]
         for key, value in extra_inputs.items():
@@ -901,6 +928,7 @@ class LlmInputs:
         extra_inputs: Dict,
         output_tokens_mean: int,
         output_tokens_stddev: int,
+        output_tokens_deterministic: bool,
         model_name: str = "",
     ) -> Dict:
         row = pa_json["data"][index]
@@ -912,7 +940,8 @@ class LlmInputs:
             number_of_tokens = int(
                 random.gauss(output_tokens_mean, output_tokens_stddev)
             )
-            row["min_length"] = [number_of_tokens]
+            if output_tokens_deterministic:
+                row["min_length"] = [number_of_tokens]
             row["max_tokens"] = [number_of_tokens]
         for key, value in extra_inputs.items():
             row[key] = [value]

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -72,6 +72,7 @@ def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:
         prompt_tokens_stddev=args.synthetic_input_tokens_stddev,
         output_tokens_mean=args.output_tokens_mean,
         output_tokens_stddev=args.output_tokens_stddev,
+        output_tokens_deterministic=args.output_tokens_mean_deterministic,
         random_seed=args.random_seed,
         num_of_output_prompts=args.num_prompts,
         add_model_name=add_model_name,

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -68,6 +68,7 @@ class Profiler:
             "synthetic_input_tokens_stddev",
             "output_tokens_mean",
             "output_tokens_stddev",
+            "output_tokens_mean_deterministic",
             "num_prompts",
             "random_seed",
             "tokenizer",

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -108,6 +108,10 @@ class TestCLIArguments:
                 {"output_tokens_stddev": 7},
             ),
             (
+                ["--output-tokens-mean", "6", "--output-tokens-mean-deterministic"],
+                {"output_tokens_mean_deterministic": True},
+            ),
+            (
                 ["--prompt-source", "synthetic"],
                 {"prompt_source": utils.get_enum_entry("synthetic", PromptSource)},
             ),
@@ -221,6 +225,39 @@ class TestCLIArguments:
             (
                 ["genai-perf", "-m", "test_model", "--output-tokens-stddev", "5"],
                 "The --output-tokens-mean option is required when using --output-tokens-stddev.",
+            ),
+            (
+                [
+                    "genai-perf",
+                    "-m",
+                    "test_model",
+                    "--output-tokens-mean-deterministic",
+                ],
+                "The --output-tokens-mean option is required when using --output-tokens-mean-deterministic.",
+            ),
+            (
+                [
+                    "genai-perf",
+                    "-m",
+                    "test_model",
+                    "--output-tokens-mean-deterministic",
+                ],
+                "The --output-tokens-mean option is required when using --output-tokens-mean-deterministic.",
+            ),
+            (
+                [
+                    "genai-perf",
+                    "-m",
+                    "test_model",
+                    "--service-kind",
+                    "openai",
+                    "--endpoint",
+                    "v1/chat/completions",
+                    "--output-tokens-mean",
+                    "100",
+                    "--output-tokens-mean-deterministic",
+                ],
+                "The --output-tokens-mean-deterministic option is only supported with the Triton service-kind",
             ),
         ],
     )

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -175,6 +175,7 @@ class TestLlmInputs:
             extra_inputs={},
             output_tokens_mean=LlmInputs.DEFAULT_OUTPUT_TOKENS_MEAN,
             output_tokens_stddev=LlmInputs.DEFAULT_OUTPUT_TOKENS_STDDEV,
+            output_tokens_deterministic=False,
         )
 
         assert pa_json is not None

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -439,77 +439,73 @@ class TestLlmInputs:
         "output_format", [format[2] for format in SERVICE_KIND_BACKEND_ENDPOINT_FORMATS]
     )
     def test_output_tokens_mean(self, output_format, default_tokenizer):
+        if output_format != OutputFormat.VLLM and output_format != OutputFormat.TRTLLM:
+            return
+
         output_tokens_mean = 100
         output_tokens_stddev = 0
+        for deterministic in [True, False]:
+            _ = LlmInputs.create_llm_inputs(
+                input_type=PromptSource.SYNTHETIC,
+                output_format=output_format,
+                num_of_output_prompts=5,
+                add_model_name=False,
+                add_stream=True,
+                tokenizer=default_tokenizer,
+                output_tokens_mean=output_tokens_mean,
+                output_tokens_stddev=output_tokens_stddev,
+                output_tokens_deterministic=deterministic,
+            )
 
-        _ = LlmInputs.create_llm_inputs(
-            input_type=PromptSource.SYNTHETIC,
-            output_format=output_format,
-            num_of_output_prompts=5,
-            add_model_name=False,
-            add_stream=True,
-            tokenizer=default_tokenizer,
-            output_tokens_mean=output_tokens_mean,
-            output_tokens_stddev=output_tokens_stddev,
-        )
+            assert os.path.exists(
+                DEFAULT_INPUT_DATA_JSON
+            ), "llm_inputs.json file is not created"
 
-        assert os.path.exists(
-            DEFAULT_INPUT_DATA_JSON
-        ), "llm_inputs.json file is not created"
+            with open(DEFAULT_INPUT_DATA_JSON, "r") as f:
+                llm_inputs_data = json.load(f)
 
-        with open(DEFAULT_INPUT_DATA_JSON, "r") as f:
-            llm_inputs_data = json.load(f)
+            for entry in llm_inputs_data["data"]:
+                if output_format == OutputFormat.VLLM:
+                    assert (
+                        "sampling_parameters" in entry
+                    ), "sampling_parameters is missing in llm_inputs.json"
+                    sampling_parameters = json.loads(entry["sampling_parameters"][0])
+                    assert (
+                        "max_tokens" in sampling_parameters
+                    ), "max_tokens parameter is missing in sampling_parameters"
+                    assert sampling_parameters["max_tokens"] == str(
+                        output_tokens_mean
+                    ), "max_tokens parameter is not properly set"
+                    if deterministic:
+                        assert (
+                            "min_tokens" in sampling_parameters
+                        ), "min_tokens parameter is missing in sampling_parameters"
+                        assert sampling_parameters["min_tokens"] == str(
+                            output_tokens_mean
+                        ), "min_tokens parameter is not properly set"
+                    else:
+                        assert (
+                            "min_tokens" not in sampling_parameters
+                        ), "min_tokens parameter is present in sampling_parameters"
+                elif output_format == OutputFormat.TRTLLM:
+                    assert (
+                        "max_tokens" in entry
+                    ), "max_tokens parameter is missing in llm_inputs.json"
+                    assert (
+                        entry["max_tokens"][0] == output_tokens_mean
+                    ), "max_tokens parameter is not properly set"
+                    if deterministic:
+                        assert (
+                            "min_length" in entry
+                        ), "min_length parameter is missing in llm_inputs.json"
+                        assert (
+                            entry["min_length"][0] == output_tokens_mean
+                        ), "min_length parameter is not properly set"
+                    else:
+                        assert (
+                            "min_length" not in entry
+                        ), "min_length parameter is present in llm_inputs.json"
+                else:
+                    assert False, f"Unsupported output format: {output_format}"
 
-        for entry in llm_inputs_data["data"]:
-            if (
-                output_format == OutputFormat.OPENAI_COMPLETIONS
-                or output_format == OutputFormat.OPENAI_CHAT_COMPLETIONS
-            ):
-                assert "payload" in entry, "payload is missing in llm_inputs.json"
-                payload = entry["payload"][0]
-                assert (
-                    "max_tokens" in payload
-                ), "max_tokens parameter is missing in llm_inputs.json"
-                assert (
-                    payload["max_tokens"] == output_tokens_mean
-                ), "max_tokens parameter is not properly set"
-                assert (
-                    "ignore_eos" in payload
-                ), "ignore_eos parameter is missing in llm_inputs.json"
-                assert (
-                    payload["ignore_eos"] == True
-                ), "ignore_eos parameter is not properly set"
-            elif output_format == OutputFormat.VLLM:
-                assert (
-                    "sampling_parameters" in entry
-                ), "sampling_parameters is missing in llm_inputs.json"
-                sampling_parameters = json.loads(entry["sampling_parameters"][0])
-                assert (
-                    "max_tokens" in sampling_parameters
-                ), "max_tokens parameter is missing in sampling_parameters"
-                assert sampling_parameters["max_tokens"] == str(
-                    output_tokens_mean
-                ), "max_tokens parameter is not properly set"
-                assert (
-                    "min_tokens" in sampling_parameters
-                ), "min_tokens parameter is missing in sampling_parameters"
-                assert sampling_parameters["min_tokens"] == str(
-                    output_tokens_mean
-                ), "min_tokens parameter is not properly set"
-            elif output_format == OutputFormat.TRTLLM:
-                assert (
-                    "max_tokens" in entry
-                ), "max_tokens parameter is missing in llm_inputs.json"
-                assert (
-                    entry["max_tokens"][0] == output_tokens_mean
-                ), "max_tokens parameter is not properly set"
-                assert (
-                    "min_length" in entry
-                ), "min_length parameter is missing in llm_inputs.json"
-                assert (
-                    entry["min_length"][0] == output_tokens_mean
-                ), "min_length parameter is not properly set"
-            else:
-                assert False, f"Unsupported output format: {output_format}"
-
-        os.remove(DEFAULT_INPUT_DATA_JSON)
+            os.remove(DEFAULT_INPUT_DATA_JSON)


### PR DESCRIPTION
Create a parameter to allow users to request a minimum number of tokens for an expected output distribution. This is currently only supported in vLLM and TRT-LLM.