### PR TITLE
Fix input token calculation

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -464,12 +464,6 @@ class LLMProfileDataParser(ProfileDataParser):
         tokenizer: Tokenizer,
     ) -> None:
         self._tokenizer = tokenizer
-        # Disable add_bos_token so that llama tokenizer does not add bos token
-        # (aka. beginning-of-sentence) to the beginning of every response
-        # outputs, increasing the token count by 1 for each output response.
-        # Note: The type is being ignored here, because not all tokenizers have
-        # an add_bos_token variable.
-        self._tokenizer.add_bos_token = False  # type: ignore
         self._service_kind = service_kind
         self._output_format = output_format
         super().__init__(filename)

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -587,7 +587,7 @@ class LLMProfileDataParser(ProfileDataParser):
         if self._output_format == _OPENAI_CHAT_COMPLETIONS:
             input_text = payload["messages"][0]["content"]
         elif self._output_format == _OPENAI_COMPLETIONS:
-            input_text = payload["prompt"][0]
+            input_text = payload["prompt"]
         else:
             raise ValueError(
                 "Failed to parse OpenAI request input in profile export file."

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/tokenizer.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/tokenizer.py
@@ -46,4 +46,11 @@ def get_tokenizer(
     except Exception as e:
         raise GenAIPerfException(e)
 
+    # Disable add_bos_token so that llama tokenizer does not add bos token
+    # (aka. beginning-of-sentence) to the beginning of every response
+    # outputs, increasing the token count by 1 for each output response.
+    # Note: The type is being ignored here, because not all tokenizers have
+    # an add_bos_token variable.
+    tokenizer.add_bos_token = False  # type: ignore
+
     return tokenizer

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
@@ -90,7 +90,7 @@ class TestLLMProfileDataParser:
         printed in csv.
         """
 
-        tokenizer = AutoTokenizer.from_pretrained(DEFAULT_TOKENIZER)
+        tokenizer = self.get_tokenizer()
         pd = LLMProfileDataParser(
             filename="triton_profile_export.json",
             service_kind="triton",
@@ -145,7 +145,7 @@ class TestLLMProfileDataParser:
             - experiment 1: [3, 4]
             - experiment 2: [3, 4]
         """
-        tokenizer = AutoTokenizer.from_pretrained(DEFAULT_TOKENIZER)
+        tokenizer = self.get_tokenizer()
         pd = LLMProfileDataParser(
             filename="triton_profile_export.json",
             service_kind="triton",
@@ -288,7 +288,7 @@ class TestLLMProfileDataParser:
         * num input tokens
             - experiment 1: [3, 4]
         """
-        tokenizer = AutoTokenizer.from_pretrained(DEFAULT_TOKENIZER)
+        tokenizer = self.get_tokenizer()
         pd = LLMProfileDataParser(
             filename="openai_profile_export.json",
             service_kind="openai",
@@ -378,6 +378,11 @@ class TestLLMProfileDataParser:
         assert metrics.get_base_name("num_input_tokens") == "num_input_token"
         with pytest.raises(KeyError):
             metrics.get_base_name("hello1234")
+
+    def get_tokenizer(self):
+        tokenizer = AutoTokenizer.from_pretrained(DEFAULT_TOKENIZER)
+        tokenizer.add_bos_token = False  # type: ignore
+        return tokenizer
 
     openai_profile_data = {
         "experiments": [


### PR DESCRIPTION
Before this fix, running openai completions endpoint was always reporting 1 for input tokens.
After a partial fix, it was always off by 1
With both fixes combined in this PR, the reported input tokens is now correct.