### PR TITLE
Speed up GenAi-Perf's help call

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 
 
 def import_heavy_modules():
-    global DEFAULT_PARQUET_FILE, JsonExporter, LlmInputs, LLMProfileDataParser, PlotConfigParser, PlotManager, get_tokenizer
+    global parser, DEFAULT_PARQUET_FILE, JsonExporter, LlmInputs, LLMProfileDataParser, PlotConfigParser, PlotManager, get_tokenizer
     from genai_perf import parser
     from genai_perf.constants import DEFAULT_PARQUET_FILE
     from genai_perf.export_data.json_exporter import JsonExporter

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -30,17 +30,33 @@ import sys
 import traceback
 from argparse import Namespace
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import genai_perf.logging as logging
-from genai_perf import parser
-from genai_perf.constants import DEFAULT_PARQUET_FILE
 from genai_perf.exceptions import GenAIPerfException
-from genai_perf.export_data.json_exporter import JsonExporter
-from genai_perf.llm_inputs.llm_inputs import LlmInputs
-from genai_perf.llm_metrics import LLMProfileDataParser
-from genai_perf.plots.plot_config_parser import PlotConfigParser
-from genai_perf.plots.plot_manager import PlotManager
-from genai_perf.tokenizer import Tokenizer, get_tokenizer
+
+# Import heavy modules to make type checker happy
+if TYPE_CHECKING:
+    from genai_perf import parser
+    from genai_perf.constants import DEFAULT_PARQUET_FILE
+    from genai_perf.export_data.json_exporter import JsonExporter
+    from genai_perf.llm_inputs.llm_inputs import LlmInputs
+    from genai_perf.llm_metrics import LLMProfileDataParser
+    from genai_perf.plots.plot_config_parser import PlotConfigParser
+    from genai_perf.plots.plot_manager import PlotManager
+    from genai_perf.tokenizer import Tokenizer, get_tokenizer
+
+
+def import_heavy_modules():
+    global DEFAULT_PARQUET_FILE, JsonExporter, LlmInputs, LLMProfileDataParser, PlotConfigParser, PlotManager, get_tokenizer
+    from genai_perf import parser
+    from genai_perf.constants import DEFAULT_PARQUET_FILE
+    from genai_perf.export_data.json_exporter import JsonExporter
+    from genai_perf.llm_inputs.llm_inputs import LlmInputs
+    from genai_perf.llm_metrics import LLMProfileDataParser
+    from genai_perf.plots.plot_config_parser import PlotConfigParser
+    from genai_perf.plots.plot_manager import PlotManager
+    from genai_perf.tokenizer import get_tokenizer
 
 
 def create_artifacts_dirs(args: Namespace) -> None:
@@ -50,8 +66,9 @@ def create_artifacts_dirs(args: Namespace) -> None:
     os.makedirs(plot_dir, exist_ok=True)
 
 
-def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:
+def generate_inputs(args: Namespace, tokenizer: "Tokenizer") -> None:
     # TODO (TMA-1759): review if add_model_name is always true
+    import_heavy_modules()
     input_filename = Path(args.input_file.name) if args.input_file else None
     add_model_name = True
     try:
@@ -82,14 +99,17 @@ def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:
     )
 
 
-def calculate_metrics(args: Namespace, tokenizer: Tokenizer) -> LLMProfileDataParser:
+def calculate_metrics(
+    args: Namespace, tokenizer: "Tokenizer"
+) -> "LLMProfileDataParser":
     return LLMProfileDataParser(
         filename=args.profile_export_file,
         tokenizer=tokenizer,
     )
 
 
-def report_output(data_parser: LLMProfileDataParser, args: Namespace) -> None:
+def report_output(data_parser: "LLMProfileDataParser", args: Namespace) -> None:
+    import_heavy_modules()
     if args.concurrency:
         infer_mode = "concurrency"
         load_level = f"{args.concurrency}"
@@ -132,10 +152,12 @@ def run():
     try:
         # TMA-1900: refactor CLI handler
         logging.init_logging()
+        import_heavy_modules()
         args, extra_args = parser.parse_args()
         if args.subcommand == "compare":
             args.func(args)
         else:
+            import_heavy_modules()
             create_artifacts_dirs(args)
             tokenizer = get_tokenizer(args.tokenizer)
             generate_inputs(args, tokenizer)
@@ -147,6 +169,10 @@ def run():
 
 
 def main():
+    # Check if help is requested early
+    if any(arg in sys.argv for arg in ("--help", "-h")):
+        return 0
+
     # Interactive use will catch exceptions and log formatted errors rather than
     # tracebacks.
     try:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/tokenizer.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/tokenizer.py
@@ -14,21 +14,16 @@
 
 import contextlib
 import io
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from genai_perf.exceptions import GenAIPerfException
 
-# Silence tokenizer warning on import
-with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(
-    io.StringIO()
-) as stderr:
-    from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
-    from transformers import logging as token_logger
-
-    token_logger.set_verbosity_error()
-
-Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
+Tokenizer = Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"]
 DEFAULT_TOKENIZER = "hf-internal-testing/llama-tokenizer"
+
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
 def get_tokenizer(
@@ -42,6 +37,10 @@ def get_tokenizer(
         with contextlib.redirect_stdout(
             io.StringIO()
         ) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
+            from transformers import AutoTokenizer
+            from transformers import logging as token_logger
+
+            token_logger.set_verbosity_error()
             tokenizer = AutoTokenizer.from_pretrained(tokenizer_model)
     except Exception as e:
         raise GenAIPerfException(e)


### PR DESCRIPTION
For those using GenAI-Perf's "--help" option, it takes 1-3 seconds to generate the help menu due to all of the heavy imports (especially the transformers library). This pull request defers those imports until they are needed. This should not impact normal runtime (see below), but it does speed up the "--help call" by up to 16x for the average case, 24x for the first-time call, and 47x for the non-parallelized case. See the runtime profiles below.

**"--help" option**

Before changes (1-3s):

![image](https://github.com/triton-inference-server/client/assets/58150256/b5e0ecc7-2a3d-42a6-bef2-6b7a7e89c7ea)

After changes (62.3ms):

![image](https://github.com/triton-inference-server/client/assets/58150256/51a13988-c8bc-446b-8a7e-50b1bf226131)

For completeness, the `-h` option:

![image](https://github.com/triton-inference-server/client/assets/58150256/6f343b2d-f0ba-46d0-a2e2-049eca802145)

**Full run**

Before changes (39.0s):
![image](https://github.com/triton-inference-server/client/assets/58150256/014b8147-deca-4da0-8c76-803889d0657e)

After changes (38.1s):
![image](https://github.com/triton-inference-server/client/assets/58150256/d48e6bd3-14b6-4ecb-900c-2fdaeff5bf72)

**Passing unit tests**
![image](https://github.com/triton-inference-server/client/assets/58150256/63a59c81-c0d7-4d55-90f3-797b4de1b859)
