### PR TITLE
Print PerfAnalyzerException message on exit

### DIFF
--- a/src/c++/perf_analyzer/main.cc
+++ b/src/c++/perf_analyzer/main.cc
@@ -40,6 +40,7 @@ main(int argc, char* argv[])
     analyzer.Run();
   }
   catch (pa::PerfAnalyzerException& e) {
+    std::cerr << e.what() << std::endl;
     return e.GetError();
   }
 


### PR DESCRIPTION
For some reason this was missing making it much more difficult to understand why a non-zero exit code was given for cases where a PerfAnalyzerException is thrown with a message supplied in the constructor.

Tested manually and it works.