### PR TITLE
Fixing memory leakage when using dlpack

### DIFF
--- a/src/python/library/tritonclient/utils/_dlpack.py
+++ b/src/python/library/tritonclient/utils/_dlpack.py
@@ -140,7 +140,6 @@ class DataViewContext:
         py_obj = ctypes.py_object(self)
         py_obj_ptr = ctypes.pointer(py_obj)
         ctypes.pythonapi.Py_IncRef(py_obj)
-        ctypes.pythonapi.Py_IncRef(ctypes.py_object(py_obj_ptr))
         return ctypes.cast(py_obj_ptr, ctypes.c_void_p)
 
 


### PR DESCRIPTION
Here's a proposed fix for the issue: https://github.com/triton-inference-server/client/issues/598

I described the results in detail in the comments of the issue.