### PR TITLE
Fixed file path for plot generation

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -47,11 +47,10 @@ def init_logging() -> None:
 
 
 def create_artifacts_dirs(generate_plots: bool) -> None:
-    if not os.path.exists("artifacts"):
+    if not os.path.exists(f"{DEFAULT_ARTIFACT_DIR}"):
         os.mkdir(f"{DEFAULT_ARTIFACT_DIR}")
         os.mkdir(f"{DEFAULT_ARTIFACT_DIR}/data")
-        if generate_plots:
-            os.mkdir(f"{DEFAULT_ARTIFACT_DIR}/plots")
+        os.mkdir(f"{DEFAULT_ARTIFACT_DIR}/plots")
 
 
 def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/plots/base_plot.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/plots/base_plot.py
@@ -71,10 +71,10 @@ class BasePlot:
     def _generate_graph_file(self, fig: Figure, file: str, title: str) -> None:
         if file.endswith("jpeg"):
             print(f"Generating '{title}' jpeg")
-            fig.write_image(f"{DEFAULT_ARTIFACT_DIR}/images/{file}")
+            fig.write_image(f"{DEFAULT_ARTIFACT_DIR}/plots/{file}")
         elif file.endswith("html"):
             print(f"Generating '{title}' html")
-            fig.write_html(f"{DEFAULT_ARTIFACT_DIR}/images/{file}")
+            fig.write_html(f"{DEFAULT_ARTIFACT_DIR}/plots/{file}")
         else:
             extension = file.split(".")[-1]
             raise GenAIPerfException(f"image file type {extension} is not supported")


### PR DESCRIPTION
Fixed a rename that was missed
Updated the artifact directory check to remove an edge case where the artifact directory is already created but the plots subdirectory was not. Now all directories are created but plots are only generated when the flag is given.