### PR TITLE
Clamp window for request-count

### DIFF
--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1390,8 +1390,6 @@ InferenceProfiler::ClampWindow(std::vector<RequestRecord>& requests)
   return std::make_pair(
       earliest_start.time_since_epoch().count(),
       latest_end.time_since_epoch().count());
-  // window_start_ns = earliest_start.time_since_epoch().count();
-  // window_end_ns = latest_end.time_since_epoch().count();
 }
 
 

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -1278,7 +1278,7 @@ InferenceProfiler::Summarize(
 
 
   if (clamp_window) {
-    std::tie(window_start_ns, window_end_ns) = ClampWindow(valid_requests);
+    auto [start, end] = ClampWindow(valid_requests);
   }
 
   uint64_t window_duration_ns = window_end_ns - window_start_ns;

--- a/src/c++/perf_analyzer/inference_profiler.cc
+++ b/src/c++/perf_analyzer/inference_profiler.cc
@@ -731,6 +731,12 @@ InferenceProfiler::ProfileHelper(
       measure_config.measurement_window = measurement_request_count_;
       measure_config.is_count_based = true;
     }
+
+    // When request_count is not 0, the experiment will run for exactly X
+    // requests. In that case, we are not measuring based on window stability,
+    // and instead need to clamp the windows to be from the start of the
+    // first request to the end of the last request of the request count
+    //
     measure_config.clamp_window = (request_count != 0);
     error.push(Measure(measurement_perf_status, measure_config));
     measurement_perf_statuses.push_back(measurement_perf_status);

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -529,7 +529,7 @@ class InferenceProfiler {
 
   /// Clamp a window around a set of requests, from the earliest start time to
   /// the latest response
-  /// \param requests A vector of requests to clamp the window around
+  /// \param requests A vector of requests to clamp the window around.
   /// \return std::pair object containing <start, end> of the window
   std::pair<uint64_t, uint64_t> ClampWindow(
       std::vector<RequestRecord>& requests);

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -504,7 +504,7 @@ class InferenceProfiler {
   /// \param window_start_ns The window start timestamp in nanoseconds.
   /// \param window_end_ns The window end timestamp in nanoseconds.
   /// \param clamp_window If true, the actual window range is reduced to the
-  /// start of the first request to the final response
+  /// start of the first request to the final response.
   /// \return cb::Error object indicating success or failure.
   cb::Error Summarize(
       const std::map<cb::ModelIdentifier, cb::ModelStatistics>& start_status,

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -482,7 +482,7 @@ class InferenceProfiler {
 
   /// Helper function to perform measurement.
   /// \param status_summary The summary of this measurement.
-  /// \param config The configuration for measurement
+  /// \param config The configuration for measurement.
   /// \return cb::Error object indicating success or failure.
   cb::Error Measure(PerfStatus& status_summary, MeasureConfig config);
 

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -77,6 +77,13 @@ struct LoadStatus {
   uint64_t avg_latency = 0;
 };
 
+/// Configuration for the Measure function
+struct MeasureConfig {
+  uint64_t measurement_window{0};
+  bool is_count_based{false};
+  bool clamp_window{false};
+};
+
 // Holds the total of the timiming components of composing models of an
 // ensemble.
 struct EnsembleDurations {
@@ -475,14 +482,9 @@ class InferenceProfiler {
 
   /// Helper function to perform measurement.
   /// \param status_summary The summary of this measurement.
-  /// \param measurement_window Indicating the number of requests or the
-  /// duration in milliseconds to collect requests.
-  /// \param is_count_based determines whether measurement_window is indicating
-  /// time or count.
+  /// \param config The configuration for measurement
   /// \return cb::Error object indicating success or failure.
-  cb::Error Measure(
-      PerfStatus& status_summary, uint64_t measurement_window,
-      bool is_count_based);
+  cb::Error Measure(PerfStatus& status_summary, MeasureConfig config);
 
   /// Gets the server side statistics
   /// \param model_status Returns the status of the models provided by
@@ -501,12 +503,15 @@ class InferenceProfiler {
   /// \param summary Returns the summary of the measurement.
   /// \param window_start_ns The window start timestamp in nanoseconds.
   /// \param window_end_ns The window end timestamp in nanoseconds.
+  /// \param clamp_window If true, the actual window range is reduced to the
+  /// start of the first request to the final response
   /// \return cb::Error object indicating success or failure.
   cb::Error Summarize(
       const std::map<cb::ModelIdentifier, cb::ModelStatistics>& start_status,
       const std::map<cb::ModelIdentifier, cb::ModelStatistics>& end_status,
       const cb::InferStat& start_stat, const cb::InferStat& end_stat,
-      PerfStatus& summary, uint64_t window_start_ns, uint64_t window_end_ns);
+      PerfStatus& summary, uint64_t window_start_ns, uint64_t window_end_ns,
+      bool clamp_window);
 
   /// \param valid_range The start and end timestamp of the measurement window.
   /// \param valid_sequence_count Returns the number of completed sequences
@@ -521,6 +526,13 @@ class InferenceProfiler {
       size_t& valid_sequence_count, size_t& delayed_request_count,
       std::vector<uint64_t>* latencies, size_t& response_count,
       std::vector<RequestRecord>& valid_requests);
+
+  /// Clamp a window around a set of requests, from the earliest start time to
+  /// the latest response
+  /// \param requests A vector of requests to clamp the window around
+  /// \return std::pair object containing <start, end> of the window
+  std::pair<uint64_t, uint64_t> ClampWindow(
+      std::vector<RequestRecord>& requests);
 
   /// Add the data from the request records to the Raw Data Collector
   /// \param perf_status PerfStatus of the current measurement

--- a/src/c++/perf_analyzer/inference_profiler.h
+++ b/src/c++/perf_analyzer/inference_profiler.h
@@ -530,7 +530,7 @@ class InferenceProfiler {
   /// Clamp a window around a set of requests, from the earliest start time to
   /// the latest response
   /// \param requests A vector of requests to clamp the window around.
-  /// \return std::pair object containing <start, end> of the window
+  /// \return std::pair object containing <start, end> of the window.
   std::pair<uint64_t, uint64_t> ClampWindow(
       std::vector<RequestRecord>& requests);
 


### PR DESCRIPTION
When the request-count feature is used, the "measurement window" should be considered to be from the start of the first request to the final response of all requests.

Note that GenAI-Perf ignores windows and was already effectively doing this. There was a mismatch in what PA reported and what GAP reported. This PR fixes the PA reporting (which is important if the feature is used for standalone PA)

Before the fix, you can see that there were 20 requests in the 1-second window, so it claimed a throughput of 20/s. However, those all finished well before the 1 second was up, and the real throughput was more than double.

Before:
![without-clamped-windows](https://github.com/triton-inference-server/client/assets/50968584/693af562-dec4-4e10-89d7-ef3a6e8a5b93)

After:
![with-clamped-window](https://github.com/triton-inference-server/client/assets/50968584/6e5586c9-2d86-4992-b755-8b6d4cba7165)

This case where the whole test is less than 1 second is obviously an extreme case, but it helps highlight the problem.