### PR TITLE
Add more metadata to profile export JSON file

### DIFF
--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -452,7 +452,7 @@ PerfAnalyzer::GenerateProfileExport()
   if (!params_->profile_export_file.empty()) {
     exporter_->Export(
         collector_->GetData(), collector_->GetVersion(),
-        params_->profile_export_file);
+        params_->profile_export_file, params_->kind, params_->endpoint);
   }
 }
 

--- a/src/c++/perf_analyzer/profile_data_exporter.cc
+++ b/src/c++/perf_analyzer/profile_data_exporter.cc
@@ -270,9 +270,10 @@ ProfileDataExporter::AddServiceKind(cb::BackendKind& kind)
   }
 
   rapidjson::Value service_kind;
-  service_kind = rapidjson::StringRef(raw_service_kind.c_str());
+  service_kind.SetString(raw_service_kind.c_str(), document_.GetAllocator());
   document_.AddMember("service_kind", service_kind, document_.GetAllocator());
 }
+
 void
 ProfileDataExporter::AddEndpoint(std::string& raw_endpoint)
 {

--- a/src/c++/perf_analyzer/profile_data_exporter.h
+++ b/src/c++/perf_analyzer/profile_data_exporter.h
@@ -49,9 +49,12 @@ class ProfileDataExporter {
   /// @param raw_version String containing the version number for the json
   /// output
   /// @param file_path File path to export profile data to.
+  /// @param service_kind Service that Perf Analyzer generates load for.
+  /// @param endpoint Endpoint to send the requests.
   void Export(
       const std::vector<Experiment>& raw_experiments, std::string& raw_version,
-      std::string& file_path);
+      std::string& file_path, cb::BackendKind& service_kind,
+      std::string& endpoint);
 
  private:
   ProfileDataExporter() = default;
@@ -60,8 +63,11 @@ class ProfileDataExporter {
   /// analyzer
   /// @param raw_version String containing the version number for the json
   /// output
+  /// @param service_kind Service that Perf Analyzer generates load for.
+  /// @param endpoint Endpoint to send the requests.
   virtual void ConvertToJson(
-      const std::vector<Experiment>& raw_experiments, std::string& raw_version);
+      const std::vector<Experiment>& raw_experiments, std::string& raw_version,
+      cb::BackendKind& service_kind, std::string& endpoint);
   virtual void OutputToFile(std::string& file_path);
   virtual void AddExperiment(
       rapidjson::Value& entry, rapidjson::Value& experiment,
@@ -83,6 +89,8 @@ class ProfileDataExporter {
       rapidjson::Value& entry, rapidjson::Value& window_boundaries,
       const Experiment& raw_experiment);
   void AddVersion(std::string& raw_version);
+  void AddServiceKind(cb::BackendKind& service_kind);
+  void AddEndpoint(std::string& endpoint);
   void ClearDocument();
 
   rapidjson::Document document_{};

--- a/src/c++/perf_analyzer/test_profile_data_exporter.cc
+++ b/src/c++/perf_analyzer/test_profile_data_exporter.cc
@@ -253,75 +253,46 @@ TEST_CASE("profile_data_exporter: AddServiceKind")
   MockProfileDataExporter exporter{};
   exporter.ClearDocument();
 
+  cb::BackendKind service_kind;
+  std::string json{""};
+
   SUBCASE("Backend kind: TRITON")
   {
-    cb::BackendKind service_kind = cb::BackendKind::TRITON;
-    exporter.AddServiceKind(service_kind);
-
-    std::string json{R"({ "service_kind": "triton" })"};
-    rapidjson::Document expected_document;
-    expected_document.Parse(json.c_str());
-
-    const rapidjson::Value& expected_kind{expected_document["service_kind"]};
-    const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
-    CHECK(actual_kind == expected_kind);
+    service_kind = cb::BackendKind::TRITON;
+    json = R"({ "service_kind": "triton" })";
   }
 
   SUBCASE("Backend kind: TENSORFLOW_SERVING")
   {
-    cb::BackendKind service_kind = cb::BackendKind::TENSORFLOW_SERVING;
-    exporter.AddServiceKind(service_kind);
-
-    std::string json{R"({ "service_kind": "tfserving" })"};
-    rapidjson::Document expected_document;
-    expected_document.Parse(json.c_str());
-
-    const rapidjson::Value& expected_kind{expected_document["service_kind"]};
-    const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
-    CHECK(actual_kind == expected_kind);
+    service_kind = cb::BackendKind::TENSORFLOW_SERVING;
+    json = R"({ "service_kind": "tfserving" })";
   }
 
   SUBCASE("Backend kind: TORCHSERVE")
   {
-    cb::BackendKind service_kind = cb::BackendKind::TORCHSERVE;
-    exporter.AddServiceKind(service_kind);
-
-    std::string json{R"({ "service_kind": "torchserve" })"};
-    rapidjson::Document expected_document;
-    expected_document.Parse(json.c_str());
-
-    const rapidjson::Value& expected_kind{expected_document["service_kind"]};
-    const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
-    CHECK(actual_kind == expected_kind);
+    service_kind = cb::BackendKind::TORCHSERVE;
+    json = R"({ "service_kind": "torchserve" })";
   }
 
   SUBCASE("Backend kind: TRITON_C_API")
   {
-    cb::BackendKind service_kind = cb::BackendKind::TRITON_C_API;
-    exporter.AddServiceKind(service_kind);
-
-    std::string json{R"({ "service_kind": "triton_c_api" })"};
-    rapidjson::Document expected_document;
-    expected_document.Parse(json.c_str());
-
-    const rapidjson::Value& expected_kind{expected_document["service_kind"]};
-    const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
-    CHECK(actual_kind == expected_kind);
+    service_kind = cb::BackendKind::TRITON_C_API;
+    json = R"({ "service_kind": "triton_c_api" })";
   }
 
   SUBCASE("Backend kind: OPENAI")
   {
-    cb::BackendKind service_kind = cb::BackendKind::OPENAI;
-    exporter.AddServiceKind(service_kind);
-
-    std::string json{R"({ "service_kind": "openai" })"};
-    rapidjson::Document expected_document;
-    expected_document.Parse(json.c_str());
-
-    const rapidjson::Value& expected_kind{expected_document["service_kind"]};
-    const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
-    CHECK(actual_kind == expected_kind);
+    service_kind = cb::BackendKind::OPENAI;
+    json = R"({ "service_kind": "openai" })";
   }
+
+  exporter.AddServiceKind(service_kind);
+  rapidjson::Document expected_document;
+  expected_document.Parse(json.c_str());
+
+  const rapidjson::Value& expected_kind{expected_document["service_kind"]};
+  const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
+  CHECK(actual_kind == expected_kind);
 }
 
 TEST_CASE("profile_data_exporter: AddEndpoint")
@@ -329,33 +300,28 @@ TEST_CASE("profile_data_exporter: AddEndpoint")
   MockProfileDataExporter exporter{};
   exporter.ClearDocument();
 
+  std::string endpoint{""};
+  std::string json{""};
+
   SUBCASE("Endpoint: OpenAI Chat Completions")
   {
-    std::string endpoint{"v1/chat/completions"};
-    exporter.AddEndpoint(endpoint);
-
-    std::string json{R"({ "endpoint": "v1/chat/completions" })"};
-    rapidjson::Document expected_document;
-    expected_document.Parse(json.c_str());
-
-    const rapidjson::Value& expected_endpoint{expected_document["endpoint"]};
-    const rapidjson::Value& actual_endpoint{exporter.document_["endpoint"]};
-    CHECK(actual_endpoint == expected_endpoint);
+    endpoint = "v1/chat/completions";
+    json = R"({ "endpoint": "v1/chat/completions" })";
   }
 
   SUBCASE("Endpoint: OpenAI Completions")
   {
-    std::string endpoint{"v1/completions"};
-    exporter.AddEndpoint(endpoint);
-
-    std::string json{R"({ "endpoint": "v1/completions" })"};
-    rapidjson::Document expected_document;
-    expected_document.Parse(json.c_str());
-
-    const rapidjson::Value& expected_endpoint{expected_document["endpoint"]};
-    const rapidjson::Value& actual_endpoint{exporter.document_["endpoint"]};
-    CHECK(actual_endpoint == expected_endpoint);
+    endpoint = "v1/completions";
+    json = R"({ "endpoint": "v1/completions" })";
   }
+
+  exporter.AddEndpoint(endpoint);
+  rapidjson::Document expected_document;
+  expected_document.Parse(json.c_str());
+
+  const rapidjson::Value& expected_endpoint{expected_document["endpoint"]};
+  const rapidjson::Value& actual_endpoint{exporter.document_["endpoint"]};
+  CHECK(actual_endpoint == expected_endpoint);
 }
 
 }}  // namespace triton::perfanalyzer

