### PR TITLE
Fix request-rate request order

### DIFF
--- a/src/c++/perf_analyzer/infer_context.h
+++ b/src/c++/perf_analyzer/infer_context.h
@@ -86,7 +86,7 @@ class InferContext {
         on_sequence_model_(on_sequence_model),
         using_json_data_(using_json_data), batch_size_(batch_size),
         thread_stat_(thread_stat), data_loader_(data_loader), parser_(parser),
-        factory_(factory), data_step_id_(id), execute_(execute),
+        factory_(factory), data_step_id_(thread_id), execute_(execute),
         infer_data_manager_(infer_data_manager),
         sequence_manager_(sequence_manager)
   {

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -330,6 +330,7 @@ class TestRequestRateManager : public TestLoadManagerBase,
   /// Helper function that will setup and run a case to verify custom data
   /// behavior
   /// \param num_requests Integer number of requests to send during the test
+  /// \param num_threads Number of worker threads to create
   /// \param tensors Vector of input ModelTensors
   /// \param json_str The custom data json text
   /// \param expected_values Vector of expected input values for each inference
@@ -427,7 +428,6 @@ class TestRequestRateManager : public TestLoadManagerBase,
       }
     }
 
-    // FIXME TKG -- only 0's status? Can we OR them together?
     return thread_stats[0]->status_;
   }
 

--- a/src/c++/perf_analyzer/test_request_rate_manager.cc
+++ b/src/c++/perf_analyzer/test_request_rate_manager.cc
@@ -338,24 +338,24 @@ class TestRequestRateManager : public TestLoadManagerBase,
   /// \param expect_thread_failure True if the thread is expected to have
   /// an error
   void TestCustomData(
-      size_t num_requests, std::vector<ModelTensor>& tensors,
-      const std::string json_str,
+      size_t num_requests, size_t num_threads,
+      std::vector<ModelTensor>& tensors, const std::string json_str,
       std::vector<std::vector<int32_t>>& expected_values,
       bool expect_init_failure, bool expect_thread_failure)
   {
-    CustomDataTestSetup(tensors, json_str, expect_init_failure);
+    CustomDataTestSetup(tensors, json_str, expect_init_failure, num_threads);
     if (expect_init_failure) {
       // The rest of the test is invalid if init failed
       return;
     }
-    auto thread_status = CustomDataTestSendRequests(num_requests);
+    auto thread_status = CustomDataTestSendRequests(num_requests, num_threads);
     CustomDataTestCheckResults(
         thread_status, expect_thread_failure, expected_values);
   }
 
   void CustomDataTestSetup(
       std::vector<ModelTensor>& tensors, const std::string json_str,
-      bool expect_init_failure)
+      bool expect_init_failure, size_t num_threads)
   {
     params_.user_data = {json_str};
 
@@ -379,7 +379,7 @@ class TestRequestRateManager : public TestLoadManagerBase,
     data_loader_ = mdl;
     using_json_data_ = true;
     execute_ = true;
-    max_threads_ = 1;
+    max_threads_ = num_threads;
 
     if (expect_init_failure) {
       REQUIRE_THROWS_AS(
@@ -401,22 +401,34 @@ class TestRequestRateManager : public TestLoadManagerBase,
     }
   }
 
-  cb::Error CustomDataTestSendRequests(size_t num_requests)
+  cb::Error CustomDataTestSendRequests(size_t num_requests, size_t num_threads)
   {
-    std::shared_ptr<ThreadStat> thread_stat{std::make_shared<ThreadStat>()};
-    std::shared_ptr<ThreadConfig> thread_config{
-        std::make_shared<ThreadConfig>(0)};
-    std::shared_ptr<IWorker> worker{MakeWorker(thread_stat, thread_config)};
+    std::vector<std::shared_ptr<MockRequestRateWorker>> workers;
+    std::vector<std::shared_ptr<ThreadStat>> thread_stats;
 
-    auto mock_worker = std::dynamic_pointer_cast<MockRequestRateWorker>(worker);
+    for (auto i = 0; i < num_threads; i++) {
+      std::shared_ptr<ThreadStat> ts{std::make_shared<ThreadStat>()};
+      thread_stats.push_back(ts);
+      std::shared_ptr<ThreadConfig> tc{std::make_shared<ThreadConfig>(i)};
+      std::shared_ptr<IWorker> worker{MakeWorker(ts, tc)};
+      workers_.push_back(worker);
 
-    mock_worker->CreateContext();
+      workers.push_back(
+          std::dynamic_pointer_cast<MockRequestRateWorker>(worker));
 
-    for (size_t i = 0; i < num_requests; i++) {
-      mock_worker->SendInferRequest();
+      workers[i]->CreateContext();
     }
 
-    return thread_stat->status_;
+    size_t sent_requests = 0;
+    while (sent_requests < num_requests) {
+      for (auto i = 0; i < workers.size(); i++) {
+        workers[i]->SendInferRequest();
+        sent_requests++;
+      }
+    }
+
+    // FIXME TKG -- only 0's status? Can we OR them together?
+    return thread_stats[0]->status_;
   }
 
   void CustomDataTestCheckResults(
@@ -1004,6 +1016,7 @@ TEST_CASE(
    ]})"};
 
   size_t num_requests = 4;
+  size_t num_threads = 1;
 
   const auto& ParameterizeTensors{[&]() {
     SUBCASE("one tensor")
@@ -1087,13 +1100,26 @@ TEST_CASE(
     }
   }};
 
-  ParameterizeSharedMemory();
+  const auto& ParameterizeNumThreads{[&]() {
+    SUBCASE("1 thread")
+    {
+      num_threads = 1;
+      ParameterizeSharedMemory();
+    }
+    SUBCASE("2 threads")
+    {
+      num_threads = 2;
+      ParameterizeSharedMemory();
+    }
+  }};
+
+  ParameterizeNumThreads();
 
   TestRequestRateManager trrm(params, is_sequence_model);
 
   trrm.TestCustomData(
-      num_requests, tensors, json_str, expected_results, expect_init_failure,
-      expect_thread_failure);
+      num_requests, num_threads, tensors, json_str, expected_results,
+      expect_init_failure, expect_thread_failure);
 }
 
 TEST_CASE("custom_json_data: handling is_shape_tensor")
