### PR TITLE
fix: Fix Client Http Async Code for Request Rate

### DIFF
--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -1371,27 +1371,23 @@ InferenceServerHttpClient::InferenceServerHttpClient(
 
 InferenceServerHttpClient::~InferenceServerHttpClient()
 {
-  exiting_ = true;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    exiting_ = true;
+  }
+
+  curl_multi_wakeup(multi_handle_);
 
   // thread not joinable if AsyncInfer() is not called
   // (it is default constructed thread before the first AsyncInfer() call)
   if (worker_.joinable()) {
-    cv_.notify_all();
     worker_.join();
   }
 
   if (easy_handle_ != nullptr) {
     curl_easy_cleanup(reinterpret_cast<CURL*>(easy_handle_));
   }
-
-  if (multi_handle_ != nullptr) {
-    for (auto& request : ongoing_async_requests_) {
-      CURL* easy_handle = reinterpret_cast<CURL*>(request.first);
-      curl_multi_remove_handle(multi_handle_, easy_handle);
-      curl_easy_cleanup(easy_handle);
-    }
-    curl_multi_cleanup(multi_handle_);
-  }
+  curl_multi_cleanup(multi_handle_);
 }
 
 Error
@@ -1887,25 +1883,28 @@ InferenceServerHttpClient::AsyncInfer(
   {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    auto insert_result = ongoing_async_requests_.emplace(std::make_pair(
+    if (exiting_) {
+      return Error("Client is exiting.");
+    }
+
+    auto insert_result = new_async_requests_.emplace(std::make_pair(
         reinterpret_cast<uintptr_t>(multi_easy_handle), async_request));
     if (!insert_result.second) {
       curl_easy_cleanup(multi_easy_handle);
       return Error("Failed to insert new asynchronous request context.");
     }
-
-    async_request->Timer().CaptureTimestamp(RequestTimers::Kind::SEND_START);
-    if (async_request->total_input_byte_size_ == 0) {
-      // Set SEND_END here because CURLOPT_READFUNCTION will not be called if
-      // content length is 0. In that case, we can't measure SEND_END properly
-      // (send ends after sending request header).
-      async_request->Timer().CaptureTimestamp(RequestTimers::Kind::SEND_END);
-    }
-
-    curl_multi_add_handle(multi_handle_, multi_easy_handle);
   }
 
-  cv_.notify_all();
+  async_request->Timer().CaptureTimestamp(RequestTimers::Kind::SEND_START);
+  curl_multi_wakeup(multi_handle_);
+
+  if (async_request->total_input_byte_size_ == 0) {
+    // Set SEND_END here because CURLOPT_READFUNCTION will not be called if
+    // content length is 0. In that case, we can't measure SEND_END properly
+    // (send ends after sending request header).
+    async_request->Timer().CaptureTimestamp(RequestTimers::Kind::SEND_END);
+  }
+
   return Error::Success;
 }
 
@@ -2249,88 +2248,96 @@ InferenceServerHttpClient::PreRunProcessing(
 void
 InferenceServerHttpClient::AsyncTransfer()
 {
-  int place_holder = 0;
+  int messages_in_queue = 0;
+  int still_running = 0;
+  int numfds = 0;
   CURLMsg* msg = nullptr;
+  AsyncReqMap ongoing_async_requests;
   do {
-    std::vector<std::shared_ptr<HttpInferRequest>> request_list;
+    // Check for new requests and add them to ongoing requests
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
 
-    // sleep if no work is available
-    std::unique_lock<std::mutex> lock(mutex_);
-    cv_.wait(lock, [this] {
-      if (this->exiting_) {
-        return true;
+      for (auto& pair : new_async_requests_) {
+        curl_multi_add_handle(
+            multi_handle_, reinterpret_cast<CURL*>(pair.first));
+
+        ongoing_async_requests[pair.first] = std::move(pair.second);
       }
-      // wake up if an async request has been generated
-      return !this->ongoing_async_requests_.empty();
-    });
+      new_async_requests_.clear();
+    }
 
-    CURLMcode mc = curl_multi_perform(multi_handle_, &place_holder);
-    int numfds;
-    if (mc == CURLM_OK) {
-      // Wait for activity. If there are no descriptors in the multi_handle_
-      // then curl_multi_wait will return immediately
-      mc = curl_multi_wait(multi_handle_, NULL, 0, INT_MAX, &numfds);
-      if (mc == CURLM_OK) {
-        while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
-          uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);
-          auto itr = ongoing_async_requests_.find(identifier);
-          // This shouldn't happen
-          if (itr == ongoing_async_requests_.end()) {
-            std::cerr
-                << "Unexpected error: received completed request that is not "
-                   "in the list of asynchronous requests"
-                << std::endl;
-            curl_multi_remove_handle(multi_handle_, msg->easy_handle);
-            curl_easy_cleanup(msg->easy_handle);
-            continue;
-          }
+    CURLMcode mc = curl_multi_perform(multi_handle_, &still_running);
 
-          long http_code = 400;
-          if (msg->data.result == CURLE_OK) {
-            curl_easy_getinfo(
-                msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_code);
-          } else if (msg->data.result == CURLE_OPERATION_TIMEDOUT) {
-            http_code = 499;
-          }
-
-          request_list.emplace_back(itr->second);
-          ongoing_async_requests_.erase(itr);
-          curl_multi_remove_handle(multi_handle_, msg->easy_handle);
-          curl_easy_cleanup(msg->easy_handle);
-
-          std::shared_ptr<HttpInferRequest> async_request = request_list.back();
-          async_request->http_code_ = http_code;
-
-          if (msg->msg != CURLMSG_DONE) {
-            // Something wrong happened.
-            std::cerr << "Unexpected error: received CURLMsg=" << msg->msg
-                      << std::endl;
-          } else {
-            async_request->Timer().CaptureTimestamp(
-                RequestTimers::Kind::REQUEST_END);
-            Error err = UpdateInferStat(async_request->Timer());
-            if (!err.IsOk()) {
-              std::cerr << "Failed to update context stat: " << err
-                        << std::endl;
-            }
-          }
-        }
-      } else {
-        std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
-                  << std::endl;
-      }
-    } else {
+    if (mc != CURLM_OK) {
       std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
                 << std::endl;
+      continue;
     }
-    lock.unlock();
 
-    for (auto& this_request : request_list) {
+    while ((msg = curl_multi_info_read(multi_handle_, &messages_in_queue))) {
+      if (msg->msg != CURLMSG_DONE) {
+        // Something wrong happened.
+        std::cerr << "Unexpected error: received CURLMsg=" << msg->msg
+                  << std::endl;
+        continue;
+      }
+
+      uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);
+      auto itr = ongoing_async_requests.find(identifier);
+      // This shouldn't happen
+      if (itr == ongoing_async_requests.end()) {
+        std::cerr << "Unexpected error: received completed request that is not "
+                     "in the list of asynchronous requests"
+                  << std::endl;
+        curl_multi_remove_handle(multi_handle_, msg->easy_handle);
+        curl_easy_cleanup(msg->easy_handle);
+        continue;
+      }
+
+      uint32_t http_code = 400;
+      if (msg->data.result == CURLE_OK) {
+        curl_easy_getinfo(msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_code);
+      } else if (msg->data.result == CURLE_OPERATION_TIMEDOUT) {
+        http_code = 499;
+      }
+
+      itr->second->http_code_ = http_code;
       InferResult* result;
-      InferResultHttp::Create(&result, this_request);
-      this_request->callback_(result);
+      InferResultHttp::Create(&result, itr->second);
+      itr->second->callback_(result);
+      ongoing_async_requests.erase(itr);
+      curl_multi_remove_handle(multi_handle_, msg->easy_handle);
+      curl_easy_cleanup(msg->easy_handle);
+    }
+
+    // Wait for activity on existing requests or
+    // explicit curl_multi_wakeup call
+    //
+    // If there are no descriptors in the multi_handle_
+    // then curl_multi_poll will wait until curl_multi_wakeup
+    // is called
+    //
+    // curl_multi_wakeup is called when adding a new request
+    // or exiting
+
+    mc = curl_multi_poll(multi_handle_, NULL, 0, INT_MAX, &numfds);
+    if (mc != CURLM_OK) {
+      std::cerr << "Unexpected error: curl_multi_poll failed. Code:" << mc
+                << std::endl;
     }
   } while (!exiting_);
+
+  for (auto& request : ongoing_async_requests) {
+    CURL* easy_handle = reinterpret_cast<CURL*>(request.first);
+    curl_multi_remove_handle(multi_handle_, easy_handle);
+    curl_easy_cleanup(easy_handle);
+  }
+
+  for (auto& request : new_async_requests_) {
+    CURL* easy_handle = reinterpret_cast<CURL*>(request.first);
+    curl_easy_cleanup(easy_handle);
+  }
 }
 
 size_t

--- a/src/c++/library/http_client.h
+++ b/src/c++/library/http_client.h
@@ -643,9 +643,9 @@ class InferenceServerHttpClient : public InferenceServerClient {
   void* easy_handle_;
   // curl multi handle for processing asynchronous requests
   void* multi_handle_;
-  // map to record ongoing asynchronous requests with pointer to easy handle
+  // map to record new asynchronous requests with pointer to easy handle
   // or tag id as key
-  AsyncReqMap ongoing_async_requests_;
+  AsyncReqMap new_async_requests_;
 };
 
 }}  // namespace triton::client

