### PR TITLE
Support Python 3.8 in GenAI-Perf

### DIFF
--- a/.github/workflows/python-package-genai.yml
+++ b/.github/workflows/python-package-genai.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04"]
-        python-version: ["3.10"]
+        python-version: ["3.8", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -29,7 +29,7 @@
 import csv
 import json
 from enum import Enum, auto
-from itertools import pairwise
+from itertools import tee
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
@@ -547,7 +547,9 @@ class LLMProfileDataParser(ProfileDataParser):
 
             # inter token latency
             itl_per_request = []
-            for (t1, _), (t2, n2) in pairwise(zip(res_timestamps, num_output_tokens)):
+            for (t1, _), (t2, n2) in self._pairwise(
+                zip(res_timestamps, num_output_tokens)
+            ):
                 # TMA-1676: handle empty first/last responses
                 # if the latter response has zero token (e.g. empty string),
                 # then set it default to one for the sake of inter token latency
@@ -571,6 +573,12 @@ class LLMProfileDataParser(ProfileDataParser):
             num_generated_tokens,
             num_input_tokens,
         )
+
+    def _pairwise(self, iterable):
+        """Generate pairs of consecutive elements from the given iterable."""
+        a, b = tee(iterable)
+        next(b, None)
+        return zip(a, b)
 
     def _preprocess_response(
         self, res_timestamps: List[int], res_outputs: List[Dict[str, str]]

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/plots/base_plot.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/plots/base_plot.py
@@ -26,6 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from pathlib import Path
+from typing import List
 
 import pandas as pd
 from genai_perf.exceptions import GenAIPerfException
@@ -38,7 +39,7 @@ class BasePlot:
     Base class for plots
     """
 
-    def __init__(self, data: list[ProfileRunData]) -> None:
+    def __init__(self, data: List[ProfileRunData]) -> None:
         self._profile_data = data
 
     def create_plot(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/plots/box_plot.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/plots/box_plot.py
@@ -26,6 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from pathlib import Path
+from typing import List
 
 import plotly.graph_objects as go
 from genai_perf.plots.base_plot import BasePlot
@@ -37,7 +38,7 @@ class BoxPlot(BasePlot):
     Generate a box plot in jpeg and html format.
     """
 
-    def __init__(self, data: list[ProfileRunData]) -> None:
+    def __init__(self, data: List[ProfileRunData]) -> None:
         super().__init__(data)
 
     def create_plot(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/plots/heat_map.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/plots/heat_map.py
@@ -26,6 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from pathlib import Path
+from typing import List
 
 import plotly.graph_objects as go
 from genai_perf.plots.base_plot import BasePlot
@@ -38,7 +39,7 @@ class HeatMap(BasePlot):
     Generate a heat map in jpeg and html format.
     """
 
-    def __init__(self, data: list[ProfileRunData]) -> None:
+    def __init__(self, data: List[ProfileRunData]) -> None:
         super().__init__(data)
 
     def create_plot(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/plots/plot_config.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/plots/plot_config.py
@@ -29,7 +29,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from typing import List, Union
+from typing import List, Sequence, Union
 
 
 class PlotType(Enum):

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/plots/plot_config.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/plots/plot_config.py
@@ -29,6 +29,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
+from typing import List, Union
 
 
 class PlotType(Enum):
@@ -40,14 +41,14 @@ class PlotType(Enum):
 @dataclass
 class ProfileRunData:
     name: str
-    x_metric: Sequence[int | float]
-    y_metric: Sequence[int | float]
+    x_metric: Sequence[Union[int, float]]
+    y_metric: Sequence[Union[int, float]]
 
 
 @dataclass
 class PlotConfig:
     title: str
-    data: list[ProfileRunData]
+    data: List[ProfileRunData]
     x_label: str
     y_label: str
     width: int

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/plots/plot_config_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/plots/plot_config_parser.py
@@ -26,6 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from pathlib import Path
+from typing import List, Union
 
 import genai_perf.logging as logging
 
@@ -46,7 +47,7 @@ class PlotConfigParser:
     def __init__(self, filename: Path) -> None:
         self._filename = filename
 
-    def generate_configs(self) -> list[PlotConfig]:
+    def generate_configs(self) -> List[PlotConfig]:
         """Load YAML configuration file and convert to PlotConfigs."""
         logger.info(
             f"Generating plot configurations by parsing {self._filename}. "
@@ -57,7 +58,7 @@ class PlotConfigParser:
         plot_configs = []
         for _, config in configs.items():
             # Collect profile run data
-            profile_data: list[ProfileRunData] = []
+            profile_data: List[ProfileRunData] = []
             for filepath in config["paths"]:
                 stats = self._get_statistics(filepath)
                 profile_data.append(
@@ -103,7 +104,7 @@ class PlotConfigParser:
             return filepath.parent.name + "/" + filepath.stem
         return filepath.stem
 
-    def _get_metric(self, stats: Statistics, name: str) -> list[int | float]:
+    def _get_metric(self, stats: Statistics, name: str) -> List[Union[int, float]]:
         if not name:  # no metric
             return []
         elif name == "inter_token_latencies":
@@ -113,7 +114,7 @@ class PlotConfigParser:
                 itl_flatten += request_itls
             return [scale(x, (1 / 1e6)) for x in itl_flatten]  # ns to ms
         elif name == "token_positions":
-            token_positions: list[int | float] = []
+            token_positions: List[Union[int, float]] = []
             for request_itls in stats.metrics.data["inter_token_latencies"]:
                 token_positions += list(range(1, len(request_itls) + 1))
             return token_positions
@@ -141,7 +142,7 @@ class PlotConfigParser:
             )
 
     @staticmethod
-    def create_init_yaml_config(filenames: list[Path], output_dir: Path) -> None:
+    def create_init_yaml_config(filenames: List[Path], output_dir: Path) -> None:
         config_str = f"""
         plot1:
           title: Time to First Token

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/plots/plot_manager.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/plots/plot_manager.py
@@ -25,6 +25,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from typing import List
+
 import genai_perf.logging as logging
 from genai_perf.plots.box_plot import BoxPlot
 from genai_perf.plots.heat_map import HeatMap
@@ -39,7 +41,7 @@ class PlotManager:
     Manage details around plots generated
     """
 
-    def __init__(self, plot_configs: list[PlotConfig]) -> None:
+    def __init__(self, plot_configs: List[PlotConfig]) -> None:
         self._plot_configs = plot_configs
 
     def _generate_filename(self, title: str) -> str:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/plots/scatter_plot.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/plots/scatter_plot.py
@@ -26,6 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from pathlib import Path
+from typing import List
 
 import plotly.graph_objects as go
 from genai_perf.plots.base_plot import BasePlot
@@ -37,7 +38,7 @@ class ScatterPlot(BasePlot):
     Generate a scatter plot in jpeg and html format.
     """
 
-    def __init__(self, data: list[ProfileRunData]) -> None:
+    def __init__(self, data: List[ProfileRunData]) -> None:
         super().__init__(data)
 
     def create_plot(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
@@ -65,7 +65,7 @@ def get_enum_names(enum: Type[Enum]) -> List:
     return names
 
 
-def get_enum_entry(name: str, enum: type[Enum]) -> Optional[Enum]:
+def get_enum_entry(name: str, enum: Type[Enum]) -> Optional[Enum]:
     for e in enum:
         if e.name.lower() == name.lower():
             return e

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
@@ -27,7 +27,7 @@
 import json
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 # Skip type checking to avoid mypy error
 # Issue: https://github.com/python/mypy/issues/10632
@@ -58,7 +58,7 @@ def convert_option_name(name: str) -> str:
     return name.replace("_", "-")
 
 
-def get_enum_names(enum: type[Enum]) -> List:
+def get_enum_names(enum: Type[Enum]) -> List:
     names = []
     for e in enum:
         names.append(e.name.lower())

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
@@ -35,7 +35,10 @@ import yaml  # type: ignore
 
 
 def remove_sse_prefix(msg: str) -> str:
-    return msg.removeprefix("data: ").strip()
+    prefix = "data: "
+    if msg.startswith(prefix):
+        return msg[len(prefix) :].strip()
+    return msg.strip()
 
 
 def load_yaml(filepath: Path) -> Dict[str, Any]:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -26,6 +26,7 @@
 
 import subprocess
 from argparse import Namespace
+from typing import List, Optional
 
 import genai_perf.logging as logging
 import genai_perf.utils as utils
@@ -37,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 class Profiler:
     @staticmethod
-    def add_protocol_args(args: Namespace) -> list[str]:
+    def add_protocol_args(args: Namespace) -> List[str]:
         cmd = []
         if args.service_kind == "triton":
             cmd += ["-i", "grpc", "--streaming"]
@@ -50,7 +51,7 @@ class Profiler:
         return cmd
 
     @staticmethod
-    def add_inference_load_args(args: Namespace) -> list[str]:
+    def add_inference_load_args(args: Namespace) -> List[str]:
         cmd = []
         if args.concurrency:
             cmd += ["--concurrency-range", f"{args.concurrency}"]
@@ -59,7 +60,7 @@ class Profiler:
         return cmd
 
     @staticmethod
-    def build_cmd(args: Namespace, extra_args: list[str] | None = None) -> list[str]:
+    def build_cmd(args: Namespace, extra_args: Optional[List[str]] = None) -> List[str]:
         skip_args = [
             "func",
             "input_dataset",
@@ -129,7 +130,7 @@ class Profiler:
         return cmd
 
     @staticmethod
-    def run(args: Namespace, extra_args: list[str] | None) -> None:
+    def run(args: Namespace, extra_args: Optional[List[str]]) -> None:
         cmd = Profiler.build_cmd(args, extra_args)
         logger.info(f"Running Perf Analyzer : '{' '.join(cmd)}'")
         if args and args.verbose:

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
@@ -29,7 +29,7 @@
 import json
 from io import StringIO
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, Union
 
 import numpy as np
 import pytest
@@ -39,7 +39,7 @@ from genai_perf.tokenizer import DEFAULT_TOKENIZER, get_tokenizer
 from transformers import AutoTokenizer
 
 
-def ns_to_sec(ns: int) -> int | float:
+def ns_to_sec(ns: int) -> Union[int, float]:
     """Convert from nanosecond to second."""
     return ns / 1e9
 


### PR DESCRIPTION
GenAI-Perf [says it supports Python 3.8](https://github.com/triton-inference-server/client/blob/4ea63a50cbea2522180bbf84811f09e3bcc71d39/src/c%2B%2B/perf_analyzer/genai-perf/pyproject.toml#L40-L41). This pull request fixes the breaking Python 3.8 code (i.e. removes features only available in 3.9+). To confirm it continues to support Python 3.8, it adds a job to build and run testing against 3.8 for each PR.

A few retrofits for Python 3.8:
1. Using the typing library rather than the built-in subscriptable types.
2. Using Union rather than "|"
3. Using a custom pairwise function rather than the itertools function
4. Using custom logic rather than the in-built removeprefix function