### PR TITLE
fix is_contiguous_logic issue in dlpack 

### DIFF
--- a/src/python/library/tests/test_cuda_shared_memory.py
+++ b/src/python/library/tests/test_cuda_shared_memory.py
@@ -42,7 +42,7 @@ class DLPackTest(unittest.TestCase):
     def test_from_gpu(self):
         # Create GPU tensor via PyTorch and CUDA shared memory region with
         # enough space
-        gpu_tensor = torch.ones(4, 4).cuda(0)
+        gpu_tensor = torch.ones(1, 4, 4).cuda(0)
         byte_size = 64
         shm_handle = cudashm.create_shared_memory_region("cudashm_data", byte_size, 0)
 
@@ -51,7 +51,7 @@ class DLPackTest(unittest.TestCase):
 
         # Make sure the DLPack specification of the shared memory region can
         # be consumed by PyTorch
-        smt = cudashm.as_shared_memory_tensor(shm_handle, "FP32", [4, 4])
+        smt = cudashm.as_shared_memory_tensor(shm_handle, "FP32", [1, 4, 4])
         generated_torch_tensor = torch.from_dlpack(smt)
         self.assertTrue(torch.allclose(gpu_tensor, generated_torch_tensor))
 

--- a/src/python/library/tritonclient/utils/_dlpack.py
+++ b/src/python/library/tritonclient/utils/_dlpack.py
@@ -227,6 +227,9 @@ def is_contiguous_data(
     calculated_stride = 1
     # iterate stride in reverse order [ndim-1, -1)
     for i in reversed(range(ndim)):
+        # don't check stride when shape is 1
+        if shape[i] == 1:
+            continue
         if stride[i] != calculated_stride:
             return False
         calculated_stride *= shape[i]


### PR DESCRIPTION
Hello, I'm making good use of the open source you provided.
When I use it, I find an issue and fix it to contribute to your project

### issue what I find
I want to use `set_shared_memory_region_from_dlpack` for GPU to GPU shared memory
I converted pytorch tensor to dlpack using by `to_dlpack` from dlpack library but it raises error in [this line](https://github.com/triton-inference-server/client/blob/main/src/python/library/tritonclient/utils/cuda_shared_memory/__init__.py#L353)

```
# it work well
img_tensor = img_tensor_raw.resize_(target_height, target_width, 3)
cudashm.set_shared_memory_region_from_dlpack(cuda_shm_ip_handle, [img_tensor])

# it doesn't work
img_tensor = img_tensor_raw.resize_(1, target_height, target_width, 3)
cudashm.set_shared_memory_region_from_dlpack(cuda_shm_ip_handle, [img_tensor])
```

although I make pytorch tensor contiguous, after making it dlpack strides corrupts
it is [known issue](https://github.com/pytorch/pytorch/issues/99803) pytorch and the maintainer says it is not an issue but logic for preventing another issue. so stride in tensor's dimension shape is 1 must be 1

so, I fix is_contiguous logic to skip contiguous checking when shape is 1 and it work well in my code.
If the contribution process is in the project, I will follow it.
thanks
    