--- a/src/c++/perf_analyzer/client_backend/openai/http_client.cc
+++ b/src/c++/perf_analyzer/client_backend/openai/http_client.cc
@@ -104,20 +104,21 @@ HttpClient::HttpClient(
 
 HttpClient::~HttpClient()
 {
-  exiting_ = true;
+  printf("exiting!\n");
+  {
+    std::lock_guard<std::mutex> lock(mutex_);  
+    exiting_ = true;
+  }
+  
+  curl_multi_wakeup(multi_handle_);
 
   // thread not joinable if AsyncInfer() is not called
   // (it is default constructed thread before the first AsyncInfer() call)
   if (worker_.joinable()) {
-    cv_.notify_all();
+    //   cv_.notify_all();
     worker_.join();
   }
 
-  for (auto& request : ongoing_async_requests_) {
-    CURL* easy_handle = reinterpret_cast<CURL*>(request.first);
-    curl_multi_remove_handle(multi_handle_, easy_handle);
-    curl_easy_cleanup(easy_handle);
-  }
   curl_multi_cleanup(multi_handle_);
 
   {
@@ -183,94 +184,133 @@ HttpClient::SetSSLCurlOptions(CURL* curl_handle)
 void
 HttpClient::Send(CURL* handle, std::unique_ptr<HttpRequest>&& request)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
 
-  auto insert_result = ongoing_async_requests_.emplace(
-      std::make_pair(reinterpret_cast<uintptr_t>(handle), std::move(request)));
-  if (!insert_result.second) {
-    curl_easy_cleanup(handle);
-    throw std::runtime_error(
-        "Failed to insert new asynchronous request context.");
+    if (exiting_) {
+      return;
+    }
+
+    auto insert_result = new_async_requests_.emplace(
+						     std::make_pair(reinterpret_cast<uintptr_t>(handle), std::move(request)));
+    if (!insert_result.second) {
+      curl_easy_cleanup(handle);
+      throw std::runtime_error(
+			       "Failed to insert new asynchronous request context.");
+    }
   }
-  curl_multi_add_handle(multi_handle_, handle);
-  cv_.notify_all();
+  //  curl_multi_add_handle(multi_handle_, handle);
+  //cv_.notify_all();
+  curl_multi_wakeup(multi_handle_);
 }
 
 void
 HttpClient::AsyncTransfer()
 {
   int place_holder = 0;
+  int numfds = 0;
   CURLMsg* msg = nullptr;
+  AsyncReqMap ongoing_async_requests;
+
   do {
-    std::vector<std::unique_ptr<HttpRequest>> request_list;
-
+    //    std::vector<std::unique_ptr<HttpRequest>> completed_request_list;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      
+      for (auto& pair : new_async_requests_) {
+	curl_multi_add_handle(multi_handle_, reinterpret_cast<CURL*>(pair.first));
+	
+	ongoing_async_requests[pair.first] = std::move(pair.second);
+      }
+      new_async_requests_.clear();
+    }
+    
     // sleep if no work is available
-    std::unique_lock<std::mutex> lock(mutex_);
-    cv_.wait(lock, [this] {
-      if (this->exiting_) {
-        return true;
-      }
+    //    std::unique_lock<std::mutex> lock(mutex_);
+    // cv_.wait(lock, [this] {
+    // if (this->exiting_) {
+    //   return true;
+    // }
       // wake up if an async request has been generated
-      return !this->ongoing_async_requests_.empty();
-    });
+    //  return !this->ongoing_async_requests_.empty();
+    //});
 
+    printf("performing\n");
     CURLMcode mc = curl_multi_perform(multi_handle_, &place_holder);
-    int numfds;
-    if (mc == CURLM_OK) {
-      // Wait for activity. If there are no descriptors in the multi_handle_
-      // then curl_multi_wait will return immediately
-      mc = curl_multi_wait(multi_handle_, NULL, 0, INT_MAX, &numfds);
-      if (mc == CURLM_OK) {
-        while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
-          uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);
-          auto itr = ongoing_async_requests_.find(identifier);
-          // This shouldn't happen
-          if (itr == ongoing_async_requests_.end()) {
-            std::cerr
-                << "Unexpected error: received completed request that is not "
-                   "in the list of asynchronous requests"
-                << std::endl;
-            curl_multi_remove_handle(multi_handle_, msg->easy_handle);
-            curl_easy_cleanup(msg->easy_handle);
-            continue;
-          }
-
-          uint32_t http_code = 400;
-          if (msg->data.result == CURLE_OK) {
-            curl_easy_getinfo(
-                msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_code);
-          } else if (msg->data.result == CURLE_OPERATION_TIMEDOUT) {
-            http_code = 499;
-          }
-
-          request_list.emplace_back(std::move(itr->second));
-          ongoing_async_requests_.erase(itr);
-          curl_multi_remove_handle(multi_handle_, msg->easy_handle);
-          curl_easy_cleanup(msg->easy_handle);
-
-          std::unique_ptr<HttpRequest>& async_request = request_list.back();
-          async_request->http_code_ = http_code;
-
-          if (msg->msg != CURLMSG_DONE) {
-            // Something wrong happened.
-            std::cerr << "Unexpected error: received CURLMsg=" << msg->msg
-                      << std::endl;
-          }
-        }
-      } else {
-        std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
-                  << std::endl;
-      }
-    } else {
+    
+    if (mc != CURLM_OK) {
       std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
                 << std::endl;
+      continue;
     }
-    lock.unlock();
+    
+    // Wait for activity. If there are no descriptors in the multi_handle_
+    // then curl_multi_wait will return immediately
+    printf("polling\n");
+    
+    mc = curl_multi_poll(multi_handle_, NULL, 0, INT_MAX, &numfds);
 
-    for (auto& this_request : request_list) {
-      this_request->completion_callback_(this_request.get());
+    printf("polling done\n");
+
+    if (mc != CURLM_OK) {
+      std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
+                << std::endl;
+      continue;
+    }
+    
+    while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
+
+      if (msg->msg != CURLMSG_DONE) {
+	// Something wrong happened.
+	std::cerr << "Unexpected error: received CURLMsg=" << msg->msg
+		  << std::endl;
+	continue;
+      }
+
+      uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);
+      auto itr = ongoing_async_requests.find(identifier);
+      // This shouldn't happen
+      if (itr == ongoing_async_requests.end()) {
+	std::cerr
+	  << "Unexpected error: received completed request that is not "
+	  "in the list of asynchronous requests"
+	  << std::endl;
+	curl_multi_remove_handle(multi_handle_, msg->easy_handle);
+	curl_easy_cleanup(msg->easy_handle);
+	continue;
+      }
+
+      uint32_t http_code = 400;
+      if (msg->data.result == CURLE_OK) {
+	curl_easy_getinfo(
+			  msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_code);
+      } else if (msg->data.result == CURLE_OPERATION_TIMEDOUT) {
+	http_code = 499;
+      }
+
+      //          completed_request_list.emplace_back(std::move(itr->second));
+      itr->second->http_code_ = http_code;
+      //      printf("completion callback!\n");
+      itr->second->completion_callback_(itr->second.get());
+      ongoing_async_requests.erase(itr);
+      curl_multi_remove_handle(multi_handle_, msg->easy_handle);
+      curl_easy_cleanup(msg->easy_handle);
+      //          std::unique_ptr<HttpRequest>& async_request = request_list.back(); 
     }
   } while (!exiting_);
