### PR TITLE
Allow multiple prompts to be supplied via --input-file to GenAI-Perf

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/README.md
+++ b/src/c++/perf_analyzer/genai-perf/README.md
@@ -407,7 +407,8 @@ The HuggingFace dataset to use for prompts.
 
 ##### `--input-file <path>`
 
-The input file containing the single prompt to use for profiling.
+The input file containing the prompts to use for profiling.
+Each prompt should be on a new line.
 
 ##### `--num-prompts <int>`
 

--- a/src/c++/perf_analyzer/genai-perf/README.md
+++ b/src/c++/perf_analyzer/genai-perf/README.md
@@ -408,7 +408,8 @@ The HuggingFace dataset to use for prompts.
 ##### `--input-file <path>`
 
 The input file containing the prompts to use for profiling.
-Each prompt should be on a new line.
+Each line should be a JSON object with a 'text_input' field in JSONL format.
+Example: {\"text_input\": \"Your prompt here\"}"
 
 ##### `--num-prompts <int>`
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -332,6 +332,19 @@ class LlmInputs:
 
     @classmethod
     def _get_input_dataset_from_file(cls, input_filename: Path) -> Dict:
+        """
+        Reads the input prompts from a JSONL file and converts them into the required dataset format.
+
+        Parameters
+        ----------
+        input_filename : Path
+            The path to the input file containing the prompts in JSONL format.
+
+        Returns
+        -------
+        Dict
+            The dataset in the required format with the prompts read from the file.
+        """
         cls.verify_file(input_filename)
         input_file_prompts = cls._get_prompts_from_input_file(input_filename)
         dataset_json: Dict[str, Any] = {}
@@ -342,15 +355,31 @@ class LlmInputs:
         return dataset_json
 
     @classmethod
+    def _get_prompts_from_input_file(cls, input_filename: Path) -> List[str]:
+        """
+        Reads the input prompts from a JSONL file and returns a list of prompts.
+
+        Parameters
+        ----------
+        input_filename : Path
+            The path to the input file containing the prompts in JSONL format.
+
+        Returns
+        -------
+        List[str]
+            A list of prompts read from the file.
+        """
+        with open(input_filename, mode="r", newline=None) as file:
+            return [
+                json.loads(line).get("text_input", "").strip()
+                for line in file
+                if line.strip()
+            ]
+
+    @classmethod
     def verify_file(cls, input_filename: Path) -> None:
         if not input_filename.exists():
             raise FileNotFoundError(f"The file '{input_filename}' does not exist.")
-
-    @classmethod
-    def _get_prompts_from_input_file(cls, input_filename: Path) -> List[str]:
-        with open(input_filename, mode="r", newline=None) as file:
-            content = file.read()
-        return [prompt.strip() for prompt in content.split("\n") if prompt.strip()]
 
     @classmethod
     def _convert_generic_json_to_output_format(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -369,12 +369,12 @@ class LlmInputs:
         List[str]
             A list of prompts read from the file.
         """
+        prompts = []
         with open(input_filename, mode="r", newline=None) as file:
-            return [
-                json.loads(line).get("text_input", "").strip()
-                for line in file
-                if line.strip()
-            ]
+            for line in file:
+                if line.strip():
+                    prompts.append(json.loads(line).get("text_input", "").strip())
+        return prompts
 
     @classmethod
     def verify_file(cls, input_filename: Path) -> None:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -333,11 +333,12 @@ class LlmInputs:
     @classmethod
     def _get_input_dataset_from_file(cls, input_filename: Path) -> Dict:
         cls.verify_file(input_filename)
-        input_file_prompt = cls._get_prompt_from_input_file(input_filename)
+        input_file_prompts = cls._get_prompts_from_input_file(input_filename)
         dataset_json: Dict[str, Any] = {}
         dataset_json["features"] = [{"name": "text_input"}]
-        dataset_json["rows"] = []
-        dataset_json["rows"].append({"row": {"text_input": input_file_prompt}})
+        dataset_json["rows"] = [
+            {"row": {"text_input": prompt}} for prompt in input_file_prompts
+        ]
         return dataset_json
 
     @classmethod
@@ -346,9 +347,10 @@ class LlmInputs:
             raise FileNotFoundError(f"The file '{input_filename}' does not exist.")
 
     @classmethod
-    def _get_prompt_from_input_file(cls, input_filename: Path) -> str:
+    def _get_prompts_from_input_file(cls, input_filename: Path) -> List[str]:
         with open(input_filename, mode="r", newline=None) as file:
-            return file.read()
+            content = file.read()
+        return [prompt.strip() for prompt in content.split("\n") if prompt.strip()]
 
     @classmethod
     def _convert_generic_json_to_output_format(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -247,7 +247,8 @@ def _add_input_args(parser):
         type=argparse.FileType("r"),
         default=None,
         required=False,
-        help="The input file containing the single prompt to use for profiling.",
+        help="The input file containing the prompts to use for profiling. "
+        "Each prompt should be on a new line.",
     )
 
     input_group.add_argument(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -248,7 +248,8 @@ def _add_input_args(parser):
         default=None,
         required=False,
         help="The input file containing the prompts to use for profiling. "
-        "Each prompt should be on a new line.",
+        "Each line should be a JSON object with a 'text_input' field in JSONL format. "
+        'Example: {"text_input": "Your prompt here"}',
     )
 
     input_group.add_argument(

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -658,9 +658,13 @@ class TestLlmInputs:
             LlmInputs._get_input_dataset_from_file(Path("prompt.txt"))
 
     @patch("pathlib.Path.exists", return_value=True)
-    @patch("builtins.open", new_callable=mock_open, read_data="prompt1")
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{"text_input": "single prompt"}\n',
+    )
     def test_get_input_file_with_single_prompt(self, mock_file, mock_exists):
-        expected_prompts = ["prompt1"]
+        expected_prompts = ["single prompt"]
         dataset = LlmInputs._get_input_dataset_from_file(Path("prompt.txt"))
 
         assert dataset is not None
@@ -670,7 +674,9 @@ class TestLlmInputs:
 
     @patch("pathlib.Path.exists", return_value=True)
     @patch(
-        "builtins.open", new_callable=mock_open, read_data="prompt1\nprompt2\nprompt3"
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{"text_input": "prompt1"}\n{"text_input": "prompt2"}\n{"text_input": "prompt3"}\n',
     )
     def test_get_input_file_with_multiple_prompts(self, mock_file, mock_exists):
         expected_prompts = ["prompt1", "prompt2", "prompt3"]


### PR DESCRIPTION
Allow multiple prompts to be passed in via --input-file as a JSONL file. Each one should be on a separate JSON object (on a new line) with the field "text_input".