--- a/src/c++/perf_analyzer/test_profile_data_exporter.cc
+++ b/src/c++/perf_analyzer/test_profile_data_exporter.cc
@@ -102,8 +102,10 @@ TEST_CASE("profile_data_exporter: ConvertToJson")
   std::vector<Experiment> experiments{experiment};
 
   std::string version{"1.2.3"};
+  cb::BackendKind service_kind = cb::BackendKind::TRITON;
+  std::string endpoint{""};
 
-  exporter.ConvertToJson(experiments, version);
+  exporter.ConvertToJson(experiments, version, service_kind, endpoint);
 
   std::string json{R"(
       {
@@ -125,7 +127,9 @@ TEST_CASE("profile_data_exporter: ConvertToJson")
             "window_boundaries" : [ 1, 5, 6 ]
           }
         ],
-        "version" : "1.2.3"
+        "version" : "1.2.3",
+        "service_kind": "triton",
+        "endpoint": ""
       }
       )"};
 
@@ -241,6 +245,116 @@ TEST_CASE("profile_data_exporter: OutputToFile")
 
     std::remove(file_path.c_str());
     CHECK(!IsFile(file_path));
+  }
+}
+
+TEST_CASE("profile_data_exporter: AddServiceKind")
+{
+  MockProfileDataExporter exporter{};
+  exporter.ClearDocument();
+
+  SUBCASE("Backend kind: TRITON")
+  {
+    cb::BackendKind service_kind = cb::BackendKind::TRITON;
+    exporter.AddServiceKind(service_kind);
+
+    std::string json{R"({ "service_kind": "triton" })"};
+    rapidjson::Document expected_document;
+    expected_document.Parse(json.c_str());
+
+    const rapidjson::Value& expected_kind{expected_document["service_kind"]};
+    const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
+    CHECK(actual_kind == expected_kind);
+  }
+
+  SUBCASE("Backend kind: TENSORFLOW_SERVING")
+  {
+    cb::BackendKind service_kind = cb::BackendKind::TENSORFLOW_SERVING;
+    exporter.AddServiceKind(service_kind);
+
+    std::string json{R"({ "service_kind": "tfserving" })"};
+    rapidjson::Document expected_document;
+    expected_document.Parse(json.c_str());
+
+    const rapidjson::Value& expected_kind{expected_document["service_kind"]};
+    const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
+    CHECK(actual_kind == expected_kind);
+  }
+
+  SUBCASE("Backend kind: TORCHSERVE")
+  {
+    cb::BackendKind service_kind = cb::BackendKind::TORCHSERVE;
+    exporter.AddServiceKind(service_kind);
+
+    std::string json{R"({ "service_kind": "torchserve" })"};
+    rapidjson::Document expected_document;
+    expected_document.Parse(json.c_str());
+
+    const rapidjson::Value& expected_kind{expected_document["service_kind"]};
+    const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
+    CHECK(actual_kind == expected_kind);
+  }
+
+  SUBCASE("Backend kind: TRITON_C_API")
+  {
+    cb::BackendKind service_kind = cb::BackendKind::TRITON_C_API;
+    exporter.AddServiceKind(service_kind);
+
+    std::string json{R"({ "service_kind": "triton_c_api" })"};
+    rapidjson::Document expected_document;
+    expected_document.Parse(json.c_str());
+
+    const rapidjson::Value& expected_kind{expected_document["service_kind"]};
+    const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
+    CHECK(actual_kind == expected_kind);
+  }
+
+  SUBCASE("Backend kind: OPENAI")
+  {
+    cb::BackendKind service_kind = cb::BackendKind::OPENAI;
+    exporter.AddServiceKind(service_kind);
+
+    std::string json{R"({ "service_kind": "openai" })"};
+    rapidjson::Document expected_document;
+    expected_document.Parse(json.c_str());
+
+    const rapidjson::Value& expected_kind{expected_document["service_kind"]};
+    const rapidjson::Value& actual_kind{exporter.document_["service_kind"]};
+    CHECK(actual_kind == expected_kind);
+  }
+}
+
+TEST_CASE("profile_data_exporter: AddEndpoint")
+{
+  MockProfileDataExporter exporter{};
+  exporter.ClearDocument();
+
+  SUBCASE("Endpoint: OpenAI Chat Completions")
+  {
+    std::string endpoint{"v1/chat/completions"};
+    exporter.AddEndpoint(endpoint);
+
+    std::string json{R"({ "endpoint": "v1/chat/completions" })"};
+    rapidjson::Document expected_document;
+    expected_document.Parse(json.c_str());
+
+    const rapidjson::Value& expected_endpoint{expected_document["endpoint"]};
+    const rapidjson::Value& actual_endpoint{exporter.document_["endpoint"]};
+    CHECK(actual_endpoint == expected_endpoint);
+  }
+
+  SUBCASE("Endpoint: OpenAI Completions")
+  {
+    std::string endpoint{"v1/completions"};
+    exporter.AddEndpoint(endpoint);
+
+    std::string json{R"({ "endpoint": "v1/completions" })"};
+    rapidjson::Document expected_document;
+    expected_document.Parse(json.c_str());
+
+    const rapidjson::Value& expected_endpoint{expected_document["endpoint"]};
+    const rapidjson::Value& actual_endpoint{exporter.document_["endpoint"]};
+    CHECK(actual_endpoint == expected_endpoint);
   }
 }
 


### PR DESCRIPTION
Add `service_kind` and `endpoint` fields to the profile export JSON file:
```json
{
  "experiments": { ... },
  "version": "1.2.3",
  "service_kind": "openai",
  "endpoint": "v1/chat/completions"
}
```
This allows GenAI-Perf to gather profile metadata through the profile export file and is needed for GenAI-Perf `compare` subcommand to parse the profile export files directly. 