+
+  printf("exiting!\n");
+  for (auto& request : ongoing_async_requests) {
+    CURL* easy_handle = reinterpret_cast<CURL*>(request.first);
+    curl_multi_remove_handle(multi_handle_, easy_handle);
+    curl_easy_cleanup(easy_handle);
+  }
+
+  for (auto& request : new_async_requests_) {
+    CURL* easy_handle = reinterpret_cast<CURL*>(request.first);
+    curl_multi_remove_handle(multi_handle_, easy_handle);
+    curl_easy_cleanup(easy_handle);
+  }
 }
 
 }}}}  // namespace triton::perfanalyzer::clientbackend::openai

--- a/src/c++/perf_analyzer/client_backend/openai/http_client.cc
+++ b/src/c++/perf_analyzer/client_backend/openai/http_client.cc
@@ -104,18 +104,16 @@ HttpClient::HttpClient(
 
 HttpClient::~HttpClient()
 {
-  printf("exiting!\n");
   {
-    std::lock_guard<std::mutex> lock(mutex_);  
+    std::lock_guard<std::mutex> lock(mutex_);
     exiting_ = true;
   }
-  
+
   curl_multi_wakeup(multi_handle_);
 
   // thread not joinable if AsyncInfer() is not called
   // (it is default constructed thread before the first AsyncInfer() call)
   if (worker_.joinable()) {
-    //   cv_.notify_all();
     worker_.join();
   }
 
@@ -191,115 +189,103 @@ HttpClient::Send(CURL* handle, std::unique_ptr<HttpRequest>&& request)
       return;
     }
 
-    auto insert_result = new_async_requests_.emplace(
-						     std::make_pair(reinterpret_cast<uintptr_t>(handle), std::move(request)));
+    auto insert_result = new_async_requests_.emplace(std::make_pair(
+        reinterpret_cast<uintptr_t>(handle), std::move(request)));
     if (!insert_result.second) {
       curl_easy_cleanup(handle);
       throw std::runtime_error(
-			       "Failed to insert new asynchronous request context.");
+          "Failed to insert new asynchronous request context.");
     }
   }
