### PR TITLE
Improve async request rate for OpenAI HTTP client

### DIFF
--- a/src/c++/perf_analyzer/client_backend/openai/http_client.cc
+++ b/src/c++/perf_analyzer/client_backend/openai/http_client.cc
@@ -183,22 +183,17 @@ HttpClient::SetSSLCurlOptions(CURL* curl_handle)
 void
 HttpClient::Send(CURL* handle, std::unique_ptr<HttpRequest>&& request)
 {
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    auto insert_result = ongoing_async_requests_.emplace(std::make_pair(
-        reinterpret_cast<uintptr_t>(handle), std::move(request)));
-    if (!insert_result.second) {
-      curl_easy_cleanup(handle);
-      throw std::runtime_error(
-          "Failed to insert new asynchronous request context.");
-    }
-    curl_multi_add_handle(multi_handle_, handle);
+  auto insert_result = ongoing_async_requests_.emplace(
+      std::make_pair(reinterpret_cast<uintptr_t>(handle), std::move(request)));
+  if (!insert_result.second) {
+    curl_easy_cleanup(handle);
+    throw std::runtime_error(
+        "Failed to insert new asynchronous request context.");
   }
-
+  curl_multi_add_handle(multi_handle_, handle);
   cv_.notify_all();
-
-  // Wake up the async transfer thread to handle new requests immediately
   curl_multi_wakeup(multi_handle_);
 }
 
@@ -207,78 +202,78 @@ HttpClient::AsyncTransfer()
 {
   int place_holder = 0;
   CURLMsg* msg = nullptr;
-
-  while (!exiting_) {
+  do {
     std::vector<std::unique_ptr<HttpRequest>> request_list;
 
-    // Lock the mutex to check for work and wait if necessary
+    // sleep if no work is available
     std::unique_lock<std::mutex> lock(mutex_);
     cv_.wait(lock, [this] {
-      return this->exiting_ || !this->ongoing_async_requests_.empty();
+      if (this->exiting_) {
+        return true;
+      }
+      // wake up if an async request has been generated
+      return !this->ongoing_async_requests_.empty();
     });
 
-    if (exiting_) {
-      break;
-    }
-
-    lock.unlock();  // Release the mutex before waiting on network activity
-
-    // Perform any pending transfers
     CURLMcode mc = curl_multi_perform(multi_handle_, &place_holder);
-    if (mc != CURLM_OK) {
-      std::cerr << "Unexpected error: curl_multi_perform failed. Code:" << mc
-                << std::endl;
-      continue;
-    }
-
-    // Wait for activity on the multi_handle_
     int numfds;
-    mc = curl_multi_poll(multi_handle_, NULL, 0, 1000, &numfds);
-    if (mc != CURLM_OK) {
-      std::cerr << "Unexpected error: curl_multi_poll failed. Code:" << mc
+    if (mc == CURLM_OK) {
+      // Wait for activity. If there are no descriptors in the multi_handle_
+      // then curl_multi_wait will return immediately
+      mc = curl_multi_poll(multi_handle_, NULL, 0, 1000, &numfds);
+      if (mc == CURLM_OK) {
+        while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
+          uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);
+          auto itr = ongoing_async_requests_.find(identifier);
+          // This shouldn't happen
+          if (itr == ongoing_async_requests_.end()) {
+            std::cerr
+                << "Unexpected error: received completed request that is not "
+                   "in the list of asynchronous requests"
                 << std::endl;
-      continue;
-    }
+            curl_multi_remove_handle(multi_handle_, msg->easy_handle);
+            curl_easy_cleanup(msg->easy_handle);
+            continue;
+          }
 
-    lock.lock();  // Re-acquire the mutex before processing responses
-    while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
-      uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);
-      auto itr = ongoing_async_requests_.find(identifier);
-      // This shouldn't happen
-      if (itr == ongoing_async_requests_.end()) {
-        std::cerr << "Unexpected error: received completed request that is not "
-                  << "in the list of asynchronous requests" << std::endl;
-        curl_multi_remove_handle(multi_handle_, msg->easy_handle);
-        curl_easy_cleanup(msg->easy_handle);
-        continue;
-      }
+          uint32_t http_code = 400;
+          if (msg->data.result == CURLE_OK) {
+            curl_easy_getinfo(
+                msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_code);
+          } else if (msg->data.result == CURLE_OPERATION_TIMEDOUT) {
+            http_code = 499;
+          }
 
-      uint32_t http_code = 400;
-      if (msg->data.result == CURLE_OK) {
-        curl_easy_getinfo(msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_code);
-      } else if (msg->data.result == CURLE_OPERATION_TIMEDOUT) {
-        http_code = 499;
-      }
+          request_list.emplace_back(std::move(itr->second));
+          ongoing_async_requests_.erase(itr);
+          curl_multi_remove_handle(multi_handle_, msg->easy_handle);
+          curl_easy_cleanup(msg->easy_handle);
 
-      request_list.emplace_back(std::move(itr->second));
-      ongoing_async_requests_.erase(itr);
-      curl_multi_remove_handle(multi_handle_, msg->easy_handle);
-      curl_easy_cleanup(msg->easy_handle);
+          std::unique_ptr<HttpRequest>& async_request = request_list.back();
+          async_request->http_code_ = http_code;
 
-      std::unique_ptr<HttpRequest>& async_request = request_list.back();
-      async_request->http_code_ = http_code;
-
-      if (msg->msg != CURLMSG_DONE) {
-        std::cerr << "Unexpected error: received CURLMsg=" << msg->msg
+          if (msg->msg != CURLMSG_DONE) {
+            // Something wrong happened.
+            std::cerr << "Unexpected error: received CURLMsg=" << msg->msg
+                      << std::endl;
+          }
+        }
+      } else {
+        std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
                   << std::endl;
       }
+    } else {
+      std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
+                << std::endl;
     }
-    lock.unlock();  // Release the mutex after processing responses
+    lock.unlock();
 
     for (auto& this_request : request_list) {
       this_request->completion_callback_(this_request.get());
     }
-  }
+    std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  } while (!exiting_);
 }
 
 }}}}  // namespace triton::perfanalyzer::clientbackend::openai

