### PR TITLE
Stabilize PA on throughput only for async case

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -484,6 +484,7 @@ InferenceProfiler::Create(
     uint64_t measurement_request_count, MeasurementMode measurement_mode,
     std::shared_ptr<MPIDriver> mpi_driver, const uint64_t metrics_interval_ms,
     const bool should_collect_metrics, const double overhead_pct_threshold,
+    const bool async_mode,
     const std::shared_ptr<ProfileDataCollector> collector,
     const bool should_collect_profile_data)
 {
@@ -492,7 +493,8 @@ InferenceProfiler::Create(
       (percentile != -1), percentile, latency_threshold_ms_, protocol, parser,
       profile_backend, std::move(manager), measurement_request_count,
       measurement_mode, mpi_driver, metrics_interval_ms, should_collect_metrics,
-      overhead_pct_threshold, collector, should_collect_profile_data));
+      overhead_pct_threshold, async_mode, collector,
+      should_collect_profile_data));
 
   *profiler = std::move(local_profiler);
   return cb::Error::Success;
@@ -508,7 +510,7 @@ InferenceProfiler::InferenceProfiler(
     std::unique_ptr<LoadManager> manager, uint64_t measurement_request_count,
     MeasurementMode measurement_mode, std::shared_ptr<MPIDriver> mpi_driver,
     const uint64_t metrics_interval_ms, const bool should_collect_metrics,
-    const double overhead_pct_threshold,
+    const double overhead_pct_threshold, const bool async_mode,
     const std::shared_ptr<ProfileDataCollector> collector,
     const bool should_collect_profile_data)
     : verbose_(verbose), measurement_window_ms_(measurement_window_ms),
@@ -519,7 +521,8 @@ InferenceProfiler::InferenceProfiler(
       measurement_request_count_(measurement_request_count),
       measurement_mode_(measurement_mode), mpi_driver_(mpi_driver),
       should_collect_metrics_(should_collect_metrics),
-      overhead_pct_threshold_(overhead_pct_threshold), collector_(collector),
+      overhead_pct_threshold_(overhead_pct_threshold), async_mode_(async_mode),
+      collector_(collector),
       should_collect_profile_data_(should_collect_profile_data)
 {
   load_parameters_.stability_threshold = stability_threshold;
@@ -839,7 +842,7 @@ bool
 InferenceProfiler::CheckWindowForStability(size_t idx, LoadStatus& load_status)
 {
   return IsInferWindowStable(idx, load_status) &&
-         IsLatencyWindowStable(idx, load_status);
+         (async_mode_ == true || IsLatencyWindowStable(idx, load_status));
 }
 
 bool

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -260,6 +260,7 @@ class InferenceProfiler {
       uint64_t measurement_request_count, MeasurementMode measurement_mode,
       std::shared_ptr<MPIDriver> mpi_driver, const uint64_t metrics_interval_ms,
       const bool should_collect_metrics, const double overhead_pct_threshold,
+      const bool async_mode,
       const std::shared_ptr<ProfileDataCollector> collector,
       const bool should_collect_profile_data);
 
@@ -363,7 +364,7 @@ class InferenceProfiler {
       std::unique_ptr<LoadManager> manager, uint64_t measurement_request_count,
       MeasurementMode measurement_mode, std::shared_ptr<MPIDriver> mpi_driver,
       const uint64_t metrics_interval_ms, const bool should_collect_metrics,
-      const double overhead_pct_threshold,
+      const double overhead_pct_threshold, const bool async_mode,
       const std::shared_ptr<ProfileDataCollector> collector,
       const bool should_collect_profile_data);
 
@@ -785,6 +786,9 @@ class InferenceProfiler {
 
   // Whether to collect profile data.
   bool should_collect_profile_data_{false};
+
+  // Whether the client is operating in async mode.
+  const bool async_mode_{false};
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend NaggyMockInferenceProfiler;

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -433,8 +433,9 @@ class InferenceProfiler {
 
   /// A helper function to determine if profiling is stable
   /// \param load_status Stores the observations of infer_per_sec and latencies
+  /// \param check_latency Whether to check latency for stability
   /// \return Returns if the threshold and latencies are stable.
-  bool DetermineStability(LoadStatus& load_status);
+  bool DetermineStability(LoadStatus& load_status, bool check_latency = true);
 
   /// Check if latency at index idx is within the latency threshold
   /// \param idx index in latency vector
@@ -453,8 +454,10 @@ class InferenceProfiler {
   /// for a single window starting at idx
   /// \param idx index in latency vector
   /// \param load_status Stores the observations of infer_per_sec and latencies
+  /// \param check_latency Whether to check latency for stability
   /// \return Returns whether inference and latency are stable
-  bool CheckWindowForStability(size_t idx, LoadStatus& load_status);
+  bool CheckWindowForStability(
+      size_t idx, LoadStatus& load_status, bool check_latency);
 
   /// Check if observed inferences are within threshold
   /// for a single window starting at idx

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -284,7 +284,7 @@ PerfAnalyzer::CreateAnalyzerObjects()
           params_->measurement_request_count, params_->measurement_mode,
           params_->mpi_driver, params_->metrics_interval_ms,
           params_->should_collect_metrics, params_->overhead_pct_threshold,
-          collector_, !params_->profile_export_file.empty()),
+          params_->async, collector_, !params_->profile_export_file.empty()),
       "failed to create profiler");
 }
 

--- a/src/c++/perf_analyzer/perf_analyzer.cc
+++ b/src/c++/perf_analyzer/perf_analyzer.cc
@@ -311,11 +311,16 @@ PerfAnalyzer::PrerunReport()
                 << std::endl;
     }
 