-  //  curl_multi_add_handle(multi_handle_, handle);
-  //cv_.notify_all();
   curl_multi_wakeup(multi_handle_);
 }
 
 void
 HttpClient::AsyncTransfer()
 {
-  int place_holder = 0;
+  int messages_in_queue = 0;
+  int still_running = 0;
   int numfds = 0;
   CURLMsg* msg = nullptr;
   AsyncReqMap ongoing_async_requests;
 
   do {
-    //    std::vector<std::unique_ptr<HttpRequest>> completed_request_list;
     {
+      // Check for new requests and add them to ongoing requests
+
       std::lock_guard<std::mutex> lock(mutex_);
-      
+
       for (auto& pair : new_async_requests_) {
-	curl_multi_add_handle(multi_handle_, reinterpret_cast<CURL*>(pair.first));
-	
-	ongoing_async_requests[pair.first] = std::move(pair.second);
+        curl_multi_add_handle(
+            multi_handle_, reinterpret_cast<CURL*>(pair.first));
+
+        ongoing_async_requests[pair.first] = std::move(pair.second);
       }
       new_async_requests_.clear();
     }
-    
-    // sleep if no work is available
-    //    std::unique_lock<std::mutex> lock(mutex_);
-    // cv_.wait(lock, [this] {
-    // if (this->exiting_) {
-    //   return true;
-    // }
-      // wake up if an async request has been generated
-    //  return !this->ongoing_async_requests_.empty();
-    //});
 
-    printf("performing\n");
-    CURLMcode mc = curl_multi_perform(multi_handle_, &place_holder);
-    
-    if (mc != CURLM_OK) {
-      std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
-                << std::endl;
-      continue;
-    }
-    
-    // Wait for activity. If there are no descriptors in the multi_handle_
-    // then curl_multi_wait will return immediately
-    printf("polling\n");
-    
-    mc = curl_multi_poll(multi_handle_, NULL, 0, INT_MAX, &numfds);
-
-    printf("polling done\n");
+    CURLMcode mc = curl_multi_perform(multi_handle_, &still_running);
 
     if (mc != CURLM_OK) {
       std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
                 << std::endl;
       continue;
     }
-    
-    while ((msg = curl_multi_info_read(multi_handle_, &place_holder))) {
 
+    while ((msg = curl_multi_info_read(multi_handle_, &messages_in_queue))) {
       if (msg->msg != CURLMSG_DONE) {
-	// Something wrong happened.
-	std::cerr << "Unexpected error: received CURLMsg=" << msg->msg
-		  << std::endl;
-	continue;
+        // Something wrong happened.
+        std::cerr << "Unexpected error: received CURLMsg=" << msg->msg
+                  << std::endl;
+        continue;
       }
 
       uintptr_t identifier = reinterpret_cast<uintptr_t>(msg->easy_handle);
       auto itr = ongoing_async_requests.find(identifier);
       // This shouldn't happen
       if (itr == ongoing_async_requests.end()) {
-	std::cerr
-	  << "Unexpected error: received completed request that is not "
-	  "in the list of asynchronous requests"
-	  << std::endl;
-	curl_multi_remove_handle(multi_handle_, msg->easy_handle);
-	curl_easy_cleanup(msg->easy_handle);
-	continue;
+        std::cerr << "Unexpected error: received completed request that is not "
+                     "in the list of asynchronous requests"
+                  << std::endl;
+        curl_multi_remove_handle(multi_handle_, msg->easy_handle);
+        curl_easy_cleanup(msg->easy_handle);
+        continue;
       }
 
       uint32_t http_code = 400;
       if (msg->data.result == CURLE_OK) {
-	curl_easy_getinfo(
-			  msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_code);
+        curl_easy_getinfo(msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_code);
       } else if (msg->data.result == CURLE_OPERATION_TIMEDOUT) {
-	http_code = 499;
+        http_code = 499;
       }
 
-      //          completed_request_list.emplace_back(std::move(itr->second));
       itr->second->http_code_ = http_code;
-      //      printf("completion callback!\n");
       itr->second->completion_callback_(itr->second.get());
       ongoing_async_requests.erase(itr);
       curl_multi_remove_handle(multi_handle_, msg->easy_handle);
       curl_easy_cleanup(msg->easy_handle);
-      //          std::unique_ptr<HttpRequest>& async_request = request_list.back(); 
     }
+
+
+    // Wait for activity on existing requests or
+    // explicit curl_multi_wakeup call
+    //
+    // If there are no descriptors in the multi_handle_
+    // then curl_multi_poll will wait until curl_multi_wakeup
+    // is called
+    //
+    // curl_multi_wakeup is called when adding a new request
+    // or exiting
+
+    mc = curl_multi_poll(multi_handle_, NULL, 0, INT_MAX, &numfds);
+
+    if (mc != CURLM_OK) {
+      std::cerr << "Unexpected error: curl_multi failed. Code:" << mc
+                << std::endl;
+    }
+
   } while (!exiting_);
 
-  printf("exiting!\n");
   for (auto& request : ongoing_async_requests) {
     CURL* easy_handle = reinterpret_cast<CURL*>(request.first);
     curl_multi_remove_handle(multi_handle_, easy_handle);
@@ -308,7 +294,6 @@ HttpClient::AsyncTransfer()
 
   for (auto& request : new_async_requests_) {
     CURL* easy_handle = reinterpret_cast<CURL*>(request.first);
-    curl_multi_remove_handle(multi_handle_, easy_handle);
     curl_easy_cleanup(easy_handle);
   }
 }

--- a/src/c++/perf_analyzer/client_backend/openai/http_client.h
+++ b/src/c++/perf_analyzer/client_backend/openai/http_client.h
@@ -149,7 +149,6 @@ class HttpClient {
 
   std::thread worker_;
   std::mutex mutex_;
-  std::condition_variable cv_;
 
   // The server url
   const std::string url_;
@@ -159,9 +158,9 @@ class HttpClient {
   using AsyncReqMap = std::map<uintptr_t, std::unique_ptr<HttpRequest>>;
   // curl multi handle for processing asynchronous requests
   void* multi_handle_;
-  // map to record ongoing asynchronous requests with pointer to easy handle
+  // map to record new asynchronous requests with pointer to easy handle
   // or tag id as key
-  AsyncReqMap ongoing_async_requests_;
+  AsyncReqMap new_async_requests_;
 
   bool verbose_;
 

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -260,6 +260,7 @@ class InferenceProfiler {
       uint64_t measurement_request_count, MeasurementMode measurement_mode,
       std::shared_ptr<MPIDriver> mpi_driver, const uint64_t metrics_interval_ms,
       const bool should_collect_metrics, const double overhead_pct_threshold,
+      const bool async_mode,
       const std::shared_ptr<ProfileDataCollector> collector,
       const bool should_collect_profile_data);
 
@@ -363,7 +364,7 @@ class InferenceProfiler {
       std::unique_ptr<LoadManager> manager, uint64_t measurement_request_count,
       MeasurementMode measurement_mode, std::shared_ptr<MPIDriver> mpi_driver,
       const uint64_t metrics_interval_ms, const bool should_collect_metrics,
-      const double overhead_pct_threshold,
+      const double overhead_pct_threshold, const bool async_mode,
       const std::shared_ptr<ProfileDataCollector> collector,
       const bool should_collect_profile_data);
 
@@ -432,8 +433,9 @@ class InferenceProfiler {
 
   /// A helper function to determine if profiling is stable
   /// \param load_status Stores the observations of infer_per_sec and latencies
+  /// \param check_latency Whether to check latency for stability
   /// \return Returns if the threshold and latencies are stable.
-  bool DetermineStability(LoadStatus& load_status);
+  bool DetermineStability(LoadStatus& load_status, bool check_latency = true);
 
   /// Check if latency at index idx is within the latency threshold
   /// \param idx index in latency vector
@@ -452,8 +454,10 @@ class InferenceProfiler {
   /// for a single window starting at idx
   /// \param idx index in latency vector
   /// \param load_status Stores the observations of infer_per_sec and latencies
+  /// \param check_latency Whether to check latency for stability
   /// \return Returns whether inference and latency are stable
-  bool CheckWindowForStability(size_t idx, LoadStatus& load_status);
+  bool CheckWindowForStability(
+      size_t idx, LoadStatus& load_status, bool check_latency);
 
   /// Check if observed inferences are within threshold
   /// for a single window starting at idx
@@ -785,6 +789,9 @@ class InferenceProfiler {
 
   // Whether to collect profile data.
   bool should_collect_profile_data_{false};
+
+  // Whether the client is operating in async mode.
+  const bool async_mode_{false};
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend NaggyMockInferenceProfiler;

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -284,7 +284,7 @@ PerfAnalyzer::CreateAnalyzerObjects()
           params_->measurement_request_count, params_->measurement_mode,
           params_->mpi_driver, params_->metrics_interval_ms,
           params_->should_collect_metrics, params_->overhead_pct_threshold,
-          collector_, !params_->profile_export_file.empty()),
+          params_->async, collector_, !params_->profile_export_file.empty()),
       "failed to create profiler");
 }
 
@@ -311,11 +311,16 @@ PerfAnalyzer::PrerunReport()
                 << std::endl;
     }
 
+    std::string stabilization_metric = "latency and throughput";
+    if (params_->async) {
+      stabilization_metric = "throughput";
+    }
     if (params_->percentile == -1) {
-      std::cout << "  Stabilizing using average latency" << std::endl;
-    } else {
-      std::cout << "  Stabilizing using p" << params_->percentile << " latency"
+      std::cout << "  Stabilizing using average " << stabilization_metric
                 << std::endl;
+    } else {
+      std::cout << "  Stabilizing using p" << params_->percentile
+                << stabilization_metric << std::endl;
     }
 
     if (params_->measurement_mode == pa::MeasurementMode::TIME_WINDOWS) {

--- a/src/c++/perf_analyzer/test_inference_profiler.cc
+++ b/src/c++/perf_analyzer/test_inference_profiler.cc
@@ -81,16 +81,17 @@ class TestInferenceProfiler : public InferenceProfiler {
     ip.load_parameters_.stability_threshold = lp.stability_threshold;
     ip.load_parameters_.stability_window = lp.stability_window;
 
-    return ip.CheckWindowForStability(idx, ls);
+    return ip.CheckWindowForStability(idx, ls, true);
   };
 
-  static bool TestDetermineStability(LoadStatus& ls, LoadParams& lp)
+  static bool TestDetermineStability(
+      LoadStatus& ls, LoadParams& lp, bool check_latency = true)
   {
     InferenceProfiler ip;
     ip.load_parameters_.stability_threshold = lp.stability_threshold;
     ip.load_parameters_.stability_window = lp.stability_window;
 
-    return ip.DetermineStability(ls);
+    return ip.DetermineStability(ls, check_latency);
   }
 
   static bool TestIsDoneProfiling(
@@ -348,6 +349,16 @@ TEST_CASE("test_determine_stability")
 
     ls.infer_per_sec = {500.0, 520.0, 510.0};
     CHECK(TestInferenceProfiler::TestDetermineStability(ls, lp) == true);
+  }
+
+  SUBCASE("test determine stability without latency check")
+  {
+    ls.infer_per_sec = {500.0, 520.0, 510.0};
+    ls.latencies = {100, 106, 112};
+    lp.stability_window = 3;
+    lp.stability_threshold = 0.1;
+    uint64_t latency_threshold_ms = 1;
+    CHECK(TestInferenceProfiler::TestDetermineStability(ls, lp, false) == true);
   }
 }
 


### PR DESCRIPTION
Changed to use `multi_curl_poll` and `multi_curl_wakeup` to allow for handling of new requests and ongoing requests.

1) Load generation thread adds requests into a mutex protected map.
2) Load generation thread calls `multi_curl_wakeup`
3) AsyncTransferThread adds new requests to `multi_handle`
4) AsyncTransferThread reads / writes to requests via `curl_multi_perform`
5) AsyncTransferThread processes complete requests via `curl_multi_info_read`
6) AsyncTransferThread waits for new data or new requests or exit signal using `curl_multi_poll`
7) When exiting, AsyncTransferThread removes and releases requests added to `multi_handle`

Note: Load generation thread only initializes and calls `curl_multi_wakeup` on `multi_handle`, all other operations are done in the AsyncTransferThread

--

Similar changes were added to the HTTP client (#686 and #691)
Since async requests have more variable latency, especially at higher request rates, stabilizatio no longer requires latency to stabilize and PA will now instead print an error if it does not stabilize. (#688)