--- a/src/c++/perf_analyzer/client_backend/openai/http_client.cc
+++ b/src/c++/perf_analyzer/client_backend/openai/http_client.cc
@@ -193,8 +193,8 @@ HttpClient::Send(CURL* handle, std::unique_ptr<HttpRequest>&& request)
         "Failed to insert new asynchronous request context.");
   }
   curl_multi_add_handle(multi_handle_, handle);
-  cv_.notify_all();
   curl_multi_wakeup(multi_handle_);
+  cv_.notify_all();
 }
 
 void
@@ -220,7 +220,7 @@ HttpClient::AsyncTransfer()
     if (mc == CURLM_OK) {
       // Wait for activity. If there are no descriptors in the multi_handle_
       // then curl_multi_wait will return immediately
-      mc = curl_multi_poll(multi_handle_, NULL, 0, 1000, &numfds);
+      mc = curl_multi_poll(multi_handle_, NULL, 0, INT_MAX, &numfds);
       if (mc == CURLM_OK) {
         while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
           uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);

--- a/src/c++/perf_analyzer/client_backend/openai/http_client.cc
+++ b/src/c++/perf_analyzer/client_backend/openai/http_client.cc
@@ -219,7 +219,7 @@ HttpClient::AsyncTransfer()
     int numfds;
     if (mc == CURLM_OK) {
       // Wait for activity. If there are no descriptors in the multi_handle_
-      // then curl_multi_wait will return immediately
+      // then curl_multi_poll will return immediately
       mc = curl_multi_poll(multi_handle_, NULL, 0, INT_MAX, &numfds);
       if (mc == CURLM_OK) {
         while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {

--- a/src/c++/perf_analyzer/client_backend/openai/http_client.cc
+++ b/src/c++/perf_analyzer/client_backend/openai/http_client.cc
@@ -220,7 +220,7 @@ HttpClient::AsyncTransfer()
     if (mc == CURLM_OK) {
       // Wait for activity. If there are no descriptors in the multi_handle_
       // then curl_multi_poll will return immediately
-      mc = curl_multi_poll(multi_handle_, NULL, 0, INT_MAX, &numfds);
+      mc = curl_multi_poll(multi_handle_, NULL, 0, 1000, &numfds);
       if (mc == CURLM_OK) {
         while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
           uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);


### PR DESCRIPTION
Resolve resource contention among the mutexes in the OpenAI HTTP client. This speeds up the request rate so that it can asynchronously add requests to the queue with less blocking related to resources.
Key changes:
- Move from `curl_multi_wait_` to `_curl_multi_poll` and `_curl_multi_wakeup` to avoid blocking call
- Set timeout to polling to help scheduler prioritize transferring new requests if none have been picked up in a while
- Add yield + sleep to help scheduler when responses are processed

Note that there is still some delay due to processing times and that can be eliminated by setting a really small timeout for polling for new requests, but that can waste cycles and reduce throughput. For now, I just set a max delay of 1 second to avoid edge cases and  slightly reduce the delay.

**Results:**

Before changes
![image](https://github.com/triton-inference-server/client/assets/58150256/3774d126-d75f-40a6-adae-28a3f570bea6)

After changes
![image](https://github.com/triton-inference-server/client/assets/58150256/076e7219-1466-4cb7-963b-ab7daf218f92)
