### PR TITLE
fix: Get validation outputs by name rather than index

### DIFF
--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -260,13 +260,14 @@ InferContext::ValidateOutputs(const cb::InferResult* result_ptr)
 {
   // Validate output if set
   if (!infer_data_.expected_outputs_.empty()) {
-    for (const auto& expected_output : infer_data_.expected_outputs_) {
+    for (size_t i = 0; i < infer_data_.expected_outputs_.size(); ++i) {
       const uint8_t* buf = nullptr;
       size_t byte_size = 0;
-      // Explicitly request the output for comparison by name, because the
-      // indices of outputs and expected_outputs may not be ordered the same.
-      result_ptr->RawData(expected_output->Name(), &buf, &byte_size);
-      for (const auto& expected : expected_output) {
+      // Request output by validation output's name explicitly, rather than
+      // relying on the array indices being sorted equally in both arrays.
+      result_ptr->RawData(
+          infer_data_.expected_outputs_[i]->Name(), &buf, &byte_size);
+      for (const auto& expected : infer_data_.expected_outputs_[i]) {
         if (!expected.is_valid) {
           return cb::Error(
               "Expected output can't be invalid", pa::GENERIC_ERROR);

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -260,11 +260,13 @@ InferContext::ValidateOutputs(const cb::InferResult* result_ptr)
 {
   // Validate output if set
   if (!infer_data_.expected_outputs_.empty()) {
-    for (size_t i = 0; i < infer_data_.outputs_.size(); ++i) {
+    for (const auto& expected_output : infer_data_.expected_outputs_) {
       const uint8_t* buf = nullptr;
       size_t byte_size = 0;
-      result_ptr->RawData(infer_data_.outputs_[i]->Name(), &buf, &byte_size);
-      for (const auto& expected : infer_data_.expected_outputs_[i]) {
+      // Explicitly request the output for comparison by name, because the
+      // indices of outputs and expected_outputs may not be ordered the same.
+      result_ptr->RawData(expected_output->Name(), &buf, &byte_size);
+      for (const auto& expected : expected_output) {
         if (!expected.is_valid) {
           return cb::Error(
               "Expected output can't be invalid", pa::GENERIC_ERROR);


### PR DESCRIPTION
If `infer_data_.outputs_` and `infer_data_.expected_outputs_` are ordered differently, then `outputs_[i] != expected_outputs_[i]` - so make sure the output being compared against the validation output is requested by the same output name.
