### PR TITLE
Update .gitignore to include GenAI-Perf artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ __pycache__/
 
 #Other
 node_modules
+
+#GenAI-Perf Artifacts
+artifacts/


### PR DESCRIPTION
Quick fix to update gitignore, I often accidentally include these output directories/files when committing