@@ -1130,7 +1156,7 @@ TEST_CASE("custom_json_data: handling is_shape_tensor")
   model_tensor2.is_optional_ = true;
 
   size_t num_requests = 4;
-
+  size_t num_threads = 1;
 
   const auto& ParameterizeBatch{[&]() {
     SUBCASE("batch 1")
@@ -1154,30 +1180,43 @@ TEST_CASE("custom_json_data: handling is_shape_tensor")
     }
   }};
 
+  const auto& ParameterizeNumThreads{[&]() {
+    SUBCASE("1 thread")
+    {
+      num_threads = 1;
+      ParameterizeBatch();
+    }
+    SUBCASE("2 threads")
+    {
+      num_threads = 2;
+      ParameterizeBatch();
+    }
+  }};
+
   // Being optional should have no impact
   SUBCASE("optional = 0,0")
   {
     model_tensor1.is_optional_ = false;
     model_tensor2.is_optional_ = false;
-    ParameterizeBatch();
+    ParameterizeNumThreads();
   }
   SUBCASE("optional = 0,1")
   {
     model_tensor1.is_optional_ = false;
     model_tensor2.is_optional_ = true;
-    ParameterizeBatch();
+    ParameterizeNumThreads();
   }
   SUBCASE("optional = 1,0")
   {
     model_tensor1.is_optional_ = true;
     model_tensor2.is_optional_ = false;
-    ParameterizeBatch();
+    ParameterizeNumThreads();
   }
   SUBCASE("optional = 1,1")
   {
     model_tensor1.is_optional_ = true;
     model_tensor2.is_optional_ = true;
-    ParameterizeBatch();
+    ParameterizeNumThreads();
   }
 
 
@@ -1187,8 +1226,8 @@ TEST_CASE("custom_json_data: handling is_shape_tensor")
   tensors.push_back(model_tensor2);
 
   trrm.TestCustomData(
-      num_requests, tensors, json_str, expected_results, expect_init_failure,
-      expect_thread_failure);
+      num_requests, num_threads, tensors, json_str, expected_results,
+      expect_init_failure, expect_thread_failure);
 }
 
 TEST_CASE("custom_json_data: handling missing optional is_shape_tensor")
@@ -1225,6 +1264,7 @@ TEST_CASE("custom_json_data: handling missing optional is_shape_tensor")
 
 
   size_t num_requests = 4;
