### PR TITLE
add --input-file support with new prompt source inference logic

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/README.md
+++ b/src/c++/perf_analyzer/genai-perf/README.md
@@ -160,7 +160,6 @@ genai-perf \
   -m gpt2 \
   --service-kind triton \
   --backend tensorrtllm \
-  --prompt-source synthetic \
   --num-prompts 100 \
   --random-seed 123 \
   --synthetic-input-tokens-mean 200 \
@@ -207,9 +206,9 @@ When the dataset is synthetic, you can specify the following options:
 * `--num-prompts <int>`: The number of unique prompts to generate as stimulus,
   >= 1.
 * `--synthetic-input-tokens-mean <int>`: The mean of number of tokens in the
-  generated prompts when prompt-source is synthetic, >= 1.
+  generated prompts when using synthetic data, >= 1.
 * `--synthetic-input-tokens-stddev <int>`: The standard deviation of number of
-  tokens in the generated prompts when prompt-source is synthetic, >= 0.
+  tokens in the generated prompts when using synthetic data, >= 0.
 * `--random-seed <int>`: The seed used to generate random values, >= 0.
 
 When the dataset is coming from HuggingFace, you can specify the following
@@ -218,6 +217,11 @@ options:
   benchmarking.
 * `--num-prompts <int>`: The number of unique prompts to generate as stimulus,
   >= 1.
+
+When the dataset is coming from a file, you can specify the following
+options:
+* `--input-file <path>`: The input file containing the single prompt to
+  use for benchmarking.
 
 For any dataset, you can specify the following options:
 * `--output-tokens-mean <int>`: The mean number of tokens in each output. Ensure
@@ -303,8 +307,12 @@ flag for multiple inputs. Inputs should be in an input_name:value format.
 
 ##### `--input-dataset {openorca,cnn_dailymail}`
 
-The HuggingFace dataset to use for prompts when prompt-source is dataset.
+The HuggingFace dataset to use for prompts.
 (default: `openorca`)
+
+##### `--input-file <path>`
+
+The input file containing the single prompt to use for profiling.
 
 ##### `--num-prompts <int>`
 
@@ -329,23 +337,19 @@ tokens. (default: `False`)
 The standard deviation of the number of tokens in each output. This is only used
 when `--output-tokens-mean` is provided. (default: `0`)
 
-##### `--prompt-source {synthetic,dataset}`
-
-The source of the input prompts. (default: `synthetic`)
-
 ##### `--random-seed <int>`
 
 The seed used to generate random values. (default: `0`)
 
 ##### `--synthetic-input-tokens-mean <int>`
 
-The mean of number of tokens in the generated prompts when `--prompt-source` is
-`synthetic`. (default: `550`)
+The mean of number of tokens in the generated prompts when using synthetic
+data. (default: `550`)
 
 ##### `--synthetic-input-tokens-stddev <int>`
 
 The standard deviation of number of tokens in the generated prompts when
-`--prompt-source` is `synthetic`. (default: `0`)
+using synthetic data. (default: `0`)
 
 ## Profiling Options
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import os
 import random
 from copy import deepcopy
 from enum import Enum, auto
@@ -331,7 +330,7 @@ class LlmInputs:
 
     @classmethod
     def verify_file(cls, input_filename: Path) -> None:
-        if not os.path.exists(input_filename):
+        if not input_filename.exists():
             raise FileNotFoundError(f"The file '{input_filename}' does not exist.")
 
     @classmethod

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -17,7 +17,7 @@ import random
 from copy import deepcopy
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import requests
 from genai_perf.constants import CNN_DAILY_MAIL, DEFAULT_INPUT_DATA_JSON, OPEN_ORCA
@@ -78,7 +78,7 @@ class LlmInputs:
         output_format: OutputFormat,
         dataset_name: str = "",
         model_name: str = "",
-        input_filename: Path = Path(""),
+        input_filename: Optional[Path] = Path(""),
         starting_index: int = DEFAULT_STARTING_INDEX,
         length: int = DEFAULT_LENGTH,
         output_tokens_mean: int = DEFAULT_OUTPUT_TOKENS_MEAN,
@@ -168,13 +168,16 @@ class LlmInputs:
                     synthetic_dataset
                 )
             )
-        else:
+        elif input_type == PromptSource.FILE:
+            input_filename = cast(Path, input_filename)
             input_file_dataset = cls._get_input_dataset_from_file(input_filename)
             generic_dataset_json = (
                 cls._convert_input_synthetic_or_file_dataset_to_generic_json(
                     input_file_dataset
                 )
             )
+        else:
+            raise GenAIPerfException("Input source is not recognized.")
 
         if extra_inputs is None:
             extra_inputs = {}

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import os
 import random
 from copy import deepcopy
 from enum import Enum, auto
