### PR TITLE
Update backend name in tutorial

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/README.md
+++ b/src/c++/perf_analyzer/genai-perf/README.md
@@ -132,7 +132,7 @@ pip install \
 3. Download model:
 
 ```bash
-triton import -m gpt2 --backend tensorrtllm
+triton import -m gpt2 --backend trtllm
 ```
 
 4. Run server:


### PR DESCRIPTION
The `trtllm` backend was renamed to `tensorrtllm` after the 24.04 release. We need to update it in one more place.