### PR TITLE
Patch vLLM for missing content entry

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -620,6 +620,8 @@ class LLMProfileDataParser(ProfileDataParser):
                 responses = response.strip().split("\n\n")
                 if len(responses) > 1:
                     merged_response = json.loads(remove_sse_prefix(responses[0]))
+                    if merged_response["choices"][0]["delta"].get("content", None) is None:
+                        merged_response["choices"][0]["delta"]["content"] = ""
                     for r in responses[1:]:
                         text = self._extract_openai_text_output(r)
                         merged_response["choices"][0]["delta"]["content"] += text

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_metrics.py
@@ -620,7 +620,10 @@ class LLMProfileDataParser(ProfileDataParser):
                 responses = response.strip().split("\n\n")
                 if len(responses) > 1:
                     merged_response = json.loads(remove_sse_prefix(responses[0]))
-                    if merged_response["choices"][0]["delta"].get("content", None) is None:
+                    if (
+                        merged_response["choices"][0]["delta"].get("content", None)
+                        is None
+                    ):
                         merged_response["choices"][0]["delta"]["content"] = ""
                     for r in responses[1:]:
                         text = self._extract_openai_text_output(r)


### PR DESCRIPTION
vLLM does not include content in the first response from the server.
Now we filter for the content entry missing before preprocessing merged requests. 