@@ -320,12 +321,18 @@ class LlmInputs:
 
     @classmethod
     def _get_input_dataset_from_file(cls, input_filename: Path) -> Dict:
+        cls.verify_file(input_filename)
         input_file_prompt = cls._get_prompt_from_input_file(input_filename)
         dataset_json: Dict[str, Any] = {}
         dataset_json["features"] = [{"name": "text_input"}]
         dataset_json["rows"] = []
         dataset_json["rows"].append({"row": {"text_input": input_file_prompt}})
         return dataset_json
+
+    @classmethod
+    def verify_file(cls, input_filename: Path) -> None:
+        if not os.path.exists(input_filename):
+            raise FileNotFoundError(f"The file '{input_filename}' does not exist.")
 
     @classmethod
     def _get_prompt_from_input_file(cls, input_filename: Path) -> str:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -16,6 +16,7 @@ import json
 import random
 from copy import deepcopy
 from enum import Enum, auto
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
@@ -77,7 +78,7 @@ class LlmInputs:
         output_format: OutputFormat,
         dataset_name: str = "",
         model_name: str = "",
-        input_filename: str = "",
+        input_filename: Path = Path(""),
         starting_index: int = DEFAULT_STARTING_INDEX,
         length: int = DEFAULT_LENGTH,
         output_tokens_mean: int = DEFAULT_OUTPUT_TOKENS_MEAN,
@@ -162,12 +163,17 @@ class LlmInputs:
                 prompt_tokens_stddev,
                 num_of_output_prompts,
             )