+    std::string stabilization_metric = "latency and throughput";
+    if (params_->async) {
+      stabilization_metric = "throughput";
+    }
     if (params_->percentile == -1) {
-      std::cout << "  Stabilizing using average latency" << std::endl;
-    } else {
-      std::cout << "  Stabilizing using p" << params_->percentile << " latency"
+      std::cout << "  Stabilizing using average " << stabilization_metric
                 << std::endl;
+    } else {
+      std::cout << "  Stabilizing using p" << params_->percentile
+                << stabilization_metric << std::endl;
     }
 
     if (params_->measurement_mode == pa::MeasurementMode::TIME_WINDOWS) {

--- a/src/c++/perf_analyzer/test_inference_profiler.cc
+++ b/src/c++/perf_analyzer/test_inference_profiler.cc
@@ -81,16 +81,17 @@ class TestInferenceProfiler : public InferenceProfiler {
     ip.load_parameters_.stability_threshold = lp.stability_threshold;
     ip.load_parameters_.stability_window = lp.stability_window;
 
-    return ip.CheckWindowForStability(idx, ls);
+    return ip.CheckWindowForStability(idx, ls, true);
   };
 
-  static bool TestDetermineStability(LoadStatus& ls, LoadParams& lp)
+  static bool TestDetermineStability(
+      LoadStatus& ls, LoadParams& lp, bool check_latency = true)
   {
     InferenceProfiler ip;
     ip.load_parameters_.stability_threshold = lp.stability_threshold;
     ip.load_parameters_.stability_window = lp.stability_window;
 
-    return ip.DetermineStability(ls);
+    return ip.DetermineStability(ls, check_latency);
   }
 
   static bool TestIsDoneProfiling(
@@ -348,6 +349,16 @@ TEST_CASE("test_determine_stability")
 
     ls.infer_per_sec = {500.0, 520.0, 510.0};
     CHECK(TestInferenceProfiler::TestDetermineStability(ls, lp) == true);
+  }
+
+  SUBCASE("test determine stability without latency check")
+  {
+    ls.infer_per_sec = {500.0, 520.0, 510.0};
+    ls.latencies = {100, 106, 112};
+    lp.stability_window = 3;
+    lp.stability_threshold = 0.1;
+    uint64_t latency_threshold_ms = 1;
+    CHECK(TestInferenceProfiler::TestDetermineStability(ls, lp, false) == true);
   }
 }
 


### PR DESCRIPTION
After fixing the async request rate case, perf analyzer no longer stabilizes most of the time for smaller models due to the latency being more variable in the async case. As a result, only use throughput (inferences per second) for stabilizing. PA quite quickly with these updates.

Before changes:
DenseNet
![image](https://github.com/triton-inference-server/client/assets/58150256/a9045089-12d6-4ad5-8070-a39249c5a31b)


After changes:
DenseNet
![image](https://github.com/triton-inference-server/client/assets/58150256/9e350e84-ab0b-4e57-8bae-e772de0c5426)
