### PR TITLE
fix: Get validation outputs by name rather than index

### DIFF
--- a/src/c++/perf_analyzer/data_loader.cc
+++ b/src/c++/perf_analyzer/data_loader.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -378,6 +378,7 @@ DataLoader::GetOutputData(
   data.data_ptr = nullptr;
   data.batch1_size = 0;
   data.is_valid = false;
+  data.name = "";
 
   // If json data is available then try to retrieve the data from there
   if (!output_data_.empty()) {
@@ -393,6 +394,7 @@ DataLoader::GetOutputData(
       data.is_valid = true;
       data.batch1_size = data_vec->size();
       data.data_ptr = (const uint8_t*)data_vec->data();
+      data.name = output_name;
     }
   }
   return cb::Error::Success;

--- a/src/c++/perf_analyzer/infer_context.cc
+++ b/src/c++/perf_analyzer/infer_context.cc
@@ -260,11 +260,13 @@ InferContext::ValidateOutputs(const cb::InferResult* result_ptr)
 {
   // Validate output if set
   if (!infer_data_.expected_outputs_.empty()) {
-    for (size_t i = 0; i < infer_data_.outputs_.size(); ++i) {
+    for (size_t i = 0; i < infer_data_.expected_outputs_.size(); ++i) {
       const uint8_t* buf = nullptr;
       size_t byte_size = 0;
-      result_ptr->RawData(infer_data_.outputs_[i]->Name(), &buf, &byte_size);
       for (const auto& expected : infer_data_.expected_outputs_[i]) {
+        // Request output by validation output's name explicitly, rather than
+        // relying on the array indices being sorted equally in both arrays.
+        result_ptr->RawData(expected.name, &buf, &byte_size);
         if (!expected.is_valid) {
           return cb::Error(
               "Expected output can't be invalid", pa::GENERIC_ERROR);

--- a/src/c++/perf_analyzer/tensor_data.h
+++ b/src/c++/perf_analyzer/tensor_data.h
@@ -1,4 +1,4 @@
-// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@ struct TensorData {
   const uint8_t* data_ptr{nullptr};
   size_t batch1_size{0};
   bool is_valid{false};
+  std::string name;
 };
 
 


### PR DESCRIPTION
We were seeing L0_long_running_stress test failing due to an output doesn't match to the expected output. 
```
Successfully read data for 1 stream/streams with 3 step/steps.
...
Inferences/Second vs. Client Average Batch Latency
Concurrency: 2, throughput: 3138.92 infer/sec, latency 600 usec
Thread [1] had error: Output doesn't match expected output
```

It seems like it's because the order of  `infer_data_.outputs_` and `infer_data_.expected_outputs_` might be different, so we need to make sure that we are comparing the correct validation output based on the same output name. Shout out to @rmccorm4 who quickly came up with the solution! This PR is based on https://github.com/triton-inference-server/client/pull/685