### PR TITLE
Fix missing dependency

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/pyproject.toml
+++ b/src/c++/perf_analyzer/genai-perf/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
   "statsmodels",
   "pyarrow",
   "fastparquet",
+  "pytest-mock",
 ]
 
 # CLI Entrypoint


### PR DESCRIPTION
Missed a pyproject.toml update.
This will fix failing unit tests.