+  size_t num_threads = 1;
 
   const auto& ParameterizeBatch{[&]() {
     SUBCASE("batch 1")
@@ -1248,21 +1288,34 @@ TEST_CASE("custom_json_data: handling missing optional is_shape_tensor")
     }
   }};
 
+  const auto& ParameterizeNumThreads{[&]() {
+    SUBCASE("1 thread")
+    {
+      num_threads = 1;
+      ParameterizeBatch();
+    }
+    SUBCASE("2 threads")
+    {
+      num_threads = 2;
+      ParameterizeBatch();
+    }
+  }};
+
   SUBCASE("no shm")
   {
     params.shared_memory_type = SharedMemoryType::NO_SHARED_MEMORY;
-    ParameterizeBatch();
+    ParameterizeNumThreads();
   }
   SUBCASE("system shm")
   {
     params.shared_memory_type = SharedMemoryType::SYSTEM_SHARED_MEMORY;
-    ParameterizeBatch();
+    ParameterizeNumThreads();
     expect_init_failure = true;
   }
   SUBCASE("cuda shm")
   {
     params.shared_memory_type = SharedMemoryType::CUDA_SHARED_MEMORY;
-    ParameterizeBatch();
+    ParameterizeNumThreads();
     expect_init_failure = true;
   }
 
@@ -1272,8 +1325,8 @@ TEST_CASE("custom_json_data: handling missing optional is_shape_tensor")
   tensors.push_back(model_tensor2);
 
   trrm.TestCustomData(
-      num_requests, tensors, json_str, expected_results, expect_init_failure,
-      expect_thread_failure);
+      num_requests, num_threads, tensors, json_str, expected_results,
+      expect_init_failure, expect_thread_failure);
 }
 
 TEST_CASE("custom_json_data: handling invalid is_shape_tensor")
@@ -1298,6 +1351,7 @@ TEST_CASE("custom_json_data: handling invalid is_shape_tensor")
   model_tensor2.name_ = "INPUT2";
 
   size_t num_requests = 4;
+  size_t num_threads = 1;
 
   std::string json_str;
 
@@ -1324,25 +1378,37 @@ TEST_CASE("custom_json_data: handling invalid is_shape_tensor")
     }
   }};
 
+  const auto& ParameterizeNumThreads{[&]() {
+    SUBCASE("1 thread")
+    {
+      num_threads = 1;
+      ParameterizeJson();
+    }
+    SUBCASE("2 threads")
+    {
+      num_threads = 2;
+      ParameterizeJson();
+    }
+  }};
 
   SUBCASE("no batching is ok")
   {
     params.batch_size = 1;
-    ParameterizeJson();
+    ParameterizeNumThreads();
   }
   SUBCASE("batching - no shm")
   {
     params.batch_size = 2;
     params.shared_memory_type = SharedMemoryType::NO_SHARED_MEMORY;
     expect_init_failure = true;
-    ParameterizeJson();
+    ParameterizeNumThreads();
   }
   SUBCASE("batching - shm")
   {
     params.batch_size = 2;
     params.shared_memory_type = SharedMemoryType::SYSTEM_SHARED_MEMORY;
     expect_init_failure = true;
-    ParameterizeJson();
+    ParameterizeNumThreads();
   }
 
   TestRequestRateManager trrm(params, is_sequence_model);
@@ -1351,8 +1417,8 @@ TEST_CASE("custom_json_data: handling invalid is_shape_tensor")
   tensors.push_back(model_tensor2);
 
   trrm.TestCustomData(
-      num_requests, tensors, json_str, expected_results, expect_init_failure,
-      expect_thread_failure);
+      num_requests, num_threads, tensors, json_str, expected_results,
+      expect_init_failure, expect_thread_failure);
 }
 
 
@@ -1385,17 +1451,31 @@ TEST_CASE("custom_json_data: handling of optional tensors")
   ]})"};
 
   size_t num_requests = 4;
