### PR TITLE
Add a check if ModelParser pointer is nullptr

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1545,7 +1545,8 @@ InferenceProfiler::DetermineStatsModelVersion(
   // hit. This is due to the scheduler sends cache response and composing models
   // do not get executed. It's a valid scenario and shouldn't throw error.
   bool model_version_unspecified_and_invalid =
-      *status_model_version == -1 && !parser_->TopLevelResponseCachingEnabled();
+      *status_model_version == -1 &&
+      (parser_ == nullptr || !parser_->TopLevelResponseCachingEnabled());
   if (model_version_unspecified_and_invalid) {
     return cb::Error(
         "failed to find the requested model version", pa::GENERIC_ERROR);


### PR DESCRIPTION
This check is needed so that test_inference_profiler unit test doesn't fail.