-            generic_dataset_json = cls._convert_input_synthetic_dataset_to_generic_json(
-                synthetic_dataset
+            generic_dataset_json = (
+                cls._convert_input_synthetic_or_file_dataset_to_generic_json(
+                    synthetic_dataset
+                )
             )
         else:
-            raise GenAIPerfException(
-                "Using a file to supply LLM Input is not supported at this time"
+            input_file_dataset = cls._get_input_dataset_from_file(input_filename)
+            generic_dataset_json = (
+                cls._convert_input_synthetic_or_file_dataset_to_generic_json(
+                    input_file_dataset
+                )
             )
 
         if extra_inputs is None:
@@ -273,7 +279,7 @@ class LlmInputs:
         return generic_dataset_json
 
     @classmethod
-    def _convert_input_synthetic_dataset_to_generic_json(
+    def _convert_input_synthetic_or_file_dataset_to_generic_json(
         cls, dataset: Dict
     ) -> Dict[str, List[Dict]]:
         generic_dataset_json = cls._convert_dataset_to_generic_input_json(dataset)
@@ -311,6 +317,20 @@ class LlmInputs:
             generic_input_json["rows"].append(row["row"])
 
         return generic_input_json
+
+    @classmethod
+    def _get_input_dataset_from_file(cls, input_filename: Path) -> Dict:
+        input_file_prompt = cls._get_prompt_from_input_file(input_filename)
+        dataset_json: Dict[str, Any] = {}
+        dataset_json["features"] = [{"name": "text_input"}]
+        dataset_json["rows"] = []
+        dataset_json["rows"].append({"row": {"text_input": input_file_prompt}})
+        return dataset_json
+
+    @classmethod
+    def _get_prompt_from_input_file(cls, input_filename: Path) -> str:
+        with open(input_filename, mode="r", newline=None) as file:
+            return file.read()
 
     @classmethod
     def _convert_generic_json_to_output_format(
@@ -528,6 +548,7 @@ class LlmInputs:
         text_input_headers: List[str] = []
 
         if "features" in dataset_json.keys():
+            # TODO (TPA-53) remove enumerate if index isnt useful
             for index, feature in enumerate(dataset_json["features"]):
                 if feature in SYSTEM_ROLE_LIST:
                     system_role_headers.append(feature)

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -29,6 +29,7 @@ from requests import Response
 class PromptSource(Enum):
     SYNTHETIC = auto()
     DATASET = auto()
+    FILE = auto()
 
 
 class OutputFormat(Enum):

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -70,7 +70,9 @@ def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:
         output_format=args.output_format,
         dataset_name=args.input_dataset if args.input_dataset is not None else "",
         model_name=args.model,
-        input_filename=args.input_file if args.input_file is not None else "",
+        input_filename=(
+            Path(args.input_file) if args.input_file is not None else Path("")
+        ),
         starting_index=LlmInputs.DEFAULT_STARTING_INDEX,
         length=args.num_prompts,
         prompt_tokens_mean=args.synthetic_input_tokens_mean,

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -68,7 +68,7 @@ def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:
     LlmInputs.create_llm_inputs(
         input_type=args.prompt_source,
         output_format=args.output_format,
-        dataset_name=args.input_dataset if args.input_dataset is not None else "",
+        dataset_name=args.input_dataset or "",
         model_name=args.model,
         input_filename=(
             Path(args.input_file) if args.input_file is not None else Path("")

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -55,24 +55,19 @@ def create_artifacts_dirs(generate_plots: bool) -> None:
 
 def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:
     # TODO (TMA-1759): review if add_model_name is always true
+    input_filename = Path(args.input_file.name) if args.input_file else None
     add_model_name = True
     try:
-        extra_input_dict = (
-            parser.get_extra_inputs_as_dict(args)
-            if args.extra_inputs is not None
-            else None
-        )
+        extra_input_dict = parser.get_extra_inputs_as_dict(args)
     except ValueError as e:
         raise GenAIPerfException(e)
 
     LlmInputs.create_llm_inputs(
         input_type=args.prompt_source,
         output_format=args.output_format,
-        dataset_name=args.input_dataset or "",
+        dataset_name=args.input_dataset,
         model_name=args.model,
-        input_filename=(
-            Path(args.input_file) if args.input_file is not None else Path("")
-        ),
+        input_filename=input_filename,
         starting_index=LlmInputs.DEFAULT_STARTING_INDEX,
         length=args.num_prompts,
         prompt_tokens_mean=args.synthetic_input_tokens_mean,

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -54,21 +54,23 @@ def create_artifacts_dirs(generate_plots: bool) -> None:
 
 
 def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:
-    # TODO (TMA-1758): remove once file support is implemented
-    input_file_name = ""
     # TODO (TMA-1759): review if add_model_name is always true
     add_model_name = True
     try:
-        extra_input_dict = parser.get_extra_inputs_as_dict(args)
+        extra_input_dict = (
+            parser.get_extra_inputs_as_dict(args)
+            if args.extra_inputs is not None
+            else None
+        )
     except ValueError as e:
         raise GenAIPerfException(e)
 
     LlmInputs.create_llm_inputs(
         input_type=args.prompt_source,
         output_format=args.output_format,
-        dataset_name=args.input_dataset,
+        dataset_name=args.input_dataset if args.input_dataset is not None else "",
         model_name=args.model,
-        input_filename=input_file_name,
+        input_filename=args.input_file if args.input_file is not None else "",
         starting_index=LlmInputs.DEFAULT_STARTING_INDEX,
         length=args.num_prompts,
         prompt_tokens_mean=args.synthetic_input_tokens_mean,

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -110,15 +110,15 @@ def _update_load_manager_args(args: argparse.Namespace) -> argparse.Namespace:
 
 
 def _infer_prompt_source(args: argparse.Namespace) -> argparse.Namespace:
-    if args.input_dataset is not None:
+    if args.input_dataset:
         args.prompt_source = PromptSource.DATASET
-        logger.info(f"Input source is the following dataset: {args.input_dataset}")
-    elif args.input_file is not None:
+        logger.debug(f"Input source is the following dataset: {args.input_dataset}")
+    elif args.input_file:
         args.prompt_source = PromptSource.FILE
-        logger.info(f"Input source is the following file: {args.input_file}")
+        logger.debug(f"Input source is the following file: {args.input_file.name}")
     else:
         args.prompt_source = PromptSource.SYNTHETIC
-        logger.info("Input source is synthetic data")
+        logger.debug("Input source is synthetic data")
     return args
 
 
@@ -166,7 +166,7 @@ def _add_input_args(parser):
 
     prompt_source_group.add_argument(
         "--input-file",
-        type=Path,
+        type=argparse.FileType("r"),
         default=None,
         required=False,
         help="The input file containing the single prompt to use for profiling.",
@@ -399,7 +399,7 @@ def _add_other_args(parser):
 
 def get_extra_inputs_as_dict(args: argparse.Namespace) -> dict:
     request_inputs = {}
-    if hasattr(args, "extra_inputs"):
+    if args.extra_inputs:
         for input_str in args.extra_inputs:
             semicolon_count = input_str.count(":")
             if semicolon_count != 1:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -115,10 +115,10 @@ def _infer_prompt_source(args: argparse.Namespace) -> argparse.Namespace:
         logger.info(f"Input source is the following dataset: {args.input_dataset}")
     elif args.input_file is not None:
         args.prompt_source = PromptSource.FILE
-        logger.info(f"Input source is from the following file: {args.input_file}")
+        logger.info(f"Input source is the following file: {args.input_file}")
     else:
         args.prompt_source = PromptSource.SYNTHETIC
-        logger.info("Input source is from synthetic data")
+        logger.info("Input source is synthetic data")
     return args
 
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -25,7 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
-import os
 import sys
 from pathlib import Path
 
@@ -116,8 +115,6 @@ def _infer_prompt_source(args: argparse.Namespace) -> argparse.Namespace:
         logger.info(f"Input source is the following dataset: {args.input_dataset}")
     elif args.input_file is not None:
         args.prompt_source = PromptSource.FILE
-        if not os.path.exists(args.input_file):
-            raise FileNotFoundError(f"The file '{args.input_file}' does not exist.")
         logger.info(f"Input source is from the following file: {args.input_file}")
     else:
         args.prompt_source = PromptSource.SYNTHETIC

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -41,7 +41,7 @@ class Profiler:
         cmd = [""]
         if args.service_kind == "triton":
             cmd += ["-i", "grpc", "--streaming"]
-            if "u" not in vars(args).keys():
+            if args.u is None:
                 cmd += ["-u", f"{DEFAULT_GRPC_URL}"]
             if args.output_format == OutputFormat.TENSORRTLLM:
                 cmd += ["--shape", "max_tokens:1", "--shape", "text_input:1"]

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -91,6 +91,8 @@ class Profiler:
         for arg, value in vars(args).items():
             if arg in skip_args:
                 pass
+            elif value is None:
+                pass
             elif value is False:
                 pass
             elif value is True:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -41,7 +41,7 @@ class Profiler:
         cmd = [""]
         if args.service_kind == "triton":
             cmd += ["-i", "grpc", "--streaming"]
-            if args.u is None:
+            if args.u is None:  # url
                 cmd += ["-u", f"{DEFAULT_GRPC_URL}"]
             if args.output_format == OutputFormat.TENSORRTLLM:
                 cmd += ["--shape", "max_tokens:1", "--shape", "text_input:1"]

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -54,6 +54,7 @@ class Profiler:
         skip_args = [
             "func",
             "input_dataset",
+            "input_file",
             "prompt_source",
             "input_format",
             "model",

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -125,6 +125,10 @@ class TestCLIArguments:
             ),
             (["--input-dataset", "openorca"], {"input_dataset": "openorca"}),
             (
+                ["--input-file", "prompt.txt"],
+                {"input_file": Path("prompt.txt")},
+            ),
+            (
                 ["--synthetic-input-tokens-mean", "6"],
                 {"synthetic_input_tokens_mean": 6},
             ),
@@ -143,14 +147,6 @@ class TestCLIArguments:
             (
                 ["--output-tokens-mean", "6", "--output-tokens-mean-deterministic"],
                 {"output_tokens_mean_deterministic": True},
-            ),
-            (
-                ["--prompt-source", "synthetic"],
-                {"prompt_source": utils.get_enum_entry("synthetic", PromptSource)},
-            ),
-            (
-                ["--prompt-source", "dataset"],
-                {"prompt_source": utils.get_enum_entry("dataset", PromptSource)},
             ),
             (["--measurement-interval", "100"], {"measurement_interval": 100}),
             (["-p", "100"], {"measurement_interval": 100}),

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -582,3 +582,7 @@ class TestLlmInputs:
                     assert False, f"Unsupported output format: {output_format}"
 
             os.remove(DEFAULT_INPUT_DATA_JSON)
+
+    def test_get_input_file_without_file_existing(self):
+        with pytest.raises(FileNotFoundError):
+            LlmInputs._get_input_dataset_from_file("prompt.txt")

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -16,6 +16,7 @@ import json
 import os
 import random
 import statistics
+from pathlib import Path
 
 import pytest
 from genai_perf import tokenizer
@@ -585,4 +586,4 @@ class TestLlmInputs:
 
     def test_get_input_file_without_file_existing(self):
         with pytest.raises(FileNotFoundError):
-            LlmInputs._get_input_dataset_from_file("prompt.txt")
+            LlmInputs._get_input_dataset_from_file(Path("prompt.txt"))


### PR DESCRIPTION
- Added a new option --input-file
- Removed --prompt-source and now genai-perf infers the prompt source:
    --input-dataset -> dataset
     --input-file -> file
    else synthetic
- Added error checking when multiple flags lead to unclear prompt source.
This maintains the default behavior of synthetic as the default.
Going forward, Genai-perf will move to infer more details and improve the UX.

- Inform user the source via a info command
![Screenshot 2024-05-03 at 16 02 29](https://github.com/triton-inference-server/client/assets/6505145/9657e32b-06b8-4f8f-840f-052af9f70e42)

sample prompt file:
![Screenshot 2024-05-03 at 16 03 05](https://github.com/triton-inference-server/client/assets/6505145/8d5e5c4a-bb1c-423e-a098-4168d64d2101)

llm_inputs.json when using an input file:
![Screenshot 2024-05-03 at 16 03 20](https://github.com/triton-inference-server/client/assets/6505145/5d17dd97-9642-4683-a17f-929e1f0300a7)
 