+  size_t num_threads = 1;
+
+  const auto& ParameterizeNumThreads{[&]() {
+    SUBCASE("1 thread")
+    {
+      num_threads = 1;
+    }
+    SUBCASE("2 threads")
+    {
+      num_threads = 2;
+    }
+  }};
 
   SUBCASE("normal")
   {
     model_tensor2.is_optional_ = true;
     params.batch_size = 1;
     expected_results = {{1}, {2, 22}, {3}, {1}};
+    ParameterizeNumThreads();
   }
   SUBCASE("tensor not optional -- expect parsing fail")
   {
     model_tensor2.is_optional_ = false;
     expect_init_failure = true;
+    ParameterizeNumThreads();
   }
   SUBCASE("shared memory not supported")
   {
@@ -1404,6 +1484,7 @@ TEST_CASE("custom_json_data: handling of optional tensors")
     // FIXME: TMA-765 - Shared memory mode does not support optional inputs,
     // currently, and will be implemented in the associated story.
     expect_init_failure = true;
+    ParameterizeNumThreads();
   }
   SUBCASE("batching with mismatching data")
   {
@@ -1413,6 +1494,7 @@ TEST_CASE("custom_json_data: handling of optional tensors")
     // must be specified for each batch. You cannot use different
     // set of optional inputs for each individual batch.
     expect_init_failure = true;
+    ParameterizeNumThreads();
   }
 
   TestRequestRateManager trrm(params, is_sequence_model);
@@ -1421,8 +1503,8 @@ TEST_CASE("custom_json_data: handling of optional tensors")
   tensors.push_back(model_tensor2);
 
   trrm.TestCustomData(
-      num_requests, tensors, json_str, expected_results, expect_init_failure,
-      expect_thread_failure);
+      num_requests, num_threads, tensors, json_str, expected_results,
+      expect_init_failure, expect_thread_failure);
 }
 
 TEST_CASE("custom_json_data: multiple streams")
@@ -1458,6 +1540,7 @@ TEST_CASE("custom_json_data: multiple streams")
   ]]})"};
 
   size_t num_requests = 10;
+  size_t num_threads = 1;
 
   const auto& ParameterizeMemory{[&]() {
     SUBCASE("No shared memory")
@@ -1474,6 +1557,19 @@ TEST_CASE("custom_json_data: multiple streams")
     }
   }};
 
+  const auto& ParameterizeNumThreads{[&]() {
+    SUBCASE("1 thread")
+    {
+      num_threads = 1;
+      ParameterizeMemory();
+    }
+    SUBCASE("2 threads")
+    {
+      num_threads = 2;
+      ParameterizeMemory();
+    }
+  }};
+
   SUBCASE("yes sequence")
   {
     // Sequences will randomly pick among all streams
@@ -1483,7 +1579,7 @@ TEST_CASE("custom_json_data: multiple streams")
     expected_results = {{201, 221}, {202, 222}, {201, 221}, {202, 222},
                         {1, 21},    {2, 22},    {3, 23},    {1, 21},
                         {2, 22},    {3, 23}};
-    ParameterizeMemory();
+    ParameterizeNumThreads();
   }
   SUBCASE("no sequence")
   {
@@ -1492,7 +1588,7 @@ TEST_CASE("custom_json_data: multiple streams")
     is_sequence_model = false;
     expected_results = {{1, 21}, {2, 22}, {3, 23}, {1, 21}, {2, 22},
                         {3, 23}, {1, 21}, {2, 22}, {3, 23}, {1, 21}};
-    ParameterizeMemory();
+    ParameterizeNumThreads();
   }
 
   TestRequestRateManager trrm(params, is_sequence_model);
@@ -1500,7 +1596,7 @@ TEST_CASE("custom_json_data: multiple streams")
   tensors.push_back(model_tensor1);
   tensors.push_back(model_tensor2);
 
-  trrm.CustomDataTestSetup(tensors, json_str, expect_init_failure);
+  trrm.CustomDataTestSetup(tensors, json_str, expect_init_failure, num_threads);
 
   if (is_sequence_model) {
     // Force GetNewDataStreamId to return 1 twice and 0 every time after
@@ -1517,7 +1613,8 @@ TEST_CASE("custom_json_data: multiple streams")
         GetNewDataStreamId())
         .Times(0);
   }
-  auto thread_status = trrm.CustomDataTestSendRequests(num_requests);
+  auto thread_status =
+      trrm.CustomDataTestSendRequests(num_requests, num_threads);
   trrm.CustomDataTestCheckResults(
       thread_status, expect_thread_failure, expected_results);
 }


### PR DESCRIPTION
This fixes both concurrency and request rate issues around iterating through the input data set

As an example, in the case of 4 worker threads (for either request-rate or concurrency), the index of the input-data for the sent data would be:
- Before fix: 0,0,0,0,4,4,4,4,8,8,8,8
- After fix: 0,1,2,3,4,5,6,7,8,9,10,11

Also added some multi-worker test cases that failed before the fix, and now pass.