### PR TITLE
Add code to catch error at line 58

### DIFF
--- a/src/c++/perf_analyzer/client_backend/triton_c_api/triton_c_api_backend.cc
+++ b/src/c++/perf_analyzer/client_backend/triton_c_api/triton_c_api_backend.cc
@@ -55,7 +55,8 @@ TritonCApiClientBackend::Create(
 
   std::unique_ptr<TritonCApiClientBackend> triton_client_backend(
       new TritonCApiClientBackend());
-  TritonLoader::Create(triton_server_path, model_repository_path, verbose);
+  RETURN_IF_ERROR(
+      TritonLoader::Create(triton_server_path, model_repository_path, verbose));
   *client_backend = std::move(triton_client_backend);
   return Error::Success;
 }


### PR DESCRIPTION
While investigation [TPA-113](https://jirasw.nvidia.com/browse/TPA-113), @matthewkotila found that the error is being dropped at line 58 in triton_c_api_backend.cc.
This PR catches the error.