### PR TITLE
Remove ITL from console when non-streaming

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/console_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/console_exporter.py
@@ -84,7 +84,7 @@ class ConsoleExporter:
 
             # Without streaming, there is no inter-token latency available, so do not print it.
             if metric == "inter_token_latency":
-                if all(value == "-1" for value in row_values[1:]):
+                if all(float(value) < 0 for value in row_values[1:]):
                     continue
             # Without streaming, TTFT and request latency are the same, so do not print TTFT.
             elif metric == "time_to_first_token":


### PR DESCRIPTION
Before:
<img width="754" alt="image" src="https://github.com/triton-inference-server/client/assets/107147848/9d2fbace-c607-4d5e-9a0b-198357760df3">

After:
<img width="734" alt="image" src="https://github.com/triton-inference-server/client/assets/107147848/f19c9427-55d6-4e45-8cc9-670a4891a198">
