### PR TITLE
Filter model name with slash for artifact path

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -140,7 +140,7 @@ def _set_artifact_paths(args: argparse.Namespace) -> argparse.Namespace:
     """
     if args.artifact_dir == Path(DEFAULT_ARTIFACT_DIR):
         # Preprocess Huggingface model names that include '/' in their model name.
-        if "/" in args.model:
+        if (args.model is not None) and ("/" in args.model):
             filtered_name = args.model.split("/")[-1]
             logger.info(
                 f"Model name '{args.model}' cannot be used to create artifact "

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -139,7 +139,17 @@ def _set_artifact_paths(args: argparse.Namespace) -> argparse.Namespace:
     Set paths for all the artifacts.
     """
     if args.artifact_dir == Path(DEFAULT_ARTIFACT_DIR):
-        name = [f"{args.model}"]
+        # Preprocess Huggingface model names that include '/' in their model name.
+        if "/" in args.model:
+            filtered_name = args.model.split("/")[-1]
+            logger.info(
+                f"Model name '{args.model}' cannot be used to create artifact "
+                f"directory. Instead, '{filtered_name}' will be used."
+            )
+            name = [f"{filtered_name}"]
+        else:
+            name = [f"{args.model}"]
+
         if args.service_kind == "openai":
             name += [f"{args.service_kind}-{args.endpoint_type}"]
         elif args.service_kind == "triton":

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -141,7 +141,7 @@ def _set_artifact_paths(args: argparse.Namespace) -> argparse.Namespace:
     if args.artifact_dir == Path(DEFAULT_ARTIFACT_DIR):
         # Preprocess Huggingface model names that include '/' in their model name.
         if (args.model is not None) and ("/" in args.model):
-            filtered_name = args.model.split("/")[-1]
+            filtered_name = "_".join(args.model.split("/"))
             logger.info(
                 f"Model name '{args.model}' cannot be used to create artifact "
                 f"directory. Instead, '{filtered_name}' will be used."

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -573,3 +573,17 @@ class TestCLIArguments:
         assert excinfo.value.code != 0
         captured = capsys.readouterr()
         assert expected_output in captured.err
+
+    @pytest.mark.parametrize(
+        "args, expected_model",
+        [
+            (["--files", "profile1.json", "profile2.json", "profile3.json"], None),
+            (["--config", "config.yaml"], None),
+        ],
+    )
+    def test_compare_model_arg(self, monkeypatch, args, expected_model):
+        combined_args = ["genai-perf", "compare"] + args
+        monkeypatch.setattr("sys.argv", combined_args)
+        args, _ = parser.parse_args()
+
+        assert args.model == expected_model

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -247,6 +247,35 @@ class TestCLIArguments:
         captured = capsys.readouterr()
         assert captured.out == ""
 
+    @pytest.mark.parametrize(
+        "arg, expected_path",
+        [
+            (
+                ["--model", "company/test_model"],
+                "artifacts/test_model-triton-tensorrtllm-concurrency1",
+            ),
+            (
+                [
+                    "--model",
+                    "company/test_model",
+                    "--service-kind",
+                    "openai",
+                    "--endpoint-type",
+                    "chat",
+                ],
+                "artifacts/test_model-openai-chat-concurrency1",
+            ),
+        ],
+    )
+    def test_model_name_artifact_path(self, monkeypatch, arg, expected_path, capsys):
+        combined_args = ["genai-perf"] + arg
+        monkeypatch.setattr("sys.argv", combined_args)
+        args, extra_args = parser.parse_args()
+
+        assert args.artifact_dir == Path(expected_path)
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
     def test_default_load_level(self, monkeypatch, capsys):
         monkeypatch.setattr("sys.argv", ["genai-perf", "--model", "test_model"])
         args, extra_args = parser.parse_args()

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -251,19 +251,19 @@ class TestCLIArguments:
         "arg, expected_path",
         [
             (
-                ["--model", "company/test_model"],
-                "artifacts/test_model-triton-tensorrtllm-concurrency1",
+                ["--model", "strange/test_model"],
+                "artifacts/strange_test_model-triton-tensorrtllm-concurrency1",
             ),
             (
                 [
                     "--model",
-                    "company/test_model",
+                    "hello/world/test_model",
                     "--service-kind",
                     "openai",
                     "--endpoint-type",
                     "chat",
                 ],
-                "artifacts/test_model-openai-chat-concurrency1",
+                "artifacts/hello_world_test_model-openai-chat-concurrency1",
             ),
         ],
     )

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -271,7 +271,7 @@ class TestCLIArguments:
                 "artifacts/hello_world_test_model-openai-chat-concurrency1",
                 (
                     "Model name 'hello/world/test_model' cannot be used to create "
-                    "artifact directory. Instead, 'hello_world_model' will be used"
+                    "artifact directory. Instead, 'hello_world_test_model' will be used"
                 ),
             ),
         ],


### PR DESCRIPTION
Some model names include slash (`/`) in their model name (e.g. Huggingface). This will break artifacts directory creation, so preprocess the model name so that we do not have slash character in the model name.