### PR TITLE
Support for fixed number of requests

### DIFF
--- a/src/c++/perf_analyzer/CMakeLists.txt
+++ b/src/c++/perf_analyzer/CMakeLists.txt
@@ -112,6 +112,7 @@ set(
   profile_data_exporter.h
   periodic_concurrency_manager.h
   periodic_concurrency_worker.h
+  thread_config.h
 )
 
 add_executable(

--- a/src/c++/perf_analyzer/client_backend/client_backend.h
+++ b/src/c++/perf_analyzer/client_backend/client_backend.h
@@ -138,6 +138,8 @@ enum BackendKind {
   TRITON_C_API = 3,
   OPENAI = 4
 };
+std::string BackendKindToString(const BackendKind kind);
+
 enum ProtocolType { HTTP = 0, GRPC = 1, UNKNOWN = 2 };
 enum GrpcCompressionAlgorithm {
   COMPRESS_NONE = 0,

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1898,6 +1898,18 @@ CLParser::VerifyOptions()
         "binary search mode.");
   }
 
+  if (params_->request_count != 0) {
+    if (params_->using_concurrency_range &&
+        params_->request_count < params_->concurrency_range.start) {
+      Usage("request-count can not be less than concurrency");
+    }
+    if (params_->using_request_rate_range &&
+        params_->request_count <
+            static_cast<int>(params_->request_rate_range[0])) {
+      Usage("request-count can not be less than request-rate");
+    }
+  }
+
   if (params_->kind == cb::TENSORFLOW_SERVING) {
     if (params_->protocol != cb::ProtocolType::GRPC) {
       Usage(

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1225,6 +1225,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
           std::string request_count{optarg};
           if (std::stoi(request_count) > 0) {
             params_->measurement_request_count = std::stoull(request_count);
+
+            // FIXME TKG -- need a different arg
+            params_->num_requests = params_->measurement_request_count;
           } else {
             Usage(
                 "Failed to parse --measurement-request-count. The value must "

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -137,7 +137,7 @@ CLParser::Usage(const std::string& msg)
                "profiling>"
             << std::endl;
   std::cerr << "\t--percentile <percentile>" << std::endl;
-  std::cerr << "\t--fixed-num-requests <number of requests>" << std::endl;
+  std::cerr << "\t--request-count <number of requests>" << std::endl;
   std::cerr << "\tDEPRECATED OPTIONS" << std::endl;
   std::cerr << "\t-t <number of concurrent requests>" << std::endl;
   std::cerr << "\t-c <maximum concurrency>" << std::endl;
@@ -466,9 +466,10 @@ CLParser::Usage(const std::string& msg)
       << std::endl;
   std::cerr
       << FormatMessage(
-             " --fixed-num-requests: Specifies a fixed number of requests to "
+             " --request-count: Specifies a total number of requests to "
              "use for measurement. The default is 0, which means that there is "
-             "no fixed number and the measurement will proceed using windows.",
+             "no request count and the measurement will proceed using windows "
+             "until stabilization is detected.",
              18)
       << std::endl;
   std::cerr << FormatMessage(
@@ -887,7 +888,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
       {"request-period", required_argument, 0, 59},
       {"request-parameter", required_argument, 0, 60},
       {"endpoint", required_argument, 0, 61},
-      {"fixed-num-requests", required_argument, 0, 62},
+      {"request-count", required_argument, 0, 62},
       {0, 0, 0, 0}};
 
   // Parse commandline...
@@ -1625,10 +1626,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
         }
         case 62: {
           if (std::stoi(optarg) < 0) {
-            Usage(
-                "Failed to parse --fixed-num-requests. The value must be > 0.");
+            Usage("Failed to parse --request-count. The value must be > 0.");
           }
-          params_->fixed_num_requests = std::stoi(optarg);
+          params_->request_count = std::stoi(optarg);
           break;
         }
         case 'v':
@@ -1725,9 +1725,9 @@ CLParser::ParseCommandLine(int argc, char** argv)
 
   // Override measurement mode to be count windows with a window size of the
   // requested count
-  if (params_->fixed_num_requests) {
+  if (params_->request_count) {
     params_->measurement_mode = MeasurementMode::COUNT_WINDOWS;
-    params_->measurement_request_count = params_->fixed_num_requests;
+    params_->measurement_request_count = params_->request_count;
   }
 }
 

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1723,8 +1723,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
     params_->search_mode = SearchMode::NONE;
   }
 
-  // Override measurement mode to be count windows with a window size of the
-  // requested count
+  // When the request-count feature is enabled, override the measurement mode to
+  // be count windows with a window size of the requested count
   if (params_->request_count) {
     params_->measurement_mode = MeasurementMode::COUNT_WINDOWS;
     params_->measurement_request_count = params_->request_count;

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1899,14 +1899,27 @@ CLParser::VerifyOptions()
   }
 
   if (params_->request_count != 0) {
-    if (params_->using_concurrency_range &&
-        params_->request_count < params_->concurrency_range.start) {
-      Usage("request-count can not be less than concurrency");
+    if (params_->using_concurrency_range) {
+      if (params_->request_count < params_->concurrency_range.start) {
+        Usage("request-count can not be less than concurrency");
+      }
+      if (params_->concurrency_range.start < params_->concurrency_range.end) {
+        Usage(
+            "request-count not supported with multiple concurrency values in "
+            "one run");
+      }
     }
-    if (params_->using_request_rate_range &&
-        params_->request_count <
-            static_cast<int>(params_->request_rate_range[0])) {
-      Usage("request-count can not be less than request-rate");
+    if (params_->using_request_rate_range) {
+      if (params_->request_count <
+          static_cast<int>(params_->request_rate_range[0])) {
+        Usage("request-count can not be less than request-rate");
+      }
+      if (params_->request_rate_range[SEARCH_RANGE::kSTART] <
+          params_->request_rate_range[SEARCH_RANGE::kEND]) {
+        Usage(
+            "request-count not supported with multiple request-rate values in "
+            "one run");
+      }
     }
   }
 

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -62,6 +62,8 @@ struct PerfAnalyzerParameters {
   uint64_t latency_threshold_ms = NO_LIMIT;
   double stability_threshold = 0.1;
   size_t max_trials = 10;
+  // FIXME TKG -- one_window_mode? num_requests?
+  size_t num_requests = 0;
   bool zero_input = false;
   size_t string_length = 128;
   std::string string_data;

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -62,8 +62,7 @@ struct PerfAnalyzerParameters {
   uint64_t latency_threshold_ms = NO_LIMIT;
   double stability_threshold = 0.1;
   size_t max_trials = 10;
-  // FIXME TKG -- one_window_mode? num_requests?
-  size_t num_requests = 0;
+  size_t fixed_num_requests = 0;
   bool zero_input = false;
   size_t string_length = 128;
   std::string string_data;

--- a/src/c++/perf_analyzer/command_line_parser.h
+++ b/src/c++/perf_analyzer/command_line_parser.h
@@ -62,7 +62,7 @@ struct PerfAnalyzerParameters {
   uint64_t latency_threshold_ms = NO_LIMIT;
   double stability_threshold = 0.1;
   size_t max_trials = 10;
-  size_t fixed_num_requests = 0;
+  size_t request_count = 0;
   bool zero_input = false;
   size_t string_length = 128;
   std::string string_data;

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -138,6 +138,12 @@ ConcurrencyManager::ReconfigThreads(const size_t concurrent_request_count)
     // and spread the remaining value
     size_t avg_concurrency = concurrent_request_count / threads_.size();
     size_t threads_add_one = concurrent_request_count % threads_.size();
+
+    // FIXME TKG -- ever possible to go down in concurrency??
+    size_t max_req_count = 17;
+    size_t avg_req_count = max_req_count / threads_.size();
+    size_t req_count_add_one = max_req_count % threads_.size();
+
     size_t seq_stat_index_offset = 0;
     active_threads_ = 0;
     for (size_t i = 0; i < threads_stat_.size(); i++) {
@@ -145,6 +151,13 @@ ConcurrencyManager::ReconfigThreads(const size_t concurrent_request_count)
 
       threads_config_[i]->concurrency_ = concurrency;
       threads_config_[i]->seq_stat_index_offset_ = seq_stat_index_offset;
+
+      // FIXME TKG -- only if specific mode
+      size_t max_reqs = avg_req_count + (i < req_count_add_one ? 1 : 0);
+      threads_stat_[i]->max_requests_ = max_reqs;
+      std::cout << "TKG -- thread " << i << " is getting max reqs of "
+                << max_reqs << std::endl;
+
       seq_stat_index_offset += concurrency;
 
       if (concurrency) {

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -84,10 +84,10 @@ ConcurrencyManager::InitManagerFinalize()
 
 cb::Error
 ConcurrencyManager::ChangeConcurrencyLevel(
-    const size_t concurrent_request_count)
+    const size_t concurrent_request_count, const size_t exact_request_count)
 {
   PauseSequenceWorkers();
-  ReconfigThreads(concurrent_request_count);
+  ReconfigThreads(concurrent_request_count, exact_request_count);
   ResumeSequenceWorkers();
 
   std::cout << "Request concurrency: " << concurrent_request_count << std::endl;
@@ -109,7 +109,8 @@ ConcurrencyManager::PauseSequenceWorkers()
 }
 
 void
-ConcurrencyManager::ReconfigThreads(const size_t concurrent_request_count)
+ConcurrencyManager::ReconfigThreads(
+    const size_t concurrent_request_count, const size_t exact_request_count)
 {
   // Always prefer to create new threads if the maximum limit has not been met
   //
@@ -140,9 +141,8 @@ ConcurrencyManager::ReconfigThreads(const size_t concurrent_request_count)
     size_t threads_add_one = concurrent_request_count % threads_.size();
 
     // FIXME TKG -- ever possible to go down in concurrency??
-    size_t max_req_count = 17;
-    size_t avg_req_count = max_req_count / threads_.size();
-    size_t req_count_add_one = max_req_count % threads_.size();
+    size_t avg_req_count = exact_request_count / threads_.size();
+    size_t req_count_add_one = exact_request_count % threads_.size();
 
     size_t seq_stat_index_offset = 0;
     active_threads_ = 0;

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -154,8 +154,6 @@ ConcurrencyManager::ReconfigThreads(
 
       size_t thread_num_reqs = avg_req_count + (i < req_count_add_one ? 1 : 0);
       threads_stat_[i]->max_requests_ = thread_num_reqs;
-      std::cout << "TKG -- thread " << i << " is getting max reqs of "
-                << thread_num_reqs << std::endl;
 
       seq_stat_index_offset += concurrency;
 

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -84,10 +84,10 @@ ConcurrencyManager::InitManagerFinalize()
 
 cb::Error
 ConcurrencyManager::ChangeConcurrencyLevel(
-    const size_t concurrent_request_count, const size_t exact_request_count)
+    const size_t concurrent_request_count, const size_t num_of_requests)
 {
   PauseSequenceWorkers();
-  ReconfigThreads(concurrent_request_count, exact_request_count);
+  ReconfigThreads(concurrent_request_count, num_of_requests);
   ResumeSequenceWorkers();
 
   std::cout << "Request concurrency: " << concurrent_request_count << std::endl;
@@ -110,7 +110,7 @@ ConcurrencyManager::PauseSequenceWorkers()
 
 void
 ConcurrencyManager::ReconfigThreads(
-    const size_t concurrent_request_count, const size_t exact_request_count)
+    const size_t concurrent_request_count, const size_t num_of_requests)
 {
   // Always prefer to create new threads if the maximum limit has not been met
   //
@@ -141,8 +141,8 @@ ConcurrencyManager::ReconfigThreads(
     size_t threads_add_one = concurrent_request_count % threads_.size();
 
     // FIXME TKG -- ever possible to go down in concurrency??
-    size_t avg_req_count = exact_request_count / threads_.size();
-    size_t req_count_add_one = exact_request_count % threads_.size();
+    size_t avg_req_count = num_of_requests / threads_.size();
+    size_t req_count_add_one = num_of_requests % threads_.size();
 
     size_t seq_stat_index_offset = 0;
     active_threads_ = 0;
@@ -152,11 +152,10 @@ ConcurrencyManager::ReconfigThreads(
       threads_config_[i]->concurrency_ = concurrency;
       threads_config_[i]->seq_stat_index_offset_ = seq_stat_index_offset;
 
-      // FIXME TKG -- only if specific mode
-      size_t max_reqs = avg_req_count + (i < req_count_add_one ? 1 : 0);
-      threads_stat_[i]->max_requests_ = max_reqs;
+      size_t thread_num_reqs = avg_req_count + (i < req_count_add_one ? 1 : 0);
+      threads_stat_[i]->max_requests_ = thread_num_reqs;
       std::cout << "TKG -- thread " << i << " is getting max reqs of "
-                << max_reqs << std::endl;
+                << thread_num_reqs << std::endl;
 
       seq_stat_index_offset += concurrency;
 

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -122,8 +122,7 @@ ConcurrencyManager::ReconfigThreads(
          (threads_.size() < max_threads_)) {
     // Launch new thread for inferencing
     threads_stat_.emplace_back(new ThreadStat());
-    threads_config_.emplace_back(
-        new ConcurrencyWorker::ThreadConfig(threads_config_.size()));
+    threads_config_.emplace_back(new ThreadConfig(threads_config_.size()));
 
     workers_.push_back(
         MakeWorker(threads_stat_.back(), threads_config_.back()));
@@ -140,7 +139,6 @@ ConcurrencyManager::ReconfigThreads(
     size_t avg_concurrency = concurrent_request_count / threads_.size();
     size_t threads_add_one = concurrent_request_count % threads_.size();
 
-    // FIXME TKG -- ever possible to go down in concurrency??
     size_t avg_req_count = num_of_requests / threads_.size();
     size_t req_count_add_one = num_of_requests % threads_.size();
 
@@ -153,7 +151,7 @@ ConcurrencyManager::ReconfigThreads(
       threads_config_[i]->seq_stat_index_offset_ = seq_stat_index_offset;
 
       size_t thread_num_reqs = avg_req_count + (i < req_count_add_one ? 1 : 0);
-      threads_stat_[i]->max_requests_ = thread_num_reqs;
+      threads_config_[i]->num_requests_ = thread_num_reqs;
 
       seq_stat_index_offset += concurrency;
 
@@ -181,7 +179,7 @@ ConcurrencyManager::ResumeSequenceWorkers()
 std::shared_ptr<IWorker>
 ConcurrencyManager::MakeWorker(
     std::shared_ptr<ThreadStat> thread_stat,
-    std::shared_ptr<ConcurrencyWorker::ThreadConfig> thread_config)
+    std::shared_ptr<ThreadConfig> thread_config)
 {
   uint32_t id = workers_.size();
 

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -84,10 +84,10 @@ ConcurrencyManager::InitManagerFinalize()
 
 cb::Error
 ConcurrencyManager::ChangeConcurrencyLevel(
-    const size_t concurrent_request_count, const size_t num_of_requests)
+    const size_t concurrent_request_count, const size_t request_count)
 {
   PauseSequenceWorkers();
-  ReconfigThreads(concurrent_request_count, num_of_requests);
+  ReconfigThreads(concurrent_request_count, request_count);
   ResumeSequenceWorkers();
 
   std::cout << "Request concurrency: " << concurrent_request_count << std::endl;
@@ -110,7 +110,7 @@ ConcurrencyManager::PauseSequenceWorkers()
 
 void
 ConcurrencyManager::ReconfigThreads(
-    size_t concurrent_request_count, size_t num_of_requests)
+    size_t concurrent_request_count, size_t request_count)
 {
   // Always prefer to create new threads if the maximum limit has not been met
   //
@@ -137,8 +137,8 @@ ConcurrencyManager::ReconfigThreads(
     // Corner case: If requested to have concurrency of 5 but asked for less
     // than that many total requests, then clamp the concurrency value to the
     // request count
-    if (num_of_requests > 0 && concurrent_request_count > num_of_requests) {
-      concurrent_request_count = num_of_requests;
+    if (request_count > 0 && concurrent_request_count > request_count) {
+      concurrent_request_count = request_count;
     }
 
     // Compute the new concurrency level for each thread (take floor)
@@ -146,8 +146,8 @@ ConcurrencyManager::ReconfigThreads(
     size_t avg_concurrency = concurrent_request_count / threads_.size();
     size_t threads_add_one = concurrent_request_count % threads_.size();
 
-    size_t avg_req_count = num_of_requests / threads_.size();
-    size_t req_count_add_one = num_of_requests % threads_.size();
+    size_t avg_req_count = request_count / threads_.size();
+    size_t req_count_add_one = request_count % threads_.size();
 
     size_t seq_stat_index_offset = 0;
     active_threads_ = 0;

--- a/src/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/c++/perf_analyzer/concurrency_manager.cc
@@ -134,13 +134,6 @@ ConcurrencyManager::ReconfigThreads(
     // Make sure all threads are reconfigured before they are woken up
     std::lock_guard<std::mutex> lock(wake_mutex_);
 
-    // Corner case: If requested to have concurrency of 5 but asked for less
-    // than that many total requests, then clamp the concurrency value to the
-    // request count
-    if (request_count > 0 && concurrent_request_count > request_count) {
-      concurrent_request_count = request_count;
-    }
-
     // Compute the new concurrency level for each thread (take floor)
     // and spread the remaining value
     size_t avg_concurrency = concurrent_request_count / threads_.size();

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -96,8 +96,7 @@ class ConcurrencyManager : public LoadManager {
  protected:
   // Makes a new worker
   virtual std::shared_ptr<IWorker> MakeWorker(
-      std::shared_ptr<ThreadStat>,
-      std::shared_ptr<ConcurrencyWorker::ThreadConfig>);
+      std::shared_ptr<ThreadStat>, std::shared_ptr<ThreadConfig>);
 
   ConcurrencyManager(
       const bool async, const bool streaming, const int32_t batch_size,
@@ -115,7 +114,7 @@ class ConcurrencyManager : public LoadManager {
 
   size_t max_concurrency_;
 
-  std::vector<std::shared_ptr<ConcurrencyWorker::ThreadConfig>> threads_config_;
+  std::vector<std::shared_ptr<ThreadConfig>> threads_config_;
 
  private:
   void InitManagerFinalize() override;
@@ -127,8 +126,7 @@ class ConcurrencyManager : public LoadManager {
   // Create new threads (if necessary), and then reconfigure all worker threads
   // to handle the new concurrent request count
   //
-  void ReconfigThreads(
-      size_t concurrent_request_count, size_t num_of_requests = 0);
+  void ReconfigThreads(size_t concurrent_request_count, size_t num_of_requests);
 
   // Restart all worker threads that were working on sequences
   //

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -91,7 +91,7 @@ class ConcurrencyManager : public LoadManager {
   /// \param concurent_request_count The number of concurrent requests.
   /// \return cb::Error object indicating success or failure.
   cb::Error ChangeConcurrencyLevel(
-      const size_t concurrent_request_count, const size_t num_of_requests = 0);
+      const size_t concurrent_request_count, const size_t request_count = 0);
 
  protected:
   // Makes a new worker
@@ -126,7 +126,7 @@ class ConcurrencyManager : public LoadManager {
   // Create new threads (if necessary), and then reconfigure all worker threads
   // to handle the new concurrent request count
   //
-  void ReconfigThreads(size_t concurrent_request_count, size_t num_of_requests);
+  void ReconfigThreads(size_t concurrent_request_count, size_t request_count);
 
   // Restart all worker threads that were working on sequences
   //

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -91,8 +91,7 @@ class ConcurrencyManager : public LoadManager {
   /// \param concurent_request_count The number of concurrent requests.
   /// \return cb::Error object indicating success or failure.
   cb::Error ChangeConcurrencyLevel(
-      const size_t concurrent_request_count,
-      const size_t exact_request_count = 0);
+      const size_t concurrent_request_count, const size_t num_of_requests = 0);
 
  protected:
   // Makes a new worker
@@ -129,7 +128,7 @@ class ConcurrencyManager : public LoadManager {
   // to handle the new concurrent request count
   //
   void ReconfigThreads(
-      size_t concurrent_request_count, size_t exact_request_count = 0);
+      size_t concurrent_request_count, size_t num_of_requests = 0);
 
   // Restart all worker threads that were working on sequences
   //

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -89,6 +89,8 @@ class ConcurrencyManager : public LoadManager {
   /// Adjusts the number of concurrent requests to be the same as
   /// 'concurrent_request_count' (by creating or pausing threads)
   /// \param concurent_request_count The number of concurrent requests.
+  /// \param request_count The number of requests to generate. If 0, then
+  /// there is no limit, and it will generate until told to stop.
   /// \return cb::Error object indicating success or failure.
   cb::Error ChangeConcurrencyLevel(
       const size_t concurrent_request_count, const size_t request_count = 0);

--- a/src/c++/perf_analyzer/concurrency_manager.h
+++ b/src/c++/perf_analyzer/concurrency_manager.h
@@ -90,7 +90,9 @@ class ConcurrencyManager : public LoadManager {
   /// 'concurrent_request_count' (by creating or pausing threads)
   /// \param concurent_request_count The number of concurrent requests.
   /// \return cb::Error object indicating success or failure.
-  cb::Error ChangeConcurrencyLevel(const size_t concurrent_request_count);
+  cb::Error ChangeConcurrencyLevel(
+      const size_t concurrent_request_count,
+      const size_t exact_request_count = 0);
 
  protected:
   // Makes a new worker
@@ -126,7 +128,8 @@ class ConcurrencyManager : public LoadManager {
   // Create new threads (if necessary), and then reconfigure all worker threads
   // to handle the new concurrent request count
   //
-  void ReconfigThreads(size_t concurrent_request_count);
+  void ReconfigThreads(
+      size_t concurrent_request_count, size_t exact_request_count = 0);
 
   // Restart all worker threads that were working on sequences
   //

--- a/src/c++/perf_analyzer/concurrency_worker.h
+++ b/src/c++/perf_analyzer/concurrency_worker.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/custom_load_manager.cc
+++ b/src/c++/perf_analyzer/custom_load_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/custom_load_manager.cc
+++ b/src/c++/perf_analyzer/custom_load_manager.cc
@@ -76,10 +76,10 @@ CustomLoadManager::CustomLoadManager(
 }
 
 cb::Error
-CustomLoadManager::InitCustomIntervals()
+CustomLoadManager::InitCustomIntervals(const size_t num_of_requests)
 {
   PauseWorkers();
-  ConfigureThreads();
+  ConfigureThreads(num_of_requests);
   auto status = GenerateSchedule();
   ResumeWorkers();
   return status;

--- a/src/c++/perf_analyzer/custom_load_manager.cc
+++ b/src/c++/perf_analyzer/custom_load_manager.cc
@@ -76,10 +76,10 @@ CustomLoadManager::CustomLoadManager(
 }
 
 cb::Error
-CustomLoadManager::InitCustomIntervals(const size_t num_of_requests)
+CustomLoadManager::InitCustomIntervals(const size_t request_count)
 {
   PauseWorkers();
-  ConfigureThreads(num_of_requests);
+  ConfigureThreads(request_count);
   auto status = GenerateSchedule();
   ResumeWorkers();
   return status;

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -89,7 +89,7 @@ class CustomLoadManager : public RequestRateManager {
   /// Initializes the load manager with the provided file containing request
   /// intervals
   /// \return cb::Error object indicating success or failure.
-  cb::Error InitCustomIntervals();
+  cb::Error InitCustomIntervals(const size_t num_of_requests);
 
   /// Computes the request rate from the time interval file. Fails with an error
   /// if the file is not present or is empty.

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -88,6 +88,8 @@ class CustomLoadManager : public RequestRateManager {
 
   /// Initializes the load manager with the provided file containing request
   /// intervals
+  /// \param request_count The number of requests to generate. If 0, then
+  /// there is no limit, and it will generate until told to stop.
   /// \return cb::Error object indicating success or failure.
   cb::Error InitCustomIntervals(const size_t request_count);
 

--- a/src/c++/perf_analyzer/custom_load_manager.h
+++ b/src/c++/perf_analyzer/custom_load_manager.h
@@ -89,7 +89,7 @@ class CustomLoadManager : public RequestRateManager {
   /// Initializes the load manager with the provided file containing request
   /// intervals
   /// \return cb::Error object indicating success or failure.
-  cb::Error InitCustomIntervals(const size_t num_of_requests);
+  cb::Error InitCustomIntervals(const size_t request_count);
 
   /// Computes the request rate from the time interval file. Fails with an error
   /// if the file is not present or is empty.

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -62,9 +62,6 @@ struct ThreadStat {
   // A lock to protect thread data
   std::mutex mu_;
 
-  // FIXME TKG comment
-  size_t max_requests_{0};
-
   // The number of sent requests by this thread.
   std::atomic<size_t> num_sent_requests_{0};
 };

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -61,7 +61,6 @@ struct ThreadStat {
   std::vector<RequestRecord> request_records_;
   // A lock to protect thread data
   std::mutex mu_;
-
   // The number of sent requests by this thread.
   std::atomic<size_t> num_sent_requests_{0};
 };

--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -61,6 +61,10 @@ struct ThreadStat {
   std::vector<RequestRecord> request_records_;
   // A lock to protect thread data
   std::mutex mu_;
+
+  // FIXME TKG comment
+  size_t max_requests_{0};
+
   // The number of sent requests by this thread.
   std::atomic<size_t> num_sent_requests_{0};
 };

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -761,6 +761,12 @@ InferenceProfiler::ProfileHelper(
 
     *is_stable = DetermineStability(load_status);
 
+    // FIXME TKG -- need to know if fixed num mode
+    if (measurement_mode_ == MeasurementMode::COUNT_WINDOWS) {
+      *is_stable = true;
+      break;
+    }
+
     if (IsDoneProfiling(load_status, is_stable)) {
       break;
     }

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -533,7 +533,7 @@ InferenceProfiler::InferenceProfiler(
 
 cb::Error
 InferenceProfiler::Profile(
-    const size_t concurrent_request_count, const size_t exact_request_count,
+    const size_t concurrent_request_count, const size_t num_of_requests,
     std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
     bool& is_stable)
 {
@@ -545,9 +545,9 @@ InferenceProfiler::Profile(
   is_stable = false;
   meets_threshold = true;
 
-  RETURN_IF_ERROR(dynamic_cast<ConcurrencyManager*>(manager_.get())
-                      ->ChangeConcurrencyLevel(
-                          concurrent_request_count, exact_request_count));
+  RETURN_IF_ERROR(
+      dynamic_cast<ConcurrencyManager*>(manager_.get())
+          ->ChangeConcurrencyLevel(concurrent_request_count, num_of_requests));
 
   err = ProfileHelper(perf_status, &is_stable);
   if (err.IsOk()) {
@@ -591,7 +591,7 @@ InferenceProfiler::Profile(
 
 cb::Error
 InferenceProfiler::Profile(
-    const double request_rate, const size_t exact_request_count,
+    const double request_rate, const size_t num_of_requests,
     std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
     bool& is_stable)
 {
@@ -604,7 +604,7 @@ InferenceProfiler::Profile(
   meets_threshold = true;
 
   RETURN_IF_ERROR(dynamic_cast<RequestRateManager*>(manager_.get())
-                      ->ChangeRequestRate(request_rate));
+                      ->ChangeRequestRate(request_rate, num_of_requests));
   std::cout << "Request Rate: " << request_rate
             << " inference requests per seconds" << std::endl;
 
@@ -640,14 +640,14 @@ InferenceProfiler::Profile(
 
 cb::Error
 InferenceProfiler::Profile(
-    const size_t exact_request_count, std::vector<PerfStatus>& perf_statuses,
+    const size_t num_of_requests, std::vector<PerfStatus>& perf_statuses,
     bool& meets_threshold, bool& is_stable)
 {
   cb::Error err;
   PerfStatus perf_status{};
 
-  RETURN_IF_ERROR(
-      dynamic_cast<CustomLoadManager*>(manager_.get())->InitCustomIntervals());
+  RETURN_IF_ERROR(dynamic_cast<CustomLoadManager*>(manager_.get())
+                      ->InitCustomIntervals(num_of_requests));
   RETURN_IF_ERROR(dynamic_cast<CustomLoadManager*>(manager_.get())
                       ->GetCustomRequestRate(&perf_status.request_rate));
 

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -533,7 +533,7 @@ InferenceProfiler::InferenceProfiler(
 
 cb::Error
 InferenceProfiler::Profile(
-    const size_t concurrent_request_count,
+    const size_t concurrent_request_count, const size_t exact_request_count,
     std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
     bool& is_stable)
 {
@@ -546,7 +546,8 @@ InferenceProfiler::Profile(
   meets_threshold = true;
 
   RETURN_IF_ERROR(dynamic_cast<ConcurrencyManager*>(manager_.get())
-                      ->ChangeConcurrencyLevel(concurrent_request_count));
+                      ->ChangeConcurrencyLevel(
+                          concurrent_request_count, exact_request_count));
 
   err = ProfileHelper(perf_status, &is_stable);
   if (err.IsOk()) {
@@ -590,8 +591,9 @@ InferenceProfiler::Profile(
 
 cb::Error
 InferenceProfiler::Profile(
-    const double request_rate, std::vector<PerfStatus>& perf_statuses,
-    bool& meets_threshold, bool& is_stable)
+    const double request_rate, const size_t exact_request_count,
+    std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
+    bool& is_stable)
 {
   cb::Error err;
   PerfStatus perf_status{};
@@ -638,8 +640,8 @@ InferenceProfiler::Profile(
 
 cb::Error
 InferenceProfiler::Profile(
-    std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
-    bool& is_stable)
+    const size_t exact_request_count, std::vector<PerfStatus>& perf_statuses,
+    bool& meets_threshold, bool& is_stable)
 {
   cb::Error err;
   PerfStatus perf_status{};

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -761,7 +761,7 @@ InferenceProfiler::ProfileHelper(
       }
     }
 
-    // If num of requests is specified, then only measure one window and exit
+    // If request-count is specified, then only measure one window and exit
     if (request_count != 0) {
       *is_stable = true;
       break;

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -533,7 +533,7 @@ InferenceProfiler::InferenceProfiler(
 
 cb::Error
 InferenceProfiler::Profile(
-    const size_t concurrent_request_count, const size_t num_of_requests,
+    const size_t concurrent_request_count, const size_t request_count,
     std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
     bool& is_stable)
 {
@@ -547,9 +547,9 @@ InferenceProfiler::Profile(
 
   RETURN_IF_ERROR(
       dynamic_cast<ConcurrencyManager*>(manager_.get())
-          ->ChangeConcurrencyLevel(concurrent_request_count, num_of_requests));
+          ->ChangeConcurrencyLevel(concurrent_request_count, request_count));
 
-  err = ProfileHelper(perf_status, num_of_requests, &is_stable);
+  err = ProfileHelper(perf_status, request_count, &is_stable);
   if (err.IsOk()) {
     uint64_t stabilizing_latency_ms =
         perf_status.stabilizing_latency_ns / NANOS_PER_MILLIS;
@@ -591,7 +591,7 @@ InferenceProfiler::Profile(
 
 cb::Error
 InferenceProfiler::Profile(
-    const double request_rate, const size_t num_of_requests,
+    const double request_rate, const size_t request_count,
     std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
     bool& is_stable)
 {
@@ -604,11 +604,11 @@ InferenceProfiler::Profile(
   meets_threshold = true;
 
   RETURN_IF_ERROR(dynamic_cast<RequestRateManager*>(manager_.get())
-                      ->ChangeRequestRate(request_rate, num_of_requests));
+                      ->ChangeRequestRate(request_rate, request_count));
   std::cout << "Request Rate: " << request_rate
             << " inference requests per seconds" << std::endl;
 
-  err = ProfileHelper(perf_status, num_of_requests, &is_stable);
+  err = ProfileHelper(perf_status, request_count, &is_stable);
   if (err.IsOk()) {
     uint64_t stabilizing_latency_ms =
         perf_status.stabilizing_latency_ns / NANOS_PER_MILLIS;
@@ -640,21 +640,21 @@ InferenceProfiler::Profile(
 
 cb::Error
 InferenceProfiler::Profile(
-    const size_t num_of_requests, std::vector<PerfStatus>& perf_statuses,
+    const size_t request_count, std::vector<PerfStatus>& perf_statuses,
     bool& meets_threshold, bool& is_stable)
 {
   cb::Error err;
   PerfStatus perf_status{};
 
   RETURN_IF_ERROR(dynamic_cast<CustomLoadManager*>(manager_.get())
-                      ->InitCustomIntervals(num_of_requests));
+                      ->InitCustomIntervals(request_count));
   RETURN_IF_ERROR(dynamic_cast<CustomLoadManager*>(manager_.get())
                       ->GetCustomRequestRate(&perf_status.request_rate));
 
   is_stable = false;
   meets_threshold = true;
 
-  err = ProfileHelper(perf_status, num_of_requests, &is_stable);
+  err = ProfileHelper(perf_status, request_count, &is_stable);
   if (err.IsOk()) {
     uint64_t stabilizing_latency_ms =
         perf_status.stabilizing_latency_ns / NANOS_PER_MILLIS;
@@ -686,7 +686,7 @@ InferenceProfiler::Profile(
 
 cb::Error
 InferenceProfiler::ProfileHelper(
-    PerfStatus& experiment_perf_status, size_t num_of_requests, bool* is_stable)
+    PerfStatus& experiment_perf_status, size_t request_count, bool* is_stable)
 {
   // Start measurement
   LoadStatus load_status;
@@ -762,7 +762,7 @@ InferenceProfiler::ProfileHelper(
     }
 
     // If num of requests is specified, then only measure one window and exit
-    if (num_of_requests != 0) {
+    if (request_count != 0) {
       *is_stable = true;
       break;
     }

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -357,7 +357,7 @@ class InferenceProfiler {
   /// \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
-      const size_t concurrent_request_count, const size_t exact_request_count,
+      const size_t concurrent_request_count, const size_t num_of_requests,
       std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
       bool& is_stable);
 
@@ -369,7 +369,7 @@ class InferenceProfiler {
   /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
-      const double request_rate, const size_t exact_request_count,
+      const double request_rate, const size_t num_of_requests,
       std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
       bool& is_stable);
 
@@ -382,7 +382,7 @@ class InferenceProfiler {
   /// \return cb::Error object indicating success
   /// or failure.
   cb::Error Profile(
-      const size_t exact_request_count, std::vector<PerfStatus>& perf_statuses,
+      const size_t num_of_requests, std::vector<PerfStatus>& perf_statuses,
       bool& meets_threshold, bool& is_stable);
 
   /// A helper function for profiling functions.

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -254,12 +254,12 @@ class InferenceProfiler {
   template <typename T>
   cb::Error Profile(
       const T start, const T end, const T step, const SearchMode search_mode,
-      const size_t exact_req_count, std::vector<PerfStatus>& perf_statuses)
+      const size_t request_count, std::vector<PerfStatus>& perf_statuses)
   {
     cb::Error err;
     bool meets_threshold, is_stable;
     if (search_mode == SearchMode::NONE) {
-      err = Profile(exact_req_count, perf_statuses, meets_threshold, is_stable);
+      err = Profile(request_count, perf_statuses, meets_threshold, is_stable);
       if (!err.IsOk()) {
         return err;
       }
@@ -267,7 +267,7 @@ class InferenceProfiler {
       T current_value = start;
       do {
         err = Profile(
-            current_value, exact_req_count, perf_statuses, meets_threshold,
+            current_value, request_count, perf_statuses, meets_threshold,
             is_stable);
         if (!err.IsOk()) {
           return err;
@@ -283,12 +283,12 @@ class InferenceProfiler {
       }
     } else {
       err = Profile(
-          start, exact_req_count, perf_statuses, meets_threshold, is_stable);
+          start, request_count, perf_statuses, meets_threshold, is_stable);
       if (!err.IsOk() || (!meets_threshold)) {
         return err;
       }
       err = Profile(
-          end, exact_req_count, perf_statuses, meets_threshold, is_stable);
+          end, request_count, perf_statuses, meets_threshold, is_stable);
       if (!err.IsOk() || (meets_threshold)) {
         return err;
       }
@@ -298,7 +298,7 @@ class InferenceProfiler {
       while ((this_end - this_start) > step) {
         T current_value = (this_end + this_start) / 2;
         err = Profile(
-            current_value, exact_req_count, perf_statuses, meets_threshold,
+            current_value, request_count, perf_statuses, meets_threshold,
             is_stable);
         if (!err.IsOk()) {
           return err;
@@ -357,7 +357,7 @@ class InferenceProfiler {
   /// \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
-      const size_t concurrent_request_count, const size_t num_of_requests,
+      const size_t concurrent_request_count, const size_t request_count,
       std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
       bool& is_stable);
 
@@ -369,7 +369,7 @@ class InferenceProfiler {
   /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
-      const double request_rate, const size_t num_of_requests,
+      const double request_rate, const size_t request_count,
       std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
       bool& is_stable);
 
@@ -382,7 +382,7 @@ class InferenceProfiler {
   /// \return cb::Error object indicating success
   /// or failure.
   cb::Error Profile(
-      const size_t num_of_requests, std::vector<PerfStatus>& perf_statuses,
+      const size_t request_count, std::vector<PerfStatus>& perf_statuses,
       bool& meets_threshold, bool& is_stable);
 
   /// A helper function for profiling functions.
@@ -390,7 +390,7 @@ class InferenceProfiler {
   /// \param is_stable Returns whether the measurement stabilized or not.
   /// \return cb::Error object indicating success or failure.
   cb::Error ProfileHelper(
-      PerfStatus& status_summary, size_t num_of_requests, bool* is_stable);
+      PerfStatus& status_summary, size_t request_count, bool* is_stable);
 
   /// A helper function to determine if profiling is stable
   /// \param load_status Stores the observations of infer_per_sec and latencies

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -254,19 +254,21 @@ class InferenceProfiler {
   template <typename T>
   cb::Error Profile(
       const T start, const T end, const T step, const SearchMode search_mode,
-      std::vector<PerfStatus>& perf_statuses)
+      const size_t exact_req_count, std::vector<PerfStatus>& perf_statuses)
   {
     cb::Error err;
     bool meets_threshold, is_stable;
     if (search_mode == SearchMode::NONE) {
-      err = Profile(perf_statuses, meets_threshold, is_stable);
+      err = Profile(exact_req_count, perf_statuses, meets_threshold, is_stable);
       if (!err.IsOk()) {
         return err;
       }
     } else if (search_mode == SearchMode::LINEAR) {
       T current_value = start;
       do {
-        err = Profile(current_value, perf_statuses, meets_threshold, is_stable);
+        err = Profile(
+            current_value, exact_req_count, perf_statuses, meets_threshold,
+            is_stable);
         if (!err.IsOk()) {
           return err;
         }
@@ -280,11 +282,13 @@ class InferenceProfiler {
             "Failed to obtain stable measurement.", pa::STABILITY_ERROR);
       }
     } else {
-      err = Profile(start, perf_statuses, meets_threshold, is_stable);
+      err = Profile(
+          start, exact_req_count, perf_statuses, meets_threshold, is_stable);
       if (!err.IsOk() || (!meets_threshold)) {
         return err;
       }
-      err = Profile(end, perf_statuses, meets_threshold, is_stable);
+      err = Profile(
+          end, exact_req_count, perf_statuses, meets_threshold, is_stable);
       if (!err.IsOk() || (meets_threshold)) {
         return err;
       }
@@ -293,7 +297,9 @@ class InferenceProfiler {
       T this_end = end;
       while ((this_end - this_start) > step) {
         T current_value = (this_end + this_start) / 2;
-        err = Profile(current_value, perf_statuses, meets_threshold, is_stable);
+        err = Profile(
+            current_value, exact_req_count, perf_statuses, meets_threshold,
+            is_stable);
         if (!err.IsOk()) {
           return err;
         }
@@ -351,7 +357,7 @@ class InferenceProfiler {
   /// \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
-      const size_t concurrent_request_count,
+      const size_t concurrent_request_count, const size_t exact_request_count,
       std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
       bool& is_stable);
 
@@ -363,8 +369,9 @@ class InferenceProfiler {
   /// threshold. \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
-      const double request_rate, std::vector<PerfStatus>& perf_statuses,
-      bool& meets_threshold, bool& is_stable);
+      const double request_rate, const size_t exact_request_count,
+      std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
+      bool& is_stable);
 
   /// Measures throughput and latencies for custom load without controlling
   /// request rate nor concurrency. Requires load manager to be loaded with
@@ -375,8 +382,8 @@ class InferenceProfiler {
   /// \return cb::Error object indicating success
   /// or failure.
   cb::Error Profile(
-      std::vector<PerfStatus>& perf_statuses, bool& meets_threshold,
-      bool& is_stable);
+      const size_t exact_request_count, std::vector<PerfStatus>& perf_statuses,
+      bool& meets_threshold, bool& is_stable);
 
   /// A helper function for profiling functions.
   /// \param status_summary Returns the summary of the measurement.

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -389,7 +389,8 @@ class InferenceProfiler {
   /// \param status_summary Returns the summary of the measurement.
   /// \param is_stable Returns whether the measurement stabilized or not.
   /// \return cb::Error object indicating success or failure.
-  cb::Error ProfileHelper(PerfStatus& status_summary, bool* is_stable);
+  cb::Error ProfileHelper(
+      PerfStatus& status_summary, size_t num_of_requests, bool* is_stable);
 
   /// A helper function to determine if profiling is stable
   /// \param load_status Stores the observations of infer_per_sec and latencies

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -248,8 +248,10 @@ class InferenceProfiler {
   /// \param step The step size to move along the search range in linear search
   /// or the precision in binary search.
   /// \param search_mode The search algorithm to be applied.
-  /// \param summary Returns the trace of the measurement along the search
-  /// path.
+  /// \param request_count The number of requests to generate in each
+  /// experiment. If 0, then there is no limit, and it will generate until
+  /// stable.
+  /// \param summary Returns the trace of the measurement along the search path.
   /// \return cb::Error object indicating success or failure.
   template <typename T>
   cb::Error Profile(
@@ -352,7 +354,10 @@ class InferenceProfiler {
   /// request and right after the last request in the measurement window).
   /// \param concurrent_request_count The concurrency level for the measurement.
   /// \param perf_statuses Appends the measurements summary at the end of this
-  /// list. \param meets_threshold Returns whether the setting meets the
+  /// list.
+  /// \param request_count The number of requests to generate when profiling. If
+  /// 0, then there is no limit, and it will generate until stable.
+  /// \param meets_threshold Returns whether the setting meets the
   /// threshold.
   /// \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
@@ -364,9 +369,13 @@ class InferenceProfiler {
   /// Similar to above function, but instead of setting the concurrency, it
   /// sets the specified request rate for measurements.
   /// \param request_rate The request rate for inferences.
+  /// \param request_count The number of requests to generate when profiling. If
+  /// 0, then there is no limit, and it will generate until stable.
   /// \param perf_statuses Appends the measurements summary at the end of this
-  /// list. \param meets_threshold Returns whether the setting meets the
-  /// threshold. \param is_stable Returns whether the measurement is stable.
+  /// list.
+  /// \param meets_threshold Returns whether the setting meets the
+  /// threshold.
+  /// \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success or failure.
   cb::Error Profile(
       const double request_rate, const size_t request_count,
@@ -376,9 +385,13 @@ class InferenceProfiler {
   /// Measures throughput and latencies for custom load without controlling
   /// request rate nor concurrency. Requires load manager to be loaded with
   /// a file specifying the time intervals.
+  /// \param request_count The number of requests to generate when profiling. If
+  /// 0, then there is no limit, and it will generate until stable.
   /// \param perf_statuses Appends the measurements summary at the end of this
-  /// list. \param meets_threshold Returns whether the measurement met the
-  /// threshold. \param is_stable Returns whether the measurement is stable.
+  /// list.
+  /// \param meets_threshold Returns whether the measurement met the
+  /// threshold.
+  /// \param is_stable Returns whether the measurement is stable.
   /// \return cb::Error object indicating success
   /// or failure.
   cb::Error Profile(
@@ -387,6 +400,8 @@ class InferenceProfiler {
 
   /// A helper function for profiling functions.
   /// \param status_summary Returns the summary of the measurement.
+  /// \param request_count The number of requests to generate when profiling. If
+  /// 0, then there is no limit, and it will generate until stable.
   /// \param is_stable Returns whether the measurement stabilized or not.
   /// \return cb::Error object indicating success or failure.
   cb::Error ProfileHelper(

--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -78,12 +78,12 @@ LoadManager::SwapRequestRecords(std::vector<RequestRecord>& new_request_records)
 uint64_t
 LoadManager::CountCollectedRequests()
 {
-  uint64_t num_of_requests = 0;
+  uint64_t request_count = 0;
   for (auto& thread_stat : threads_stat_) {
     std::lock_guard<std::mutex> lock(thread_stat->mu_);
-    num_of_requests += thread_stat->request_records_.size();
+    request_count += thread_stat->request_records_.size();
   }
-  return num_of_requests;
+  return request_count;
 }
 
 cb::Error

--- a/src/c++/perf_analyzer/load_manager.cc
+++ b/src/c++/perf_analyzer/load_manager.cc
@@ -78,12 +78,12 @@ LoadManager::SwapRequestRecords(std::vector<RequestRecord>& new_request_records)
 uint64_t
 LoadManager::CountCollectedRequests()
 {
-  uint64_t request_count = 0;
+  uint64_t num_of_requests = 0;
   for (auto& thread_stat : threads_stat_) {
     std::lock_guard<std::mutex> lock(thread_stat->mu_);
-    request_count += thread_stat->request_records_.size();
+    num_of_requests += thread_stat->request_records_.size();
   }
-  return request_count;
+  return num_of_requests;
 }
 
 cb::Error

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -47,8 +47,8 @@ bool
 LoadWorker::HandleExitConditions()
 {
   if (ShouldExit()) {
-    thread_stat_->idle_timer.Start();
     CompleteOngoingSequences();
+    thread_stat_->idle_timer.Start();
     WaitForOngoingRequests();
     return true;
   }

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -37,10 +37,14 @@ namespace triton { namespace perfanalyzer {
 bool
 LoadWorker::ShouldExit()
 {
-  return early_exit || !thread_stat_->cb_status_.IsOk() ||
-         !thread_stat_->status_.IsOk() ||
-         (thread_config_->num_requests_ &&
-          thread_stat_->num_sent_requests_ >= thread_config_->num_requests_);
+  bool bad_status =
+      !thread_stat_->cb_status_.IsOk() || !thread_stat_->status_.IsOk();
+
+  bool done_with_request_count =
+      thread_config_->num_requests_ != 0 &&
+      thread_stat_->num_sent_requests_ >= thread_config_->num_requests_;
+
+  return early_exit || bad_status || done_with_request_count;
 }
 
 bool

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -47,9 +47,9 @@ bool
 LoadWorker::HandleExitConditions()
 {
   if (ShouldExit()) {
+    thread_stat_->idle_timer.Start();
     CompleteOngoingSequences();
     WaitForOngoingRequests();
-    thread_stat_->idle_timer.Start();
     return true;
   }
   return false;

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -39,8 +39,8 @@ LoadWorker::ShouldExit()
 {
   return early_exit || !thread_stat_->cb_status_.IsOk() ||
          !thread_stat_->status_.IsOk() ||
-         (thread_stat_->max_requests_ &&
-          thread_stat_->num_sent_requests_ >= thread_stat_->max_requests_);
+         (thread_config_->num_requests_ &&
+          thread_stat_->num_sent_requests_ >= thread_config_->num_requests_);
 }
 
 bool

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -38,7 +38,9 @@ bool
 LoadWorker::ShouldExit()
 {
   return early_exit || !thread_stat_->cb_status_.IsOk() ||
-         !thread_stat_->status_.IsOk();
+         !thread_stat_->status_.IsOk() ||
+         (thread_stat_->max_requests_ &&
+          thread_stat_->num_sent_requests_ >= thread_stat_->max_requests_);
 }
 
 bool
@@ -47,6 +49,7 @@ LoadWorker::HandleExitConditions()
   if (ShouldExit()) {
     CompleteOngoingSequences();
     WaitForOngoingRequests();
+    thread_stat_->idle_timer.Start();
     return true;
   }
   return false;

--- a/src/c++/perf_analyzer/load_worker.cc
+++ b/src/c++/perf_analyzer/load_worker.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/load_worker.h
+++ b/src/c++/perf_analyzer/load_worker.h
@@ -36,6 +36,7 @@
 #include "iworker.h"
 #include "model_parser.h"
 #include "sequence_manager.h"
+#include "thread_config.h"
 
 namespace triton { namespace perfanalyzer {
 
@@ -45,6 +46,7 @@ class LoadWorker : public IWorker {
  protected:
   LoadWorker(
       uint32_t id, std::shared_ptr<ThreadStat> thread_stat,
+      std::shared_ptr<ThreadConfig> thread_config,
       const std::shared_ptr<ModelParser> parser,
       std::shared_ptr<DataLoader> data_loader,
       const std::shared_ptr<cb::ClientBackendFactory> factory,
@@ -54,8 +56,8 @@ class LoadWorker : public IWorker {
       bool& execute,
       const std::shared_ptr<IInferDataManager>& infer_data_manager,
       std::shared_ptr<SequenceManager> sequence_manager)
-      : id_(id), thread_stat_(thread_stat), parser_(parser),
-        data_loader_(data_loader), factory_(factory),
+      : id_(id), thread_stat_(thread_stat), thread_config_(thread_config),
+        parser_(parser), data_loader_(data_loader), factory_(factory),
         on_sequence_model_(on_sequence_model), async_(async),
         streaming_(streaming), batch_size_(batch_size),
         using_json_data_(using_json_data), wake_signal_(wake_signal),
@@ -137,6 +139,8 @@ class LoadWorker : public IWorker {
 
   // Stats for this thread
   std::shared_ptr<ThreadStat> thread_stat_;
+  // Configuration for this thread
+  std::shared_ptr<ThreadConfig> thread_config_;
 
   std::shared_ptr<DataLoader> data_loader_;
   const std::shared_ptr<ModelParser> parser_;

--- a/src/c++/perf_analyzer/load_worker.h
+++ b/src/c++/perf_analyzer/load_worker.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -384,7 +384,7 @@ PerfAnalyzer::Profile()
     err = profiler_->Profile<size_t>(
         params_->concurrency_range.start, params_->concurrency_range.end,
         params_->concurrency_range.step, params_->search_mode,
-        params_->num_requests, perf_statuses_);
+        params_->fixed_num_requests, perf_statuses_);
   } else if (params_->is_using_periodic_concurrency_mode) {
     err = profiler_->ProfilePeriodicConcurrencyMode();
   } else {
@@ -392,7 +392,7 @@ PerfAnalyzer::Profile()
         params_->request_rate_range[pa::SEARCH_RANGE::kSTART],
         params_->request_rate_range[pa::SEARCH_RANGE::kEND],
         params_->request_rate_range[pa::SEARCH_RANGE::kSTEP],
-        params_->search_mode, params_->num_requests, perf_statuses_);
+        params_->search_mode, params_->fixed_num_requests, perf_statuses_);
   }
 
   params_->mpi_driver->MPIBarrierWorld();

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -315,6 +315,7 @@ PerfAnalyzer::PrerunReport()
     std::cout << "  Measurement window: " << params_->measurement_window_ms
               << " msec" << std::endl;
   } else if (params_->measurement_mode == pa::MeasurementMode::COUNT_WINDOWS) {
+    // FIXME TKG -- change based on new arg?
     std::cout << "  Minimum number of samples in each window: "
               << params_->measurement_request_count << std::endl;
   }

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -295,30 +295,39 @@ PerfAnalyzer::PrerunReport()
   if (params_->kind == cb::BackendKind::TRITON || params_->using_batch_size) {
     std::cout << "  Batch size: " << params_->batch_size << std::endl;
   }
-  if (params_->kind == cb::BackendKind::TRITON_C_API) {
-    std::cout << "  Service Kind: Triton C-API" << std::endl;
-  } else if (params_->kind == cb::BackendKind::TRITON) {
-    std::cout << "  Service Kind: Triton" << std::endl;
-  } else if (params_->kind == cb::BackendKind::TORCHSERVE) {
-    std::cout << "  Service Kind: TorchServe" << std::endl;
-  } else if (params_->kind == cb::BackendKind::TENSORFLOW_SERVING) {
-    std::cout << "  Service Kind: TensorFlow Serving" << std::endl;
+
+  std::cout << "  Service Kind: " << BackendKindToString(params_->kind)
+            << std::endl;
+
+  if (params_->request_count != 0) {
+    std::cout << "  Sending a total of " << params_->request_count
+              << " requests" << std::endl;
+  } else {
+    if (params_->measurement_mode == pa::MeasurementMode::COUNT_WINDOWS) {
+      std::cout << "  Using \"count_windows\" mode for stabilization"
+                << std::endl;
+    } else {
+      std::cout << "  Using \"time_windows\" mode for stabilization"
+                << std::endl;
+    }
+
+    if (params_->percentile == -1) {
+      std::cout << "  Stabilizing using average latency" << std::endl;
+    } else {
+      std::cout << "  Stabilizing using p" << params_->percentile << " latency"
+                << std::endl;
+    }
+
+    if (params_->measurement_mode == pa::MeasurementMode::TIME_WINDOWS) {
+      std::cout << "  Measurement window: " << params_->measurement_window_ms
+                << " msec" << std::endl;
+    } else if (
+        params_->measurement_mode == pa::MeasurementMode::COUNT_WINDOWS) {
+      std::cout << "  Minimum number of samples in each window: "
+                << params_->measurement_request_count << std::endl;
+    }
   }
 
-  if (params_->measurement_mode == pa::MeasurementMode::COUNT_WINDOWS) {
-    std::cout << "  Using \"count_windows\" mode for stabilization"
-              << std::endl;
-  } else {
-    std::cout << "  Using \"time_windows\" mode for stabilization" << std::endl;
-  }
-  if (params_->measurement_mode == pa::MeasurementMode::TIME_WINDOWS) {
-    std::cout << "  Measurement window: " << params_->measurement_window_ms
-              << " msec" << std::endl;
-  } else if (params_->measurement_mode == pa::MeasurementMode::COUNT_WINDOWS) {
-    // FIXME TKG -- change based on new arg?
-    std::cout << "  Minimum number of samples in each window: "
-              << params_->measurement_request_count << std::endl;
-  }
   if (params_->concurrency_range.end != 1) {
     std::cout << "  Latency limit: " << params_->latency_threshold_ms << " msec"
               << std::endl;
@@ -365,12 +374,6 @@ PerfAnalyzer::PrerunReport()
               << std::endl;
   }
 
-  if (params_->percentile == -1) {
-    std::cout << "  Stabilizing using average latency" << std::endl;
-  } else {
-    std::cout << "  Stabilizing using p" << params_->percentile << " latency"
-              << std::endl;
-  }
   std::cout << std::endl;
 }
 

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -383,7 +383,8 @@ PerfAnalyzer::Profile()
   if (params_->targeting_concurrency()) {
     err = profiler_->Profile<size_t>(
         params_->concurrency_range.start, params_->concurrency_range.end,
-        params_->concurrency_range.step, params_->search_mode, perf_statuses_);
+        params_->concurrency_range.step, params_->search_mode,
+        params_->num_requests, perf_statuses_);
   } else if (params_->is_using_periodic_concurrency_mode) {
     err = profiler_->ProfilePeriodicConcurrencyMode();
   } else {
@@ -391,7 +392,7 @@ PerfAnalyzer::Profile()
         params_->request_rate_range[pa::SEARCH_RANGE::kSTART],
         params_->request_rate_range[pa::SEARCH_RANGE::kEND],
         params_->request_rate_range[pa::SEARCH_RANGE::kSTEP],
-        params_->search_mode, perf_statuses_);
+        params_->search_mode, params_->num_requests, perf_statuses_);
   }
 
   params_->mpi_driver->MPIBarrierWorld();

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -384,7 +384,7 @@ PerfAnalyzer::Profile()
     err = profiler_->Profile<size_t>(
         params_->concurrency_range.start, params_->concurrency_range.end,
         params_->concurrency_range.step, params_->search_mode,
-        params_->fixed_num_requests, perf_statuses_);
+        params_->request_count, perf_statuses_);
   } else if (params_->is_using_periodic_concurrency_mode) {
     err = profiler_->ProfilePeriodicConcurrencyMode();
   } else {
@@ -392,7 +392,7 @@ PerfAnalyzer::Profile()
         params_->request_rate_range[pa::SEARCH_RANGE::kSTART],
         params_->request_rate_range[pa::SEARCH_RANGE::kEND],
         params_->request_rate_range[pa::SEARCH_RANGE::kSTEP],
-        params_->search_mode, params_->fixed_num_requests, perf_statuses_);
+        params_->search_mode, params_->request_count, perf_statuses_);
   }
 
   params_->mpi_driver->MPIBarrierWorld();

--- a/src/c++/perf_analyzer/periodic_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/periodic_concurrency_manager.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/periodic_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/periodic_concurrency_manager.cc
@@ -65,8 +65,10 @@ void
 PeriodicConcurrencyManager::AddConcurrentRequest(size_t seq_stat_index_offset)
 {
   threads_stat_.emplace_back(std::make_shared<ThreadStat>());
-  threads_config_.emplace_back(std::make_shared<ThreadConfig>(
-      threads_config_.size(), 1, seq_stat_index_offset));
+  threads_config_.emplace_back(
+      std::make_shared<ThreadConfig>(threads_config_.size()));
+  threads_config_.back()->concurrency_ = 1;
+  threads_config_.back()->seq_stat_index_offset_ = seq_stat_index_offset;
   workers_.emplace_back(
       MakeWorker(threads_stat_.back(), threads_config_.back()));
   threads_.emplace_back(&IWorker::Infer, workers_.back());

--- a/src/c++/perf_analyzer/periodic_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/periodic_concurrency_manager.cc
@@ -39,7 +39,7 @@ PeriodicConcurrencyManager::RunExperiment()
 std::shared_ptr<IWorker>
 PeriodicConcurrencyManager::MakeWorker(
     std::shared_ptr<ThreadStat> thread_stat,
-    std::shared_ptr<PeriodicConcurrencyWorker::ThreadConfig> thread_config)
+    std::shared_ptr<ThreadConfig> thread_config)
 {
   uint32_t id = workers_.size();
   auto worker = std::make_shared<PeriodicConcurrencyWorker>(
@@ -65,9 +65,8 @@ void
 PeriodicConcurrencyManager::AddConcurrentRequest(size_t seq_stat_index_offset)
 {
   threads_stat_.emplace_back(std::make_shared<ThreadStat>());
-  threads_config_.emplace_back(
-      std::make_shared<ConcurrencyWorker::ThreadConfig>(
-          threads_config_.size(), 1, seq_stat_index_offset));
+  threads_config_.emplace_back(std::make_shared<ThreadConfig>(
+      threads_config_.size(), 1, seq_stat_index_offset));
   workers_.emplace_back(
       MakeWorker(threads_stat_.back(), threads_config_.back()));
   threads_.emplace_back(&IWorker::Infer, workers_.back());

--- a/src/c++/perf_analyzer/periodic_concurrency_manager.h
+++ b/src/c++/perf_analyzer/periodic_concurrency_manager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/periodic_concurrency_manager.h
+++ b/src/c++/perf_analyzer/periodic_concurrency_manager.h
@@ -61,8 +61,7 @@ class PeriodicConcurrencyManager : public ConcurrencyManager {
  private:
   std::shared_ptr<IWorker> MakeWorker(
       std::shared_ptr<ThreadStat> thread_stat,
-      std::shared_ptr<PeriodicConcurrencyWorker::ThreadConfig> thread_config)
-      override;
+      std::shared_ptr<ThreadConfig> thread_config) override;
 
   void AddConcurrentRequests(uint64_t num_concurrent_requests);
 

--- a/src/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/c++/perf_analyzer/request_rate_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/c++/perf_analyzer/request_rate_manager.cc
@@ -261,8 +261,6 @@ RequestRateManager::ConfigureThreads(const size_t num_of_requests)
 
       size_t thread_num_reqs = avg_req_count + (i < req_count_add_one ? 1 : 0);
       threads_stat_[i]->max_requests_ = thread_num_reqs;
-      std::cout << "TKG -- req rate thread " << i << " is getting max reqs of "
-                << thread_num_reqs << std::endl;
 
       threads_.emplace_back(&IWorker::Infer, workers_[i]);
     }

--- a/src/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/c++/perf_analyzer/request_rate_manager.cc
@@ -90,10 +90,10 @@ RequestRateManager::InitManagerFinalize()
 
 cb::Error
 RequestRateManager::ChangeRequestRate(
-    const double request_rate, const size_t num_of_requests)
+    const double request_rate, const size_t request_count)
 {
   PauseWorkers();
-  ConfigureThreads(num_of_requests);
+  ConfigureThreads(request_count);
   // Can safely update the schedule
   GenerateSchedule(request_rate);
   ResumeWorkers();
@@ -230,7 +230,7 @@ RequestRateManager::PauseWorkers()
 }
 
 void
-RequestRateManager::ConfigureThreads(const size_t num_of_requests)
+RequestRateManager::ConfigureThreads(const size_t request_count)
 {
   if (threads_.empty()) {
     size_t num_of_threads = DetermineNumThreads();
@@ -248,8 +248,8 @@ RequestRateManager::ConfigureThreads(const size_t num_of_requests)
     size_t num_seqs_add_one = num_of_sequences_ % workers_.size();
     size_t seq_offset = 0;
 
-    size_t avg_req_count = num_of_requests / workers_.size();
-    size_t req_count_add_one = num_of_requests % workers_.size();
+    size_t avg_req_count = request_count / workers_.size();
+    size_t req_count_add_one = request_count % workers_.size();
 
 
     for (size_t i = 0; i < workers_.size(); i++) {

--- a/src/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/c++/perf_analyzer/request_rate_manager.cc
@@ -237,8 +237,7 @@ RequestRateManager::ConfigureThreads(const size_t num_of_requests)
     while (workers_.size() < num_of_threads) {
       // Launch new thread for inferencing
       threads_stat_.emplace_back(new ThreadStat());
-      threads_config_.emplace_back(
-          new RequestRateWorker::ThreadConfig(workers_.size()));
+      threads_config_.emplace_back(new ThreadConfig(workers_.size()));
 
       workers_.push_back(
           MakeWorker(threads_stat_.back(), threads_config_.back()));
@@ -260,7 +259,7 @@ RequestRateManager::ConfigureThreads(const size_t num_of_requests)
       seq_offset += num_of_seq;
 
       size_t thread_num_reqs = avg_req_count + (i < req_count_add_one ? 1 : 0);
-      threads_stat_[i]->max_requests_ = thread_num_reqs;
+      threads_config_[i]->num_requests_ = thread_num_reqs;
 
       threads_.emplace_back(&IWorker::Infer, workers_[i]);
     }
@@ -281,7 +280,7 @@ RequestRateManager::ResumeWorkers()
 std::shared_ptr<IWorker>
 RequestRateManager::MakeWorker(
     std::shared_ptr<ThreadStat> thread_stat,
-    std::shared_ptr<RequestRateWorker::ThreadConfig> thread_config)
+    std::shared_ptr<ThreadConfig> thread_config)
 {
   size_t id = workers_.size();
   size_t num_of_threads = DetermineNumThreads();

--- a/src/c++/perf_analyzer/request_rate_manager.h
+++ b/src/c++/perf_analyzer/request_rate_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/request_rate_manager.h
+++ b/src/c++/perf_analyzer/request_rate_manager.h
@@ -99,8 +99,10 @@ class RequestRateManager : public LoadManager {
           request_parameters);
 
   /// Adjusts the rate of issuing requests to be the same as 'request_rate'
-  /// \param request_rate The rate at which requests must be issued to the
-  /// server.
+  /// \param target_request_rate The rate at which requests must be issued to
+  /// the server.
+  /// \param request_count The number of requests to generate when profiling. If
+  /// 0, then there is no limit, and it will generate until told to stop.
   /// \return cb::Error object indicating success or failure.
   cb::Error ChangeRequestRate(
       const double target_request_rate, const size_t request_count = 0);

--- a/src/c++/perf_analyzer/request_rate_manager.h
+++ b/src/c++/perf_analyzer/request_rate_manager.h
@@ -103,7 +103,7 @@ class RequestRateManager : public LoadManager {
   /// server.
   /// \return cb::Error object indicating success or failure.
   cb::Error ChangeRequestRate(
-      const double target_request_rate, const size_t request_count);
+      const double target_request_rate, const size_t request_count = 0);
 
  protected:
   RequestRateManager(

--- a/src/c++/perf_analyzer/request_rate_manager.h
+++ b/src/c++/perf_analyzer/request_rate_manager.h
@@ -103,7 +103,7 @@ class RequestRateManager : public LoadManager {
   /// server.
   /// \return cb::Error object indicating success or failure.
   cb::Error ChangeRequestRate(
-      const double target_request_rate, const size_t num_of_requests);
+      const double target_request_rate, const size_t request_count);
 
  protected:
   RequestRateManager(
@@ -139,7 +139,7 @@ class RequestRateManager : public LoadManager {
   // Pauses the worker threads
   void PauseWorkers();
 
-  void ConfigureThreads(const size_t num_of_requests = 0);
+  void ConfigureThreads(const size_t request_count = 0);
 
   // Resets the counters and resumes the worker threads
   void ResumeWorkers();

--- a/src/c++/perf_analyzer/request_rate_manager.h
+++ b/src/c++/perf_analyzer/request_rate_manager.h
@@ -102,7 +102,9 @@ class RequestRateManager : public LoadManager {
   /// \param request_rate The rate at which requests must be issued to the
   /// server.
   /// \return cb::Error object indicating success or failure.
-  cb::Error ChangeRequestRate(const double target_request_rate);
+  // FIXME TKG -- no default(?)
+  cb::Error ChangeRequestRate(
+      const double target_request_rate, const size_t num_of_requests = 0);
 
  protected:
   RequestRateManager(
@@ -138,7 +140,8 @@ class RequestRateManager : public LoadManager {
   // Pauses the worker threads
   void PauseWorkers();
 
-  void ConfigureThreads();
+  // FIXME TKG -- no default(?)
+  void ConfigureThreads(const size_t num_of_requests = 0);
 
   // Resets the counters and resumes the worker threads
   void ResumeWorkers();

--- a/src/c++/perf_analyzer/request_rate_manager.h
+++ b/src/c++/perf_analyzer/request_rate_manager.h
@@ -102,9 +102,8 @@ class RequestRateManager : public LoadManager {
   /// \param request_rate The rate at which requests must be issued to the
   /// server.
   /// \return cb::Error object indicating success or failure.
-  // FIXME TKG -- no default(?)
   cb::Error ChangeRequestRate(
-      const double target_request_rate, const size_t num_of_requests = 0);
+      const double target_request_rate, const size_t num_of_requests);
 
  protected:
   RequestRateManager(
@@ -140,7 +139,6 @@ class RequestRateManager : public LoadManager {
   // Pauses the worker threads
   void PauseWorkers();
 
-  // FIXME TKG -- no default(?)
   void ConfigureThreads(const size_t num_of_requests = 0);
 
   // Resets the counters and resumes the worker threads
@@ -148,12 +146,11 @@ class RequestRateManager : public LoadManager {
 
   // Makes a new worker
   virtual std::shared_ptr<IWorker> MakeWorker(
-      std::shared_ptr<ThreadStat>,
-      std::shared_ptr<RequestRateWorker::ThreadConfig>);
+      std::shared_ptr<ThreadStat>, std::shared_ptr<ThreadConfig>);
 
   size_t DetermineNumThreads();
 
-  std::vector<std::shared_ptr<RequestRateWorker::ThreadConfig>> threads_config_;
+  std::vector<std::shared_ptr<ThreadConfig>> threads_config_;
 
   std::shared_ptr<std::chrono::nanoseconds> gen_duration_;
   Distribution request_distribution_;

--- a/src/c++/perf_analyzer/request_rate_worker.h
+++ b/src/c++/perf_analyzer/request_rate_worker.h
@@ -31,6 +31,7 @@
 #include "load_worker.h"
 #include "model_parser.h"
 #include "sequence_manager.h"
+#include "thread_config.h"
 
 namespace triton { namespace perfanalyzer {
 
@@ -50,21 +51,6 @@ class TestCustomLoadManager;
 ///
 class RequestRateWorker : public LoadWorker, public IScheduler {
  public:
-  struct ThreadConfig {
-    ThreadConfig(uint32_t index)
-        : id_(index), seq_stat_index_offset_(0), is_paused_(false),
-          num_sequences_(1)
-    {
-    }
-
-    uint32_t id_;
-
-    // The starting sequence stat index for this worker
-    size_t seq_stat_index_offset_;
-    uint32_t num_sequences_;
-    bool is_paused_;
-  };
-
   RequestRateWorker(
       uint32_t id, std::shared_ptr<ThreadStat> thread_stat,
       std::shared_ptr<ThreadConfig> thread_config,
@@ -80,11 +66,12 @@ class RequestRateWorker : public LoadWorker, public IScheduler {
       const std::shared_ptr<IInferDataManager>& infer_data_manager,
       std::shared_ptr<SequenceManager> sequence_manager)
       : LoadWorker(
-            id, thread_stat, parser, data_loader, factory, on_sequence_model,
-            async, streaming, batch_size, using_json_data, wake_signal,
-            wake_mutex, execute, infer_data_manager, sequence_manager),
-        thread_config_(thread_config), num_threads_(num_threads),
-        start_time_(start_time), serial_sequences_(serial_sequences)
+            id, thread_stat, thread_config, parser, data_loader, factory,
+            on_sequence_model, async, streaming, batch_size, using_json_data,
+            wake_signal, wake_mutex, execute, infer_data_manager,
+            sequence_manager),
+        num_threads_(num_threads), start_time_(start_time),
+        serial_sequences_(serial_sequences)
   {
   }
 
@@ -100,8 +87,6 @@ class RequestRateWorker : public LoadWorker, public IScheduler {
   const size_t num_threads_;
   const bool serial_sequences_;
   std::chrono::steady_clock::time_point& start_time_;
-
-  std::shared_ptr<ThreadConfig> thread_config_;
 
   void CreateCtxIdTracker();
 

--- a/src/c++/perf_analyzer/request_rate_worker.h
+++ b/src/c++/perf_analyzer/request_rate_worker.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -262,7 +262,7 @@ TEST_CASE("Testing PerfAnalyzerParameters")
   CHECK(params->max_threads_specified == false);
   CHECK(params->sequence_length == 20);
   CHECK(params->percentile == -1);
-  CHECK(params->fixed_num_requests == 0);
+  CHECK(params->request_count == 0);
   CHECK(params->user_data.size() == 0);
   CHECK_STRING("endpoint", params->endpoint, "");
   CHECK(params->input_shapes.size() == 0);
@@ -1470,42 +1470,40 @@ TEST_CASE("Testing Command Line Parser")
     }
   }
 
-  SUBCASE("Option : --fixed-num-requests")
+  SUBCASE("Option : --request-count")
   {
     SUBCASE("valid value")
     {
       int argc = 5;
-      char* argv[argc] = {
-          app_name, "-m", model_name, "--fixed-num-requests", "500"};
+      char* argv[argc] = {app_name, "-m", model_name, "--request-count", "500"};
 
       REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
       CHECK(!parser.UsageCalled());
 
-      exp->fixed_num_requests = 500;
+      exp->request_count = 500;
       exp->measurement_mode = MeasurementMode::COUNT_WINDOWS;
       exp->measurement_request_count = 500;
     }
     SUBCASE("negative value")
     {
       int argc = 5;
-      char* argv[argc] = {
-          app_name, "-m", model_name, "--fixed-num-requests", "-2"};
+      char* argv[argc] = {app_name, "-m", model_name, "--request-count", "-2"};
 
       expected_msg =
-          CreateUsageMessage("--fixed-num-requests", "The value must be > 0.");
+          CreateUsageMessage("--request-count", "The value must be > 0.");
       CHECK_THROWS_WITH_AS(
           act = parser.Parse(argc, argv), expected_msg.c_str(),
           PerfAnalyzerException);
       check_params = false;
     }
-    SUBCASE("mode and count are overwritten with non-zero fixed-num-requests")
+    SUBCASE("mode and count are overwritten with non-zero request-count")
     {
       int argc = 9;
       char* argv[argc] = {
           app_name,
           "-m",
           model_name,
-          "--fixed-num-requests",
+          "--request-count",
           "2000",
           "--measurement-mode",
           "time_windows",
@@ -1515,22 +1513,21 @@ TEST_CASE("Testing Command Line Parser")
       REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
       CHECK(!parser.UsageCalled());
 
-      exp->fixed_num_requests = 2000;
+      exp->request_count = 2000;
       exp->measurement_mode = MeasurementMode::COUNT_WINDOWS;
       exp->measurement_request_count = 2000;
     }
     SUBCASE("zero value (no override to measurement mode)")
     {
       int argc = 7;
-      char* argv[argc] = {app_name,      "-m",
-                          model_name,    "--fixed-num-requests",
-                          "0",           "--measurement-mode",
+      char* argv[argc] = {app_name,          "-m", model_name,
+                          "--request-count", "0",  "--measurement-mode",
                           "time_windows"};
 
       REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
       CHECK(!parser.UsageCalled());
 
-      exp->fixed_num_requests = 0;
+      exp->request_count = 0;
       exp->measurement_mode = MeasurementMode::TIME_WINDOWS;
     }
     SUBCASE("zero value (no override to measurement request count)")
@@ -1540,7 +1537,7 @@ TEST_CASE("Testing Command Line Parser")
           app_name,
           "-m",
           model_name,
-          "--fixed-num-requests",
+          "--request-count",
           "0",
           "--measurement-mode",
           "count_windows",
@@ -1550,7 +1547,7 @@ TEST_CASE("Testing Command Line Parser")
       REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
       CHECK(!parser.UsageCalled());
 
-      exp->fixed_num_requests = 0;
+      exp->request_count = 0;
       exp->measurement_mode = MeasurementMode::COUNT_WINDOWS;
       exp->measurement_request_count = 50;
     }

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -1524,6 +1524,39 @@ TEST_CASE("Testing Command Line Parser")
           PerfAnalyzerException);
       check_params = false;
     }
+    SUBCASE("multiple request rate")
+    {
+      int argc = 7;
+      char* argv[argc] = {app_name,   "-m",
+                          model_name, "--request-count",
+                          "20",       "--request-rate-range",
+                          "5:6:1"};
+
+      expected_msg =
+          "request-count not supported with multiple request-rate values in "
+          "one run";
+      CHECK_THROWS_WITH_AS(
+          act = parser.Parse(argc, argv), expected_msg.c_str(),
+          PerfAnalyzerException);
+      check_params = false;
+    }
+    SUBCASE("multiple concurrency")
+    {
+      int argc = 7;
+      char* argv[argc] = {app_name,   "-m",
+                          model_name, "--request-count",
+                          "20",       "--concurrency-range",
+                          "5:6:1"};
+
+      expected_msg =
+          "request-count not supported with multiple concurrency values in "
+          "one run";
+      CHECK_THROWS_WITH_AS(
+          act = parser.Parse(argc, argv), expected_msg.c_str(),
+          PerfAnalyzerException);
+      check_params = false;
+    }
+
     SUBCASE("mode and count are overwritten with non-zero request-count")
     {
       int argc = 9;

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -1496,6 +1496,34 @@ TEST_CASE("Testing Command Line Parser")
           PerfAnalyzerException);
       check_params = false;
     }
+    SUBCASE("less than request rate")
+    {
+      int argc = 7;
+      char* argv[argc] = {app_name,   "-m",
+                          model_name, "--request-count",
+                          "2",        "--request-rate-range",
+                          "5"};
+
+      expected_msg = "request-count can not be less than request-rate";
+      CHECK_THROWS_WITH_AS(
+          act = parser.Parse(argc, argv), expected_msg.c_str(),
+          PerfAnalyzerException);
+      check_params = false;
+    }
+    SUBCASE("less than concurrency")
+    {
+      int argc = 7;
+      char* argv[argc] = {app_name,   "-m",
+                          model_name, "--request-count",
+                          "2",        "--concurrency-range",
+                          "5"};
+
+      expected_msg = "request-count can not be less than concurrency";
+      CHECK_THROWS_WITH_AS(
+          act = parser.Parse(argc, argv), expected_msg.c_str(),
+          PerfAnalyzerException);
+      check_params = false;
+    }
     SUBCASE("mode and count are overwritten with non-zero request-count")
     {
       int argc = 9;

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -83,7 +83,8 @@ class TestConcurrencyManager : public TestLoadManagerBase,
       const size_t concurrent_request_count,
       std::vector<ConcurrencyWorker::ThreadConfig>& expected_configs)
   {
-    ConcurrencyManager::ReconfigThreads(concurrent_request_count);
+    // FIXME TKG! don't hardcode, and add new tests
+    ConcurrencyManager::ReconfigThreads(concurrent_request_count, 0);
 
     auto expected_size = expected_configs.size();
 

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -870,7 +870,7 @@ TEST_CASE(
 TEST_CASE(
     "reconfigure_threads" *
     doctest::description(
-        "This test confirms the side-effects of ReconfigureThreads(). Namely, "
+        "This test confirms the side-effects of ReconfigThreads(). Namely, "
         "that the correct number of threads are created and that they are "
         "configured properly"))
 {
@@ -922,6 +922,22 @@ TEST_CASE(
     expected_concurrencies = {7, 7};
     expected_seq_stat_index_offsets = {0, 7};
     expected_num_requests = {0, 0};
+  }
+  SUBCASE("more concurrency than num_requests (corner case)")
+  {
+    params.max_threads = 4;
+    target_concurrency = 4;
+    target_num_requests = 2;
+
+    // Despite a request for concurrency of 4, we only need to generate 2
+    // requests, so only 2 threads should have a concurrency
+    //
+    // The last two seq stat index offsets can effectively be ignored, but
+    // are equal to 2 just due to how the code is arranged
+    //
+    expected_concurrencies = {1, 1, 0, 0};
+    expected_seq_stat_index_offsets = {0, 1, 2, 2};
+    expected_num_requests = {1, 1, 0, 0};
   }
 
   for (auto i = 0; i < expected_concurrencies.size(); i++) {

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -923,22 +923,6 @@ TEST_CASE(
     expected_seq_stat_index_offsets = {0, 7};
     expected_num_requests = {0, 0};
   }
-  SUBCASE("more concurrency than num_requests (corner case)")
-  {
-    params.max_threads = 4;
-    target_concurrency = 4;
-    target_num_requests = 2;
-
-    // Despite a request for concurrency of 4, we only need to generate 2
-    // requests, so only 2 threads should have a concurrency
-    //
-    // The last two seq stat index offsets can effectively be ignored, but
-    // are equal to 2 just due to how the code is arranged
-    //
-    expected_concurrencies = {1, 1, 0, 0};
-    expected_seq_stat_index_offsets = {0, 1, 2, 2};
-    expected_num_requests = {1, 1, 0, 0};
-  }
 
   for (auto i = 0; i < expected_concurrencies.size(); i++) {
     ThreadConfig tc(i);

--- a/src/c++/perf_analyzer/test_concurrency_manager.cc
+++ b/src/c++/perf_analyzer/test_concurrency_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/test_custom_load_manager.cc
+++ b/src/c++/perf_analyzer/test_custom_load_manager.cc
@@ -70,7 +70,7 @@ class TestCustomLoadManager : public TestLoadManagerBase,
 
   std::shared_ptr<IWorker> MakeWorker(
       std::shared_ptr<ThreadStat> thread_stat,
-      std::shared_ptr<RequestRateWorker::ThreadConfig> thread_config) override
+      std::shared_ptr<ThreadConfig> thread_config) override
   {
     size_t id = workers_.size();
     auto worker = std::make_shared<MockRequestRateWorker>(

--- a/src/c++/perf_analyzer/test_custom_load_manager.cc
+++ b/src/c++/perf_analyzer/test_custom_load_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -85,15 +85,6 @@ class TestRequestRateManager : public TestLoadManagerBase,
     return worker;
   }
 
-  // This function exists to make testing the common case easier
-  // (num_requests==0)
-  cb::Error ChangeRequestRate(const double target_request_rate)
-  {
-    size_t num_requests = 0;
-    return RequestRateManager::ChangeRequestRate(
-        target_request_rate, num_requests);
-  }
-
   void TestConfigureThreads(
       std::vector<ThreadConfig>& expected_configs, size_t request_count)
   {

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/c++/perf_analyzer/thread_config.h
+++ b/src/c++/perf_analyzer/thread_config.h
@@ -27,7 +27,7 @@
 
 namespace triton { namespace perfanalyzer {
 
-// FIXME document
+// Holds the configuration for a worker thread
 struct ThreadConfig {
   ThreadConfig(size_t thread_id) : thread_id_(thread_id) {}
 
@@ -35,10 +35,13 @@ struct ThreadConfig {
   size_t thread_id_{0};
 
   // The concurrency level that the worker should produce
-  // FIXME TKG: Only used for concurrency mode
+  // TPA-69: This is only used in concurrency mode and shouldn't be visible in
+  // other modes
   size_t concurrency_{0};
 
-  // FIXME TKG: Only used for request rate
+  // The number of sequences owned by this worker
+  // TPA-69: This is only used in request-rate mode and shouldn't be visible in
+  // other modes
   uint32_t num_sequences_{1};
 
   // How many requests to generate before stopping. If 0, generate indefinitely

--- a/src/c++/perf_analyzer/thread_config.h
+++ b/src/c++/perf_analyzer/thread_config.h
@@ -29,34 +29,26 @@ namespace triton { namespace perfanalyzer {
 
 // FIXME document
 struct ThreadConfig {
-  ThreadConfig(
-      size_t thread_id, size_t concurrency = 0, size_t num_sequences = 0,
-      size_t seq_stat_index_offset = 0, size_t num_requests = 0)
-      : thread_id_(thread_id), concurrency_(concurrency),
-        num_sequences_(num_sequences),
-        seq_stat_index_offset_(seq_stat_index_offset),
-        num_requests_(num_requests), is_paused_(false)
-  {
-  }
+  ThreadConfig(size_t thread_id) : thread_id_(thread_id) {}
 
   // ID of corresponding worker thread
-  size_t thread_id_;
+  size_t thread_id_{0};
 
   // The concurrency level that the worker should produce
   // FIXME TKG: Only used for concurrency mode
-  size_t concurrency_;
+  size_t concurrency_{0};
 
   // FIXME TKG: Only used for request rate
-  uint32_t num_sequences_;
+  uint32_t num_sequences_{1};
 
   // How many requests to generate before stopping. If 0, generate indefinitely
-  size_t num_requests_;
+  size_t num_requests_{0};
 
   // The starting sequence stat index for this worker
-  size_t seq_stat_index_offset_;
+  size_t seq_stat_index_offset_{0};
 
   // Whether or not the thread is issuing new inference requests
-  bool is_paused_;
+  bool is_paused_{false};
 };
 
 

--- a/src/c++/perf_analyzer/thread_config.h
+++ b/src/c++/perf_analyzer/thread_config.h
@@ -1,0 +1,63 @@
+// Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+namespace triton { namespace perfanalyzer {
+
+// FIXME document
+struct ThreadConfig {
+  ThreadConfig(
+      size_t thread_id, size_t concurrency = 0, size_t num_sequences = 0,
+      size_t seq_stat_index_offset = 0, size_t num_requests = 0)
+      : thread_id_(thread_id), concurrency_(concurrency),
+        num_sequences_(num_sequences),
+        seq_stat_index_offset_(seq_stat_index_offset),
+        num_requests_(num_requests), is_paused_(false)
+  {
+  }
+
+  // ID of corresponding worker thread
+  size_t thread_id_;
+
+  // The concurrency level that the worker should produce
+  // FIXME TKG: Only used for concurrency mode
+  size_t concurrency_;
+
+  // FIXME TKG: Only used for request rate
+  uint32_t num_sequences_;
+
+  // How many requests to generate before stopping. If 0, generate indefinitely
+  size_t num_requests_;
+
+  // The starting sequence stat index for this worker
+  size_t seq_stat_index_offset_;
+
+  // Whether or not the thread is issuing new inference requests
+  bool is_paused_;
+};
+
+
+}}  // namespace triton::perfanalyzer


### PR DESCRIPTION
new CLI arg `--request-count`, which when specified tells PA exactly how many requests to issue for the experiment

Works with concurrency, request-rate, and custom load

Also:
- Combined thread_config classes into one, so that the base LoadWorker class has access to it
- Cleaned up some printing


