### PR TITLE
Fix response preprocessing bug

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -600,13 +600,13 @@ class LLMProfileDataParser(ProfileDataParser):
 
             # Remove responses without any content
             # These are only observed to happen at the start or end
-            while res_outputs[0] and self._is_openai_empty_response(
+            while res_outputs and self._is_openai_empty_response(
                 res_outputs[0]["response"]
             ):
                 res_timestamps.pop(0)
                 res_outputs.pop(0)
 
-            while res_outputs[-1] and self._is_openai_empty_response(
+            while res_outputs and self._is_openai_empty_response(
                 res_outputs[-1]["response"]
             ):
                 res_timestamps.pop()

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
@@ -409,7 +409,7 @@ class TestLLMProfileDataParser:
         tokenizer = get_tokenizer(DEFAULT_TOKENIZER)
 
         # Should not throw error
-        pd = LLMProfileDataParser(
+        _ = LLMProfileDataParser(
             filename=Path("empty_profile_export.json"),
             tokenizer=tokenizer,
         )


### PR DESCRIPTION
When preprocessing responses, if all responses are either empty or null, then the `res_outputs` and `res_timestamps` will eventually be empty and will raise index out of range error. Instead of indexing 0-th and last element, check if the list is empty or not.