### PR TITLE
Support embedding metrics and output export

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/console_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/console_exporter.py
@@ -85,7 +85,7 @@ class ConsoleExporter:
             table.add_row(*row_values)
 
     def _should_skip(self, metric_name: str) -> bool:
-        if self._args.endpoint_type in ["embeddings", "ranking"]:
+        if self._args.endpoint_type == "embeddings":
             return False  # skip nothing
 
         # TODO (TMA-1712): need to decide if we need this metric. Remove

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/console_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/console_exporter.py
@@ -25,10 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from typing import List
-
 from genai_perf.export_data.exporter_config import ExporterConfig
-from genai_perf.metrics import Metrics
 from rich.console import Console
 from rich.table import Table
 
@@ -38,7 +35,7 @@ class ConsoleExporter:
     A class to export the statistics and arg values to the console.
     """
 
-    STAT_COLUMNS = ["avg", "min", "max", "p99", "p90", "p75"]
+    STAT_COLUMN_KEYS = ["avg", "min", "max", "p99", "p90", "p75"]
 
     def __init__(self, config: ExporterConfig):
         self._stats = config.stats
@@ -47,14 +44,14 @@ class ConsoleExporter:
 
     def _get_title(self):
         if self._args.endpoint_type == "embeddings":
-            return "Embedding Metrics"
+            return "Embeddings Metrics"
         return "LLM Metrics"
 
     def export(self) -> None:
         table = Table(title=self._get_title())
 
         table.add_column("Statistic", justify="right", style="cyan", no_wrap=True)
-        for stat in self.STAT_COLUMNS:
+        for stat in self.STAT_COLUMN_KEYS:
             table.add_column(stat, justify="right", style="green")
 
         # Request metrics table
@@ -78,12 +75,13 @@ class ConsoleExporter:
             metric_str = metric.name.replace("_", " ").capitalize()
             metric_str += f" ({metric.unit})" if metric.unit != "tokens" else ""
             row_values = [metric_str]
-            for stat in self.STAT_COLUMNS:
+            for stat in self.STAT_COLUMN_KEYS:
                 value = self._stats[metric.name][stat]
                 row_values.append(f"{value:,.2f}")
 
             table.add_row(*row_values)
 
+    # (TMA-1976) Refactor this method as the csv exporter shares identical method.
     def _should_skip(self, metric_name: str) -> bool:
         if self._args.endpoint_type == "embeddings":
             return False  # skip nothing

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/csv_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/csv_exporter.py
@@ -99,7 +99,7 @@ class CsvExporter:
             csv_writer.writerow([metric_str, f"{value:.2f}"])
 
     def _should_skip(self, metric_name: str) -> bool:
-        if self._args.endpoint_type in ["embeddings", "ranking"]:
+        if self._args.endpoint_type == "embeddings":
             return False  # skip nothing
 
         # TODO (TMA-1712): need to decide if we need this metric. Remove

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/csv_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/csv_exporter.py
@@ -43,6 +43,7 @@ class CsvExporter:
 
     def __init__(self, config: ExporterConfig):
         self._stats = config.stats
+        self._metrics = config.metrics
         self._output_dir = config.artifact_dir
 
     def export(self) -> None:
@@ -73,7 +74,7 @@ class CsvExporter:
             csv_writer = csv.writer(csvfile)
             csv_writer.writerow(multiple_metric_header)
 
-            for metric in Metrics.metric_labels:
+            for metric in self._metrics.names:
                 formatted_metric = metric.replace("_", " ").title()
 
                 is_throughput_field = metric in Metrics.throughput_fields

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/csv_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/csv_exporter.py
@@ -29,7 +29,6 @@ import csv
 
 import genai_perf.logging as logging
 from genai_perf.export_data.exporter_config import ExporterConfig
-from genai_perf.metrics import Metrics
 
 DEFAULT_OUTPUT_DATA_CSV = "profile_export_genai_perf.csv"
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/csv_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/csv_exporter.py
@@ -41,98 +41,81 @@ class CsvExporter:
     A class to export the statistics and arg values in a csv format.
     """
 
+    REQUEST_METRICS_HEADER = [
+        "Metric",
+        "avg",
+        "min",
+        "max",
+        "p99",
+        "p95",
+        "p90",
+        "p75",
+        "p50",
+        "p25",
+    ]
+
+    SYSTEM_METRICS_HEADER = [
+        "Metric",
+        "Value",
+    ]
+
     def __init__(self, config: ExporterConfig):
         self._stats = config.stats
         self._metrics = config.metrics
         self._output_dir = config.artifact_dir
+        self._args = config.args
 
     def export(self) -> None:
         csv_filename = self._output_dir / DEFAULT_OUTPUT_DATA_CSV
         logger.info(f"Generating {csv_filename}")
 
-        multiple_metric_header = [
-            "Metric",
-            "avg",
-            "min",
-            "max",
-            "p99",
-            "p95",
-            "p90",
-            "p75",
-            "p50",
-            "p25",
-        ]
-
-        single_metric_header = [
-            "Metric",
-            "Value",
-        ]
-
         with open(csv_filename, mode="w", newline="") as csvfile:
-            singular_metric_rows = []
-
             csv_writer = csv.writer(csvfile)
-            csv_writer.writerow(multiple_metric_header)
-
-            for metric in self._metrics.names:
-                formatted_metric = metric.replace("_", " ").title()
-
-                is_throughput_field = metric in Metrics.throughput_fields
-                is_time_field = metric in Metrics.time_fields
-
-                if is_time_field:
-                    formatted_metric += " (ms)"
-                elif is_throughput_field:
-                    formatted_metric += " (per sec)"
-                # TODO (TMA-1712): need to decide if we need this metric. Do not
-                # include in the csv for now.
-                # TODO (TMA-1678): output_token_throughput_per_request is treated
-                # separately since the current code treats all throughput metrics
-                # to be displayed outside of the statistics table.
-                elif metric == "output_token_throughput_per_request":
-                    formatted_metric += " (per sec)"
-                    continue
-
-                row_values = [formatted_metric]
-
-                if is_throughput_field:
-                    value = self._stats.get(f"{metric}", -1).get(
-                        multiple_metric_header[1], -1
-                    )
-                    row_values.append(f"{value:.2f}")
-                    singular_metric_rows.append(row_values)
-                    continue
-
-                for stat in multiple_metric_header[1:]:
-                    value = self._stats.get(f"{metric}", -1)
-                    # Need to check for -1 for the non streaming case
-                    if value == -1:
-                        row_values.append(f"{value:,.2f}")
-                    else:
-                        value = value.get(stat, -1)
-                        row_values.append(f"{value:,.2f}")
-
-                # Without streaming, there is no inter-token latency available, so do not print it.
-                if metric == "inter_token_latency":
-                    if all(value == "-1" for value in row_values[1:]):
-                        continue
-                # Without streaming, TTFT and request latency are the same, so do not print TTFT.
-                elif metric == "time_to_first_token":
-                    unique_values = False
-                    for stat in multiple_metric_header[1:]:
-                        value_ttft = self._stats.get(f"{metric}", -1).get(stat, -1)
-                        value_req_latency = self._stats.get("request_latency", -1).get(
-                            stat, -1
-                        )
-                        if value_ttft != value_req_latency:
-                            unique_values = True
-                            break
-                    if not unique_values:
-                        continue
-
-                csv_writer.writerow(row_values)
-
+            self._write_request_metrics(csv_writer)
             csv_writer.writerow([])
-            csv_writer.writerow(single_metric_header)
-            for row in singular_metric_rows:
-                csv_writer.writerow(row)
+            self._write_system_metrics(csv_writer)
+
+    def _write_request_metrics(self, csv_writer) -> None:
+        csv_writer.writerow(self.REQUEST_METRICS_HEADER)
+        for metric, unit in self._metrics.request_metric_names:
+            if self._should_skip(metric):
+                continue
+
+            formatted_metric = metric.replace("_", " ").title()
+            formatted_metric += f" ({unit})" if unit != "tokens" else ""
+
+            row_values = [formatted_metric]
+            for stat in self.REQUEST_METRICS_HEADER[1:]:
+                value = self._stats[metric][stat]
+                row_values.append(f"{value:,.2f}")
+
+            csv_writer.writerow(row_values)
+
+    def _write_system_metrics(self, csv_writer) -> None:
+        csv_writer.writerow(self.SYSTEM_METRICS_HEADER)
+        for metric, unit in self._metrics.system_metric_names:
+            formatted_metric = metric.replace("_", " ").title()
+            formatted_metric += f" ({unit})"
+            value = self._stats[metric]["avg"]
+            csv_writer.writerow([formatted_metric, f"{value:.2f}"])
+
+    def _should_skip(self, metric: str) -> bool:
+        if self._args.endpoint_type in ["embeddings", "ranking"]:
+            return False  # skip nothing
+
+        # TODO (TMA-1712): need to decide if we need this metric. Remove
+        # from statistics display for now.
+        # TODO (TMA-1678): output_token_throughput_per_request is treated
+        # separately since the current code treats all throughput metrics to
+        # be displayed outside of the statistics table.
+        if metric == "output_token_throughput_per_request":
+            return True
+
+        # When non-streaming, skip ITL and TTFT
+        streaming_metrics = [
+            "inter_token_latency",
+            "time_to_first_token",
+        ]
+        if not self._args.streaming and metric in streaming_metrics:
+            return True
+        return False

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/exporter_config.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/exporter_config.py
@@ -25,9 +25,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+from genai_perf.metrics import Metrics
+
+
 class ExporterConfig:
     def __init__(self):
         self._stats = None
+        self._metrics = None
         self._args = None
         self._extra_inputs = None
         self._artifact_dir = None
@@ -39,6 +43,14 @@ class ExporterConfig:
     @stats.setter
     def stats(self, stats_value):
         self._stats = stats_value
+
+    @property
+    def metrics(self):
+        return self._metrics
+
+    @metrics.setter
+    def metrics(self, metrics: Metrics):
+        self._metrics = metrics
 
     @property
     def args(self):

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/json_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/json_exporter.py
@@ -58,8 +58,8 @@ class JsonExporter:
             f.write(json.dumps(self._stats_and_args, indent=2))
 
     def _prepare_args_for_export(self) -> None:
-        del self._args["func"]
-        del self._args["output_format"]
+        self._args.pop("func", None)
+        self._args.pop("output_format", None)
         self._args["profile_export_file"] = str(self._args["profile_export_file"])
         self._args["artifact_dir"] = str(self._args["artifact_dir"])
         for k, v in self._args.items():

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/json_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/json_exporter.py
@@ -60,6 +60,7 @@ class JsonExporter:
     def _prepare_args_for_export(self) -> None:
         self._args.pop("func", None)
         self._args.pop("output_format", None)
+        self._args.pop("input_file", None)
         self._args["profile_export_file"] = str(self._args["profile_export_file"])
         self._args["artifact_dir"] = str(self._args["artifact_dir"])
         for k, v in self._args.items():

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/output_reporter.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/export_data/output_reporter.py
@@ -54,6 +54,7 @@ class OutputReporter:
     def _create_exporter_config(self) -> ExporterConfig:
         config = ExporterConfig()
         config.stats = self.stats.stats_dict
+        config.metrics = self.stats.metrics
         config.args = self.args
         config.artifact_dir = self.args.artifact_dir
         config.extra_inputs = get_extra_inputs_as_dict(self.args)

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -84,13 +84,16 @@ def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:
 
 
 def calculate_metrics(args: Namespace, tokenizer: Tokenizer) -> ProfileDataParser:
+    if args.endpoint_type == "embeddings":
+        return ProfileDataParser(args.profile_export_file)
+
     return LLMProfileDataParser(
         filename=args.profile_export_file,
         tokenizer=tokenizer,
     )
 
 
-def report_output(data_parser: LLMProfileDataParser, args: Namespace) -> None:
+def report_output(data_parser: ProfileDataParser, args: Namespace) -> None:
     if args.concurrency:
         infer_mode = "concurrency"
         load_level = f"{args.concurrency}"

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -86,11 +86,11 @@ def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:
 def calculate_metrics(args: Namespace, tokenizer: Tokenizer) -> ProfileDataParser:
     if args.endpoint_type == "embeddings":
         return ProfileDataParser(args.profile_export_file)
-
-    return LLMProfileDataParser(
-        filename=args.profile_export_file,
-        tokenizer=tokenizer,
-    )
+    else:
+        return LLMProfileDataParser(
+            filename=args.profile_export_file,
+            tokenizer=tokenizer,
+        )
 
 
 def report_output(data_parser: ProfileDataParser, args: Namespace) -> None:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/__init__.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/__init__.py
@@ -25,5 +25,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from genai_perf.metrics.llm_metrics import LLMMetrics
-from genai_perf.metrics.metrics import Metric, Metrics, ResponseFormat
+from genai_perf.metrics.metrics import MetricMetadata, Metrics, ResponseFormat
 from genai_perf.metrics.statistics import Statistics

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/llm_metrics.py
@@ -26,24 +26,24 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import List, Tuple
+from typing import List
 
-from genai_perf.metrics.metrics import Metrics
+from genai_perf.metrics.metrics import Metric, Metrics
 
 
 class LLMMetrics(Metrics):
     """A simple dataclass that holds core LLM performance metrics."""
 
     LLM_REQUEST_METRICS = [
-        ("time_to_first_token", "ms"),
-        ("inter_token_latency", "ms"),
-        ("output_token_throughput_per_request", "tokens/sec"),
-        ("output_sequence_length", "tokens"),
-        ("input_sequence_length", "tokens"),
+        Metric("time_to_first_token", "ms"),
+        Metric("inter_token_latency", "ms"),
+        Metric("output_token_throughput_per_request", "tokens/sec"),
+        Metric("output_sequence_length", "tokens"),
+        Metric("input_sequence_length", "tokens"),
     ]
 
     LLM_SYSTEM_METRICS = [
-        ("output_token_throughput", "tokens/sec"),
+        Metric("output_token_throughput", "tokens/sec"),
     ]
 
     def __init__(
@@ -81,15 +81,11 @@ class LLMMetrics(Metrics):
         self._base_names["input_sequence_lengths"] = "input_sequence_length"
 
     @property
-    def metric_names(self) -> List[Tuple[str, str]]:
-        return self.request_metric_names + self.system_metric_names
-
-    @property
-    def request_metric_names(self) -> List[Tuple[str, str]]:
-        base_metrics = super().request_metric_names  # base Metrics
+    def request_metrics(self) -> List[Metric]:
+        base_metrics = super().request_metrics  # base metrics
         return base_metrics + self.LLM_REQUEST_METRICS
 
     @property
-    def system_metric_names(self) -> List[Tuple[str, str]]:
-        base_metrics = super().system_metric_names  # base Metrics
+    def system_metrics(self) -> List[Metric]:
+        base_metrics = super().system_metrics  # base metrics
         return base_metrics + self.LLM_SYSTEM_METRICS

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/llm_metrics.py
@@ -43,7 +43,8 @@ class LLMMetrics(Metrics):
     ]
 
     LLM_SYSTEM_METRICS = [
-        Metric("output_token_throughput", "tokens/sec"),
+        # (TMA-1977) Make the unit consistent with statistics dict (e.g. tokens/sec)
+        Metric("output_token_throughput", "per sec"),
     ]
 
     def __init__(
@@ -83,9 +84,25 @@ class LLMMetrics(Metrics):
     @property
     def request_metrics(self) -> List[Metric]:
         base_metrics = super().request_metrics  # base metrics
-        return base_metrics + self.LLM_REQUEST_METRICS
+
+        # (TMA-1975) The order is hardcoded as below to avoid introducing any
+        # breaking changes to the users who might be parsing the outputs. However,
+        # we would eventually want to impose some consistent order such as a
+        # base metrics first and then task specific metrics. Uncomment the below
+        # line to enable this order:
+        # return base_metrics + self.LLM_REQUEST_METRICS
+        return (
+            self.LLM_REQUEST_METRICS[:2] + base_metrics + self.LLM_REQUEST_METRICS[2:]
+        )
 
     @property
     def system_metrics(self) -> List[Metric]:
         base_metrics = super().system_metrics  # base metrics
-        return base_metrics + self.LLM_SYSTEM_METRICS
+
+        # (TMA-1975) The order is hardcoded as below to avoid introducing any
+        # breaking changes to the users who might be parsing the outputs. However,
+        # we would eventually want to impose some consistent order such as a
+        # base metrics first and then task specific metrics. Uncomment the below
+        # line to enable this order:
+        # return base_metrics + self.LLM_SYSTEM_METRICS
+        return self.LLM_SYSTEM_METRICS + base_metrics

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/llm_metrics.py
@@ -28,23 +28,23 @@
 
 from typing import List
 
-from genai_perf.metrics.metrics import Metric, Metrics
+from genai_perf.metrics.metrics import MetricMetadata, Metrics
 
 
 class LLMMetrics(Metrics):
     """A simple dataclass that holds core LLM performance metrics."""
 
     LLM_REQUEST_METRICS = [
-        Metric("time_to_first_token", "ms"),
-        Metric("inter_token_latency", "ms"),
-        Metric("output_token_throughput_per_request", "tokens/sec"),
-        Metric("output_sequence_length", "tokens"),
-        Metric("input_sequence_length", "tokens"),
+        MetricMetadata("time_to_first_token", "ms"),
+        MetricMetadata("inter_token_latency", "ms"),
+        MetricMetadata("output_token_throughput_per_request", "tokens/sec"),
+        MetricMetadata("output_sequence_length", "tokens"),
+        MetricMetadata("input_sequence_length", "tokens"),
     ]
 
     LLM_SYSTEM_METRICS = [
         # (TMA-1977) Make the unit consistent with statistics dict (e.g. tokens/sec)
-        Metric("output_token_throughput", "per sec"),
+        MetricMetadata("output_token_throughput", "per sec"),
     ]
 
     def __init__(
@@ -82,7 +82,7 @@ class LLMMetrics(Metrics):
         self._base_names["input_sequence_lengths"] = "input_sequence_length"
 
     @property
-    def request_metrics(self) -> List[Metric]:
+    def request_metrics(self) -> List[MetricMetadata]:
         base_metrics = super().request_metrics  # base metrics
 
         # (TMA-1975) The order is hardcoded as below to avoid introducing any
@@ -96,7 +96,7 @@ class LLMMetrics(Metrics):
         )
 
     @property
-    def system_metrics(self) -> List[Metric]:
+    def system_metrics(self) -> List[MetricMetadata]:
         base_metrics = super().system_metrics  # base metrics
 
         # (TMA-1975) The order is hardcoded as below to avoid introducing any

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/llm_metrics.py
@@ -34,6 +34,29 @@ from genai_perf.metrics.metrics import Metrics
 class LLMMetrics(Metrics):
     """A simple dataclass that holds core LLM performance metrics."""
 
+    _LLM_METRICS = [
+        "time_to_first_token",
+        "inter_token_latency",
+        "output_token_throughput",
+        "output_token_throughput_per_request",
+        "output_sequence_length",
+        "input_sequence_length",
+    ]
+
+    time_fields = [
+        "inter_token_latency",
+        "time_to_first_token",
+        "request_latency",
+    ]
+
+    # TODO (TMA-1678): output_token_throughput_per_request is not on this list
+    # since the current code treats all the throughput metrics to be displayed
+    # outside of the statistics table.
+    throughput_fields = [
+        "request_throughput",
+        "output_token_throughput",
+    ]
+
     def __init__(
         self,
         request_throughputs: List[float] = [],
@@ -67,3 +90,8 @@ class LLMMetrics(Metrics):
         )
         self._base_names["output_sequence_lengths"] = "output_sequence_length"
         self._base_names["input_sequence_lengths"] = "input_sequence_length"
+
+    @property
+    def names(self) -> List[str]:
+        base_metrics = super().names  # get Metrics metric names
+        return base_metrics + self._LLM_METRICS

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/llm_metrics.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import List
+from typing import List, Tuple
 
 from genai_perf.metrics.metrics import Metrics
 
@@ -34,27 +34,16 @@ from genai_perf.metrics.metrics import Metrics
 class LLMMetrics(Metrics):
     """A simple dataclass that holds core LLM performance metrics."""
 
-    _LLM_METRICS = [
-        "time_to_first_token",
-        "inter_token_latency",
-        "output_token_throughput",
-        "output_token_throughput_per_request",
-        "output_sequence_length",
-        "input_sequence_length",
+    LLM_REQUEST_METRICS = [
+        ("time_to_first_token", "ms"),
+        ("inter_token_latency", "ms"),
+        ("output_token_throughput_per_request", "tokens/sec"),
+        ("output_sequence_length", "tokens"),
+        ("input_sequence_length", "tokens"),
     ]
 
-    time_fields = [
-        "inter_token_latency",
-        "time_to_first_token",
-        "request_latency",
-    ]
-
-    # TODO (TMA-1678): output_token_throughput_per_request is not on this list
-    # since the current code treats all the throughput metrics to be displayed
-    # outside of the statistics table.
-    throughput_fields = [
-        "request_throughput",
-        "output_token_throughput",
+    LLM_SYSTEM_METRICS = [
+        ("output_token_throughput", "tokens/sec"),
     ]
 
     def __init__(
@@ -92,6 +81,15 @@ class LLMMetrics(Metrics):
         self._base_names["input_sequence_lengths"] = "input_sequence_length"
 
     @property
-    def names(self) -> List[str]:
-        base_metrics = super().names  # get Metrics metric names
-        return base_metrics + self._LLM_METRICS
+    def metric_names(self) -> List[Tuple[str, str]]:
+        return self.request_metric_names + self.system_metric_names
+
+    @property
+    def request_metric_names(self) -> List[Tuple[str, str]]:
+        base_metrics = super().request_metric_names  # base Metrics
+        return base_metrics + self.LLM_REQUEST_METRICS
+
+    @property
+    def system_metric_names(self) -> List[Tuple[str, str]]:
+        base_metrics = super().system_metric_names  # base Metrics
+        return base_metrics + self.LLM_SYSTEM_METRICS

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/metrics.py
@@ -52,7 +52,8 @@ class Metrics:
     ]
 
     SYSTEM_METRICS = [
-        Metric("request_throughput", "requests/sec"),
+        # (TMA-1977) Make the unit consistent with statistics dict (e.g. tokens/sec)
+        Metric("request_throughput", "per sec"),
     ]
 
     def __init__(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/metrics.py
@@ -33,21 +33,16 @@ from typing import List
 class ResponseFormat(Enum):
     OPENAI_CHAT_COMPLETIONS = auto()
     OPENAI_COMPLETIONS = auto()
+    OPENAI_EMBEDDINGS = auto()
     TRITON = auto()
 
 
 class Metrics:
     """A base class for all the metrics class that contains common metrics."""
 
-    metric_labels = [
-        "time_to_first_token",
-        "inter_token_latency",
+    _METRICS = [
         "request_latency",
-        "output_token_throughput",
-        "output_token_throughput_per_request",
         "request_throughput",
-        "output_sequence_length",
-        "input_sequence_length",
     ]
 
     time_fields = [
@@ -82,6 +77,10 @@ class Metrics:
             if not k.startswith("_"):
                 attr_strs.append(f"{k}={v}")
         return f"Metrics({','.join(attr_strs)})"
+
+    @property
+    def names(self) -> List[str]:
+        return self._METRICS
 
     @property
     def data(self) -> dict:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/metrics.py
@@ -26,8 +26,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from dataclasses import dataclass
 from enum import Enum, auto
-from typing import List, Tuple
+from typing import List
 
 
 class ResponseFormat(Enum):
@@ -37,15 +38,21 @@ class ResponseFormat(Enum):
     TRITON = auto()
 
 
+@dataclass
+class Metric:
+    name: str
+    unit: str
+
+
 class Metrics:
     """A base class for all the metrics class that contains common metrics."""
 
     REQUEST_METRICS = [
-        ("request_latency", "ms"),
+        Metric("request_latency", "ms"),
     ]
 
     SYSTEM_METRICS = [
-        ("request_throughput", "requests/sec"),
+        Metric("request_throughput", "requests/sec"),
     ]
 
     def __init__(
@@ -68,15 +75,11 @@ class Metrics:
         return f"Metrics({','.join(attr_strs)})"
 
     @property
-    def metric_names(self) -> List[Tuple[str, str]]:
-        return self.request_metric_names + self.system_metric_names
-
-    @property
-    def request_metric_names(self) -> List[Tuple[str, str]]:
+    def request_metrics(self) -> List[Metric]:
         return self.REQUEST_METRICS
 
     @property
-    def system_metric_names(self) -> List[Tuple[str, str]]:
+    def system_metrics(self) -> List[Metric]:
         return self.SYSTEM_METRICS
 
     @property

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/metrics.py
@@ -27,7 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from enum import Enum, auto
-from typing import List
+from typing import List, Tuple
 
 
 class ResponseFormat(Enum):
@@ -40,23 +40,12 @@ class ResponseFormat(Enum):
 class Metrics:
     """A base class for all the metrics class that contains common metrics."""
 
-    _METRICS = [
-        "request_latency",
-        "request_throughput",
+    REQUEST_METRICS = [
+        ("request_latency", "ms"),
     ]
 
-    time_fields = [
-        "inter_token_latency",
-        "time_to_first_token",
-        "request_latency",
-    ]
-
-    # TODO (TMA-1678): output_token_throughput_per_request is not on this list
-    # since the current code treats all the throughput metrics to be displayed
-    # outside of the statistics table.
-    throughput_fields = [
-        "request_throughput",
-        "output_token_throughput",
+    SYSTEM_METRICS = [
+        ("request_throughput", "requests/sec"),
     ]
 
     def __init__(
@@ -79,8 +68,16 @@ class Metrics:
         return f"Metrics({','.join(attr_strs)})"
 
     @property
-    def names(self) -> List[str]:
-        return self._METRICS
+    def metric_names(self) -> List[Tuple[str, str]]:
+        return self.request_metric_names + self.system_metric_names
+
+    @property
+    def request_metric_names(self) -> List[Tuple[str, str]]:
+        return self.REQUEST_METRICS
+
+    @property
+    def system_metric_names(self) -> List[Tuple[str, str]]:
+        return self.SYSTEM_METRICS
 
     @property
     def data(self) -> dict:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/metrics.py
@@ -39,21 +39,21 @@ class ResponseFormat(Enum):
 
 
 @dataclass
-class Metric:
+class MetricMetadata:
     name: str
     unit: str
 
 
 class Metrics:
-    """A base class for all the metrics class that contains common metrics."""
+    """A base class that contains common request level metrics."""
 
     REQUEST_METRICS = [
-        Metric("request_latency", "ms"),
+        MetricMetadata("request_latency", "ms"),
     ]
 
     SYSTEM_METRICS = [
         # (TMA-1977) Make the unit consistent with statistics dict (e.g. tokens/sec)
-        Metric("request_throughput", "per sec"),
+        MetricMetadata("request_throughput", "per sec"),
     ]
 
     def __init__(
@@ -76,11 +76,11 @@ class Metrics:
         return f"Metrics({','.join(attr_strs)})"
 
     @property
-    def request_metrics(self) -> List[Metric]:
+    def request_metrics(self) -> List[MetricMetadata]:
         return self.REQUEST_METRICS
 
     @property
-    def system_metrics(self) -> List[Metric]:
+    def system_metrics(self) -> List[MetricMetadata]:
         return self.SYSTEM_METRICS
 
     @property

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/statistics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/statistics.py
@@ -158,8 +158,7 @@ class Statistics:
         return self._stats_dict
 
     def _is_system_metric(self, metrics: Metrics, attr: str) -> bool:
-        system_metrics = [m for m, _ in metrics.system_metric_names]
-        return attr in system_metrics
+        return attr in [m.name for m in metrics.system_metrics]
 
     def _is_time_metric(self, field: str) -> bool:
         # TMA-?: Remove the hardcoded time metrics list

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/statistics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/statistics.py
@@ -161,7 +161,7 @@ class Statistics:
         return attr in [m.name for m in metrics.system_metrics]
 
     def _is_time_metric(self, field: str) -> bool:
-        # TMA-?: Remove the hardcoded time metrics list
+        # TPA-188: Remove the hardcoded time metrics list
         time_metrics = [
             "inter_token_latency",
             "time_to_first_token",

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
@@ -50,6 +50,8 @@ class ProfileDataParser:
                 self._response_format = ResponseFormat.OPENAI_CHAT_COMPLETIONS
             elif data["endpoint"] == "v1/completions":
                 self._response_format = ResponseFormat.OPENAI_COMPLETIONS
+            elif data["endpoint"] == "v1/embeddings":
+                self._response_format = ResponseFormat.OPENAI_EMBEDDINGS
             else:
                 # TPA-66: add PA metadata to handle this case
                 # When endpoint field is either empty or custom endpoint, fall
@@ -60,6 +62,8 @@ class ProfileDataParser:
                     self._response_format = ResponseFormat.OPENAI_CHAT_COMPLETIONS
                 elif "text_completion" in response:
                     self._response_format = ResponseFormat.OPENAI_COMPLETIONS
+                elif "embedding" in response:
+                    self._response_format = ResponseFormat.OPENAI_EMBEDDINGS
                 else:
                     raise RuntimeError("Unknown OpenAI response format.")
 
@@ -84,7 +88,29 @@ class ProfileDataParser:
 
     def _parse_requests(self, requests: dict) -> Metrics:
         """Parse each request in profile data to extract core metrics."""
-        raise NotImplementedError
+        min_req_timestamp, max_res_timestamp = float("inf"), 0
+        request_latencies = []
+
+        for request in requests:
+            req_timestamp = request["timestamp"]
+            res_timestamps = request["response_timestamps"]
+
+            # track entire benchmark duration
+            min_req_timestamp = min(min_req_timestamp, req_timestamp)
+            max_res_timestamp = max(max_res_timestamp, res_timestamps[-1])
+
+            # request latencies
+            req_latency_ns = res_timestamps[-1] - req_timestamp
+            request_latencies.append(req_latency_ns)  # nanosec
+
+        # request throughput
+        benchmark_duration = (max_res_timestamp - min_req_timestamp) / 1e9  # nanosec
+        request_throughputs = [len(requests) / benchmark_duration]
+
+        return Metrics(
+            request_throughputs,
+            request_latencies,
+        )
 
     def get_statistics(self, infer_mode: str, load_level: str) -> Statistics:
         """Return profile statistics if it exists."""

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
@@ -100,11 +100,11 @@ class ProfileDataParser:
             max_res_timestamp = max(max_res_timestamp, res_timestamps[-1])
 
             # request latencies
-            req_latency_ns = res_timestamps[-1] - req_timestamp
-            request_latencies.append(req_latency_ns)  # nanosec
+            req_latency = res_timestamps[-1] - req_timestamp
+            request_latencies.append(req_latency)
 
         # request throughput
-        benchmark_duration = (max_res_timestamp - min_req_timestamp) / 1e9  # nanosec
+        benchmark_duration = (max_res_timestamp - min_req_timestamp) / 1e9  # to seconds
         request_throughputs = [len(requests) / benchmark_duration]
 
         return Metrics(

--- a/src/c++/perf_analyzer/genai-perf/tests/test_console_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_console_exporter.py
@@ -70,14 +70,14 @@ class TestConsoleExporter:
             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓\n"
             "┃                Statistic ┃   avg ┃   min ┃   max ┃   p99 ┃   p90 ┃   p75 ┃\n"
             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩\n"
-            "│     Request latency (ms) │  5.00 │  4.00 │  6.00 │  5.98 │  5.80 │  5.50 │\n"
             "│ Time to first token (ms) │  8.00 │  7.00 │  9.00 │  8.98 │  8.80 │  8.50 │\n"
             "│ Inter token latency (ms) │ 11.00 │ 10.00 │ 12.00 │ 11.98 │ 11.80 │ 11.50 │\n"
+            "│     Request latency (ms) │  5.00 │  4.00 │  6.00 │  5.98 │  5.80 │  5.50 │\n"
             "│   Output sequence length │  2.00 │  1.00 │  3.00 │  2.98 │  2.80 │  2.50 │\n"
             "│    Input sequence length │  6.00 │  5.00 │  7.00 │  6.98 │  6.80 │  6.50 │\n"
             "└──────────────────────────┴───────┴───────┴───────┴───────┴───────┴───────┘\n"
-            "Request throughput (requests/sec): 123.00\n"
-            "Output token throughput (tokens/sec): 456.00\n"
+            "Output token throughput (per sec): 456.00\n"
+            "Request throughput (per sec): 123.00\n"
         )
 
         returned_data = capsys.readouterr().out
@@ -125,8 +125,8 @@ class TestConsoleExporter:
             "│ Output sequence length │ 2.00 │ 1.00 │ 3.00 │ 2.98 │ 2.80 │ 2.50 │\n"
             "│  Input sequence length │ 6.00 │ 5.00 │ 7.00 │ 6.98 │ 6.80 │ 6.50 │\n"
             "└────────────────────────┴──────┴──────┴──────┴──────┴──────┴──────┘\n"
-            "Request throughput (requests/sec): 123.00\n"
-            "Output token throughput (tokens/sec): 456.00\n"
+            "Output token throughput (per sec): 456.00\n"
+            "Request throughput (per sec): 123.00\n"
         )
 
         returned_data = capsys.readouterr().out
@@ -160,13 +160,13 @@ class TestConsoleExporter:
         exporter.export()
 
         expected_content = (
-            "                        Embedding Metrics                         \n"
+            "                        Embeddings Metrics                        \n"
             "┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓\n"
             "┃            Statistic ┃  avg ┃  min ┃  max ┃  p99 ┃  p90 ┃  p75 ┃\n"
             "┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━┩\n"
             "│ Request latency (ms) │ 5.00 │ 4.00 │ 6.00 │ 5.98 │ 5.80 │ 5.50 │\n"
             "└──────────────────────┴──────┴──────┴──────┴──────┴──────┴──────┘\n"
-            "Request throughput (requests/sec): 123.00\n"
+            "Request throughput (per sec): 123.00\n"
         )
 
         returned_data = capsys.readouterr().out

--- a/src/c++/perf_analyzer/genai-perf/tests/test_console_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_console_exporter.py
@@ -24,39 +24,78 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from genai_perf import parser
 from genai_perf.export_data.console_exporter import ConsoleExporter
 from genai_perf.export_data.exporter_config import ExporterConfig
-from genai_perf.metrics import LLMMetrics, Statistics
+from genai_perf.metrics import LLMMetrics, Metrics, Statistics
 
 
 class TestConsoleExporter:
 
-    def test_pretty_print_output(self, capsys) -> None:
+    def test_streaming_llm_output(self, monkeypatch, capsys) -> None:
+        argv = [
+            "genai-perf",
+            "-m",
+            "model_name",
+            "--service-kind",
+            "openai",
+            "--endpoint-type",
+            "chat",
+            "--streaming",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        args, _ = parser.parse_args()
+
+        metrics = LLMMetrics(
+            request_throughputs=[123],
+            request_latencies=[4, 5, 6],
+            time_to_first_tokens=[7, 8, 9],
+            inter_token_latencies=[10, 11, 12],
+            output_token_throughputs=[456],
+            output_sequence_lengths=[1, 2, 3],
+            input_sequence_lengths=[5, 6, 7],
+        )
+        stats = Statistics(metrics=metrics)
+
         config = ExporterConfig()
-        config.stats = stats
+        config.stats = stats.stats_dict
+        config.metrics = stats.metrics
+        config.args = args
+
         exporter = ConsoleExporter(config)
         exporter.export()
 
         expected_content = (
-            "                             LLM Metrics                              \n"
-            "┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓\n"
-            "┃                Statistic ┃  avg ┃  min ┃  max ┃  p99 ┃  p90 ┃  p75 ┃\n"
-            "┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━┩\n"
-            "│ Time to first token (ms) │ 2.00 │ 2.00 │ 3.00 │ 2.99 │ 2.90 │ 2.75 │\n"
-            "│ Inter token latency (ms) │ 0.50 │ 0.00 │ 1.00 │ 0.99 │ 0.90 │ 0.75 │\n"
-            "│     Request latency (ms) │ 3.00 │ 3.00 │ 4.00 │ 3.99 │ 3.90 │ 3.75 │\n"
-            "│   Output sequence length │ 6.50 │ 6.00 │ 7.00 │ 6.99 │ 6.90 │ 6.75 │\n"
-            "│    Input sequence length │ 7.50 │ 7.00 │ 8.00 │ 7.99 │ 7.90 │ 7.75 │\n"
-            "└──────────────────────────┴──────┴──────┴──────┴──────┴──────┴──────┘\n"
-            "Output token throughput (per sec): 123.00\n"
-            "Request throughput (per sec): 456.00\n"
+            "                                LLM Metrics                                 \n"
+            "┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓\n"
+            "┃                Statistic ┃   avg ┃   min ┃   max ┃   p99 ┃   p90 ┃   p75 ┃\n"
+            "┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩\n"
+            "│     Request latency (ms) │  5.00 │  4.00 │  6.00 │  5.98 │  5.80 │  5.50 │\n"
+            "│ Time to first token (ms) │  8.00 │  7.00 │  9.00 │  8.98 │  8.80 │  8.50 │\n"
+            "│ Inter token latency (ms) │ 11.00 │ 10.00 │ 12.00 │ 11.98 │ 11.80 │ 11.50 │\n"
+            "│   Output sequence length │  2.00 │  1.00 │  3.00 │  2.98 │  2.80 │  2.50 │\n"
+            "│    Input sequence length │  6.00 │  5.00 │  7.00 │  6.98 │  6.80 │  6.50 │\n"
+            "└──────────────────────────┴───────┴───────┴───────┴───────┴───────┴───────┘\n"
+            "Request throughput (requests/sec): 123.00\n"
+            "Output token throughput (tokens/sec): 456.00\n"
         )
 
         returned_data = capsys.readouterr().out
-
         assert returned_data == expected_content
 
-    def test_nonstreaming_llm_output(self, capsys) -> None:
+    def test_nonstreaming_llm_output(self, monkeypatch, capsys) -> None:
+        argv = [
+            "genai-perf",
+            "-m",
+            "model_name",
+            "--service-kind",
+            "openai",
+            "--endpoint-type",
+            "chat",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        args, _ = parser.parse_args()
+
         metrics = LLMMetrics(
             request_throughputs=[123],
             request_latencies=[4, 5, 6],
@@ -70,6 +109,9 @@ class TestConsoleExporter:
 
         config = ExporterConfig()
         config.stats = stats.stats_dict
+        config.metrics = stats.metrics
+        config.args = args
+
         exporter = ConsoleExporter(config)
         exporter.export()
 
@@ -83,93 +125,49 @@ class TestConsoleExporter:
             "│ Output sequence length │ 2.00 │ 1.00 │ 3.00 │ 2.98 │ 2.80 │ 2.50 │\n"
             "│  Input sequence length │ 6.00 │ 5.00 │ 7.00 │ 6.98 │ 6.80 │ 6.50 │\n"
             "└────────────────────────┴──────┴──────┴──────┴──────┴──────┴──────┘\n"
-            "Output token throughput (per sec): 456.00\n"
-            "Request throughput (per sec): 123.00\n"
+            "Request throughput (requests/sec): 123.00\n"
+            "Output token throughput (tokens/sec): 456.00\n"
         )
 
         returned_data = capsys.readouterr().out
         assert returned_data == expected_content
 
+    def test_embedding_output(self, monkeypatch, capsys) -> None:
+        argv = [
+            "genai-perf",
+            "-m",
+            "model_name",
+            "--service-kind",
+            "openai",
+            "--endpoint-type",
+            "embeddings",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        args, _ = parser.parse_args()
 
-stats = {
-    "request_throughput": {"unit": "requests/sec", "avg": 456.0},
-    "request_latency": {
-        "unit": "ms",
-        "avg": 3.0,
-        "p99": 3.99,
-        "p95": 3.95,
-        "p90": 3.90,
-        "p75": 3.75,
-        "p50": 3.50,
-        "p25": 3.25,
-        "max": 4.0,
-        "min": 3.0,
-        "std": 3.50,
-    },
-    "time_to_first_token": {
-        "unit": "ms",
-        "avg": 2.0,
-        "p99": 2.99,
-        "p95": 2.95,
-        "p90": 2.90,
-        "p75": 2.75,
-        "p50": 2.50,
-        "p25": 2.25,
-        "max": 3.00,
-        "min": 2.00,
-        "std": 2.50,
-    },
-    "inter_token_latency": {
-        "unit": "ms",
-        "avg": 0.50,
-        "p99": 0.99,
-        "p95": 0.95,
-        "p90": 0.90,
-        "p75": 0.75,
-        "p50": 0.50,
-        "p25": 0.25,
-        "max": 1.00,
-        "min": 0.00,
-        "std": 0.50,
-    },
-    "output_token_throughput": {"unit": "tokens/sec", "avg": 123.0},
-    "output_token_throughput_per_request": {
-        "unit": "tokens/sec",
-        "avg": 300.00,
-        "p99": 300.00,
-        "p95": 300.00,
-        "p90": 300.00,
-        "p75": 300.00,
-        "p50": 300.00,
-        "p25": 300.00,
-        "max": 300.00,
-        "min": 300.00,
-        "std": 300.00,
-    },
-    "output_sequence_length": {
-        "unit": "tokens",
-        "avg": 6.5,
-        "p99": 6.99,
-        "p95": 6.95,
-        "p90": 6.90,
-        "p75": 6.75,
-        "p50": 6.5,
-        "p25": 6.25,
-        "max": 7.0,
-        "min": 6.0,
-        "std": 6.5,
-    },
-    "input_sequence_length": {
-        "unit": "tokens",
-        "avg": 7.5,
-        "p99": 7.99,
-        "p95": 7.95,
-        "p90": 7.90,
-        "p75": 7.75,
-        "p50": 7.5,
-        "p25": 7.25,
-        "max": 8.0,
-        "min": 7.0,
-        "std": 7.5,
-    },
-}
+        metrics = Metrics(
+            request_throughputs=[123],
+            request_latencies=[4, 5, 6],
+        )
+        stats = Statistics(metrics=metrics)
+
+        config = ExporterConfig()
+        config.stats = stats.stats_dict
+        config.metrics = stats.metrics
+        config.args = args
+
+        exporter = ConsoleExporter(config)
+        exporter.export()
+
+        expected_content = (
+            "                        Embedding Metrics                         \n"
+            "┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓\n"
+            "┃            Statistic ┃  avg ┃  min ┃  max ┃  p99 ┃  p90 ┃  p75 ┃\n"
+            "┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━┩\n"
+            "│ Request latency (ms) │ 5.00 │ 4.00 │ 6.00 │ 5.98 │ 5.80 │ 5.50 │\n"
+            "└──────────────────────┴──────┴──────┴──────┴──────┴──────┴──────┘\n"
+            "Request throughput (requests/sec): 123.00\n"
+        )
+
+        returned_data = capsys.readouterr().out
+        assert returned_data == expected_content

--- a/src/c++/perf_analyzer/genai-perf/tests/test_csv_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_csv_exporter.py
@@ -104,15 +104,15 @@ class TestCsvExporter:
 
         expected_content = [
             "Metric,avg,min,max,p99,p95,p90,p75,p50,p25\r\n",
-            "Request Latency (ms),5.00,4.00,6.00,5.98,5.90,5.80,5.50,5.00,4.50\r\n",
             "Time To First Token (ms),8.00,7.00,9.00,8.98,8.90,8.80,8.50,8.00,7.50\r\n",
             "Inter Token Latency (ms),11.00,10.00,12.00,11.98,11.90,11.80,11.50,11.00,10.50\r\n",
+            "Request Latency (ms),5.00,4.00,6.00,5.98,5.90,5.80,5.50,5.00,4.50\r\n",
             "Output Sequence Length,2.00,1.00,3.00,2.98,2.90,2.80,2.50,2.00,1.50\r\n",
             "Input Sequence Length,6.00,5.00,7.00,6.98,6.90,6.80,6.50,6.00,5.50\r\n",
             "\r\n",
             "Metric,Value\r\n",
-            "Request Throughput (requests/sec),123.00\r\n",
-            "Output Token Throughput (tokens/sec),456.00\r\n",
+            "Output Token Throughput (per sec),456.00\r\n",
+            "Request Throughput (per sec),123.00\r\n",
         ]
         returned_data = mock_read_write
         assert returned_data == expected_content
@@ -163,8 +163,8 @@ class TestCsvExporter:
             "Input Sequence Length,6.00,5.00,7.00,6.98,6.90,6.80,6.50,6.00,5.50\r\n",
             "\r\n",
             "Metric,Value\r\n",
-            "Request Throughput (requests/sec),123.00\r\n",
-            "Output Token Throughput (tokens/sec),456.00\r\n",
+            "Output Token Throughput (per sec),456.00\r\n",
+            "Request Throughput (per sec),123.00\r\n",
         ]
         returned_data = mock_read_write
         assert returned_data == expected_content
@@ -204,7 +204,7 @@ class TestCsvExporter:
             "Request Latency (ms),5.00,4.00,6.00,5.98,5.90,5.80,5.50,5.00,4.50\r\n",
             "\r\n",
             "Metric,Value\r\n",
-            "Request Throughput (requests/sec),123.00\r\n",
+            "Request Throughput (per sec),123.00\r\n",
         ]
         returned_data = mock_read_write
         assert returned_data == expected_content

--- a/src/c++/perf_analyzer/genai-perf/tests/test_csv_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_csv_exporter.py
@@ -24,16 +24,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import json
 from io import StringIO
 from pathlib import Path
 from typing import Any, List
 
 import pytest
+from genai_perf import parser
 from genai_perf.export_data.csv_exporter import CsvExporter
 from genai_perf.export_data.exporter_config import ExporterConfig
-from genai_perf.profile_data_parser import LLMProfileDataParser
-from genai_perf.tokenizer import DEFAULT_TOKENIZER, get_tokenizer
+from genai_perf.metrics import LLMMetrics, Metrics, Statistics
 
 
 class TestCsvExporter:
@@ -52,10 +51,7 @@ class TestCsvExporter:
                 written_data.append(content)
                 return len(content)
 
-            if str(filename) == "triton_profile_export.json":
-                tmp_file = StringIO(json.dumps(triton_profile_data))
-                return tmp_file
-            elif str(filename) == "profile_export_genai_perf.csv":
+            if str(filename) == "profile_export_genai_perf.csv":
                 tmp_file = StringIO()
                 tmp_file.write = write.__get__(tmp_file)
                 return tmp_file
@@ -66,102 +62,149 @@ class TestCsvExporter:
 
         return written_data
 
-    def test_csv_output(self, mock_read_write: pytest.MonkeyPatch) -> None:
+    def test_streaming_llm_csv_output(
+        self, monkeypatch, mock_read_write: pytest.MonkeyPatch
+    ) -> None:
         """
         Collect LLM metrics from profile export data and confirm correct values are
         printed in csv.
         """
-
-        tokenizer = get_tokenizer(DEFAULT_TOKENIZER)
-        pd = LLMProfileDataParser(
-            filename=Path("triton_profile_export.json"),
-            tokenizer=tokenizer,
-        )
-        stat = pd.get_statistics(infer_mode="concurrency", load_level="10")
-
-        expected_content = [
-            "Metric,avg,min,max,p99,p95,p90,p75,p50,p25\r\n",
-            "Time To First Token (ms),2.00,2.00,2.00,2.00,2.00,2.00,2.00,2.00,2.00\r\n",
-            "Inter Token Latency (ms),1.50,1.00,2.00,1.99,1.95,1.90,1.75,1.50,1.25\r\n",
-            "Request Latency (ms),8.00,7.00,9.00,8.98,8.90,8.80,8.50,8.00,7.50\r\n",
-            "Output Sequence Length,4.50,3.00,6.00,5.97,5.85,5.70,5.25,4.50,3.75\r\n",
-            "Input Sequence Length,3.50,3.00,4.00,3.99,3.95,3.90,3.75,3.50,3.25\r\n",
-            "\r\n",
-            "Metric,Value\r\n",
-            "Output Token Throughput (per sec),900000000.00\r\n",
-            "Request Throughput (per sec),200000000.00\r\n",
+        argv = [
+            "genai-perf",
+            "-m",
+            "model_name",
+            "--service-kind",
+            "openai",
+            "--endpoint-type",
+            "chat",
+            "--streaming",
         ]
+        monkeypatch.setattr("sys.argv", argv)
+        args, _ = parser.parse_args()
+
+        metrics = LLMMetrics(
+            request_throughputs=[123],
+            request_latencies=[4, 5, 6],
+            time_to_first_tokens=[7, 8, 9],
+            inter_token_latencies=[10, 11, 12],
+            output_token_throughputs=[456],
+            output_sequence_lengths=[1, 2, 3],
+            input_sequence_lengths=[5, 6, 7],
+        )
+        stats = Statistics(metrics=metrics)
+
         config = ExporterConfig()
-        config.stats = stat.stats_dict
+        config.stats = stats.stats_dict
+        config.metrics = stats.metrics
         config.artifact_dir = Path(".")
+        config.args = args
+
         exporter = CsvExporter(config)
         exporter.export()
 
+        expected_content = [
+            "Metric,avg,min,max,p99,p95,p90,p75,p50,p25\r\n",
+            "Request Latency (ms),5.00,4.00,6.00,5.98,5.90,5.80,5.50,5.00,4.50\r\n",
+            "Time To First Token (ms),8.00,7.00,9.00,8.98,8.90,8.80,8.50,8.00,7.50\r\n",
+            "Inter Token Latency (ms),11.00,10.00,12.00,11.98,11.90,11.80,11.50,11.00,10.50\r\n",
+            "Output Sequence Length,2.00,1.00,3.00,2.98,2.90,2.80,2.50,2.00,1.50\r\n",
+            "Input Sequence Length,6.00,5.00,7.00,6.98,6.90,6.80,6.50,6.00,5.50\r\n",
+            "\r\n",
+            "Metric,Value\r\n",
+            "Request Throughput (requests/sec),123.00\r\n",
+            "Output Token Throughput (tokens/sec),456.00\r\n",
+        ]
         returned_data = mock_read_write
-
         assert returned_data == expected_content
 
+    def test_nonstreaming_llm_csv_output(
+        self, monkeypatch, mock_read_write: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Collect LLM metrics from profile export data and confirm correct values are
+        printed in csv.
+        """
+        argv = [
+            "genai-perf",
+            "-m",
+            "model_name",
+            "--service-kind",
+            "openai",
+            "--endpoint-type",
+            "chat",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        args, _ = parser.parse_args()
 
-triton_profile_data = {
-    "service_kind": "triton",
-    "endpoint": "",
-    "experiments": [
-        {
-            "experiment": {
-                "mode": "concurrency",
-                "value": 10,
-            },
-            "requests": [
-                {
-                    "timestamp": 1,
-                    "request_inputs": {"text_input": "This is test"},
-                    "response_timestamps": [3, 5, 8],
-                    "response_outputs": [
-                        {"text_output": "I"},
-                        {"text_output": " like"},
-                        {"text_output": " dogs"},
-                    ],
-                },
-                {
-                    "timestamp": 2,
-                    "request_inputs": {"text_input": "This is test too"},
-                    "response_timestamps": [4, 7, 11],
-                    "response_outputs": [
-                        {"text_output": "I"},
-                        {"text_output": " don't"},
-                        {"text_output": " cook food"},
-                    ],
-                },
-            ],
-        },
-        {
-            "experiment": {
-                "mode": "request_rate",
-                "value": 2.0,
-            },
-            "requests": [
-                {
-                    "timestamp": 5,
-                    "request_inputs": {"text_input": "This is test"},
-                    "response_timestamps": [7, 8, 13, 18],
-                    "response_outputs": [
-                        {"text_output": "cat"},
-                        {"text_output": " is"},
-                        {"text_output": " cool"},
-                        {"text_output": " too"},
-                    ],
-                },
-                {
-                    "timestamp": 3,
-                    "request_inputs": {"text_input": "This is test too"},
-                    "response_timestamps": [6, 8, 11],
-                    "response_outputs": [
-                        {"text_output": "it's"},
-                        {"text_output": " very"},
-                        {"text_output": " simple work"},
-                    ],
-                },
-            ],
-        },
-    ],
-}
+        metrics = LLMMetrics(
+            request_throughputs=[123],
+            request_latencies=[4, 5, 6],
+            time_to_first_tokens=[4, 5, 6],  # same as request_latency
+            inter_token_latencies=[],  # no ITL
+            output_token_throughputs=[456],
+            output_sequence_lengths=[1, 2, 3],
+            input_sequence_lengths=[5, 6, 7],
+        )
+        stats = Statistics(metrics=metrics)
+
+        config = ExporterConfig()
+        config.stats = stats.stats_dict
+        config.metrics = stats.metrics
+        config.artifact_dir = Path(".")
+        config.args = args
+
+        exporter = CsvExporter(config)
+        exporter.export()
+
+        expected_content = [
+            "Metric,avg,min,max,p99,p95,p90,p75,p50,p25\r\n",
+            "Request Latency (ms),5.00,4.00,6.00,5.98,5.90,5.80,5.50,5.00,4.50\r\n",
+            "Output Sequence Length,2.00,1.00,3.00,2.98,2.90,2.80,2.50,2.00,1.50\r\n",
+            "Input Sequence Length,6.00,5.00,7.00,6.98,6.90,6.80,6.50,6.00,5.50\r\n",
+            "\r\n",
+            "Metric,Value\r\n",
+            "Request Throughput (requests/sec),123.00\r\n",
+            "Output Token Throughput (tokens/sec),456.00\r\n",
+        ]
+        returned_data = mock_read_write
+        assert returned_data == expected_content
+
+    def test_embedding_csv_output(
+        self, monkeypatch, mock_read_write: pytest.MonkeyPatch
+    ) -> None:
+        argv = [
+            "genai-perf",
+            "-m",
+            "model_name",
+            "--service-kind",
+            "openai",
+            "--endpoint-type",
+            "embeddings",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        args, _ = parser.parse_args()
+
+        metrics = Metrics(
+            request_throughputs=[123],
+            request_latencies=[4, 5, 6],
+        )
+        stats = Statistics(metrics=metrics)
+
+        config = ExporterConfig()
+        config.stats = stats.stats_dict
+        config.metrics = stats.metrics
+        config.artifact_dir = Path(".")
+        config.args = args
+
+        exporter = CsvExporter(config)
+        exporter.export()
+
+        expected_content = [
+            "Metric,avg,min,max,p99,p95,p90,p75,p50,p25\r\n",
+            "Request Latency (ms),5.00,4.00,6.00,5.98,5.90,5.80,5.50,5.00,4.50\r\n",
+            "\r\n",
+            "Metric,Value\r\n",
+            "Request Throughput (requests/sec),123.00\r\n",
+        ]
+        returned_data = mock_read_write
+        assert returned_data == expected_content

--- a/src/c++/perf_analyzer/genai-perf/tests/test_json_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_json_exporter.py
@@ -241,7 +241,6 @@ class TestJsonExporter:
           "streaming": true,
           "u": null,
           "input_dataset": null,
-          "input_file": null,
           "num_prompts": 100,
           "output_tokens_mean": -1,
           "output_tokens_mean_deterministic": false,

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
@@ -44,11 +44,11 @@ class TestLLMMetrics:
         )
         req_metrics = m.request_metrics
         assert len(req_metrics) == 6
-        assert req_metrics[0].name == "request_latency"
+        assert req_metrics[0].name == "time_to_first_token"
         assert req_metrics[0].unit == "ms"
-        assert req_metrics[1].name == "time_to_first_token"
+        assert req_metrics[1].name == "inter_token_latency"
         assert req_metrics[1].unit == "ms"
-        assert req_metrics[2].name == "inter_token_latency"
+        assert req_metrics[2].name == "request_latency"
         assert req_metrics[2].unit == "ms"
         assert req_metrics[3].name == "output_token_throughput_per_request"
         assert req_metrics[3].unit == "tokens/sec"
@@ -71,10 +71,10 @@ class TestLLMMetrics:
         )
         sys_metrics = m.system_metrics
         assert len(sys_metrics) == 2
-        assert sys_metrics[0].name == "request_throughput"
-        assert sys_metrics[0].unit == "requests/sec"
-        assert sys_metrics[1].name == "output_token_throughput"
-        assert sys_metrics[1].unit == "tokens/sec"
+        assert sys_metrics[0].name == "output_token_throughput"
+        assert sys_metrics[0].unit == "per sec"
+        assert sys_metrics[1].name == "request_throughput"
+        assert sys_metrics[1].unit == "per sec"
 
     def test_llm_metrics_get_base_name(self) -> None:
         """Test get_base_name method in LLMMetrics class."""

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_metrics.py
@@ -30,6 +30,52 @@ from genai_perf.metrics import LLMMetrics
 
 class TestLLMMetrics:
 
+    def test_llm_metric_request_metrics(self) -> None:
+        """Test request_metrics property."""
+        m = LLMMetrics(
+            request_throughputs=[10.12, 11.33],
+            request_latencies=[3, 44],
+            time_to_first_tokens=[1, 2, 3],
+            inter_token_latencies=[4, 5],
+            output_token_throughputs=[22.13, 9423.02],
+            output_token_throughputs_per_request=[7, 8, 9],
+            output_sequence_lengths=[3, 4],
+            input_sequence_lengths=[12, 34],
+        )
+        req_metrics = m.request_metrics
+        assert len(req_metrics) == 6
+        assert req_metrics[0].name == "request_latency"
+        assert req_metrics[0].unit == "ms"
+        assert req_metrics[1].name == "time_to_first_token"
+        assert req_metrics[1].unit == "ms"
+        assert req_metrics[2].name == "inter_token_latency"
+        assert req_metrics[2].unit == "ms"
+        assert req_metrics[3].name == "output_token_throughput_per_request"
+        assert req_metrics[3].unit == "tokens/sec"
+        assert req_metrics[4].name == "output_sequence_length"
+        assert req_metrics[4].unit == "tokens"
+        assert req_metrics[5].name == "input_sequence_length"
+        assert req_metrics[5].unit == "tokens"
+
+    def test_llm_metric_system_metrics(self) -> None:
+        """Test system_metrics property."""
+        m = LLMMetrics(
+            request_throughputs=[10.12, 11.33],
+            request_latencies=[3, 44],
+            time_to_first_tokens=[1, 2, 3],
+            inter_token_latencies=[4, 5],
+            output_token_throughputs=[22.13, 9423.02],
+            output_token_throughputs_per_request=[7, 8, 9],
+            output_sequence_lengths=[3, 4],
+            input_sequence_lengths=[12, 34],
+        )
+        sys_metrics = m.system_metrics
+        assert len(sys_metrics) == 2
+        assert sys_metrics[0].name == "request_throughput"
+        assert sys_metrics[0].unit == "requests/sec"
+        assert sys_metrics[1].name == "output_token_throughput"
+        assert sys_metrics[1].unit == "tokens/sec"
+
     def test_llm_metrics_get_base_name(self) -> None:
         """Test get_base_name method in LLMMetrics class."""
         # initialize with dummy values

--- a/src/c++/perf_analyzer/genai-perf/tests/test_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_metrics.py
@@ -50,7 +50,7 @@ class TestMetrics:
         sys_metrics = m.system_metrics
         assert len(sys_metrics) == 1
         assert sys_metrics[0].name == "request_throughput"
-        assert sys_metrics[0].unit == "requests/sec"
+        assert sys_metrics[0].unit == "per sec"
 
     def test_metrics_get_base_name(self) -> None:
         """Test get_base_name method in Metrics class."""

--- a/src/c++/perf_analyzer/genai-perf/tests/test_metrics.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_metrics.py
@@ -24,6 +24,41 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from genai_perf.metrics.llm_metrics import LLMMetrics
-from genai_perf.metrics.metrics import Metric, Metrics, ResponseFormat
-from genai_perf.metrics.statistics import Statistics
+import pytest
+from genai_perf.metrics import Metrics
+
+
+class TestMetrics:
+
+    def test_metric_request_metrics(self) -> None:
+        """Test request_metrics property."""
+        m = Metrics(
+            request_throughputs=[10.12, 11.33],
+            request_latencies=[3, 44],
+        )
+        req_metrics = m.request_metrics
+        assert len(req_metrics) == 1
+        assert req_metrics[0].name == "request_latency"
+        assert req_metrics[0].unit == "ms"
+
+    def test_metric_system_metrics(self) -> None:
+        """Test system_metrics property."""
+        m = Metrics(
+            request_throughputs=[10.12, 11.33],
+            request_latencies=[3, 44],
+        )
+        sys_metrics = m.system_metrics
+        assert len(sys_metrics) == 1
+        assert sys_metrics[0].name == "request_throughput"
+        assert sys_metrics[0].unit == "requests/sec"
+
+    def test_metrics_get_base_name(self) -> None:
+        """Test get_base_name method in Metrics class."""
+        metrics = Metrics(
+            request_throughputs=[10.12, 11.33],
+            request_latencies=[3, 44],
+        )
+        assert metrics.get_base_name("request_throughputs") == "request_throughput"
+        assert metrics.get_base_name("request_latencies") == "request_latency"
+        with pytest.raises(KeyError):
+            metrics.get_base_name("hello1234")

--- a/src/c++/perf_analyzer/genai-perf/tests/test_profile_data_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_profile_data_parser.py
@@ -1,0 +1,146 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+from io import StringIO
+from pathlib import Path
+from typing import Any, List, Union
+
+import numpy as np
+import pytest
+from genai_perf.metrics import Metrics
+from genai_perf.profile_data_parser import ProfileDataParser
+
+
+def ns_to_sec(ns: int) -> Union[int, float]:
+    """Convert from nanosecond to second."""
+    return ns / 1e9
+
+
+class TestProfileDataParser:
+    @pytest.fixture
+    def mock_read_write(self, monkeypatch: pytest.MonkeyPatch) -> List[str]:
+        """
+        This function will mock the open function for specific files:
+
+        - For "triton_profile_export.json", it will read and return the
+          contents of self.triton_profile_data
+        - For "openai_profile_export.json", it will read and return the
+          contents of self.openai_profile_data
+        - For "profile_export.csv", it will capture all data written to
+          the file, and return it as the return value of this function
+        - For all other files, it will behave like the normal open function
+        """
+
+        written_data = []
+
+        original_open = open
+
+        def custom_open(filename, *args, **kwargs):
+            def write(self: Any, content: str) -> int:
+                written_data.append(content)
+                return len(content)
+
+            if filename == "embedding_profile_export.json":
+                tmp_file = StringIO(json.dumps(self.embedding_profile_data))
+                return tmp_file
+            elif filename == "profile_export.csv":
+                tmp_file = StringIO()
+                tmp_file.write = write.__get__(tmp_file)
+                return tmp_file
+            else:
+                return original_open(filename, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", custom_open)
+
+        return written_data
+
+    def test_base_profile_data(self, mock_read_write: pytest.MonkeyPatch) -> None:
+        """Collect base metrics from profile export data and check values.
+
+        Metrics
+        * request latencies
+            - experiment 1: [3 - 1, 5 - 2] = [2, 3]
+        * request throughputs
+            - experiment 1: [2 / (5e-9 - 1e-9)] = [5e8]
+        """
+        pd = ProfileDataParser(filename=Path("embedding_profile_export.json"))
+
+        # experiment 1 statistics
+        stats = pd.get_statistics(infer_mode="concurrency", load_level="10")
+        metrics = stats.metrics
+        stats_dict = stats.stats_dict
+        assert isinstance(metrics, Metrics)
+
+        assert metrics.request_latencies == [2, 3]
+        assert metrics.request_throughputs == [pytest.approx(5e8)]
+
+        assert stats_dict["request_latency"]["avg"] == pytest.approx(2.5)  # type: ignore
+        assert stats_dict["request_latency"]["p50"] == pytest.approx(2.5)  # type: ignore
+        assert stats_dict["request_latency"]["min"] == pytest.approx(2)  # type: ignore
+        assert stats_dict["request_latency"]["max"] == pytest.approx(3)  # type: ignore
+        assert stats_dict["request_latency"]["std"] == np.std([2, 3])  # type: ignore
+
+        assert stats_dict["request_throughput"]["avg"] == pytest.approx(5e8)  # type: ignore
+
+    embedding_profile_data = {
+        "service_kind": "openai",
+        "endpoint": "v1/embeddings",
+        "experiments": [
+            {
+                "experiment": {
+                    "mode": "concurrency",
+                    "value": 10,
+                },
+                "requests": [
+                    {
+                        "timestamp": 1,
+                        "request_inputs": {
+                            "payload": '{"input":"This is test","model":"NV-Embed-QA","input_type":"passage","encoding_format":"float","truncate":"NONE"}',
+                        },
+                        "response_timestamps": [3],
+                        "response_outputs": [
+                            {
+                                "response": '{"object":"list","data":[{"index":0,"embedding":[1, 2, 3],"object":"embedding"}],"model":"NV-Embed-QA","usage":{"prompt_tokens":7,"total_tokens":7}}'
+                            },
+                        ],
+                    },
+                    {
+                        "timestamp": 2,
+                        "request_inputs": {
+                            "payload": '{"input":"This is test too","model":"NV-Embed-QA","input_type":"passage","encoding_format":"float","truncate":"NONE"}',
+                        },
+                        "response_timestamps": [5],
+                        "response_outputs": [
+                            {
+                                "response": '{"object":"list","data":[{"index":0,"embedding":[1, 2, 3, 4],"object":"embedding"}],"model":"NV-Embed-QA","usage":{"prompt_tokens":8,"total_tokens":8}}'
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }


### PR DESCRIPTION
It looks like a lot of changes but really they're mostly just reduce/refactoring the exporters and fix/adding the unit tests.

Major changes
1. Introduce a small `MetricMetadata` dataclass to store metric name and unit information.
2. `Metrics` and `LLMMetrics` can now return list of request and system metrics.
3. Both `ConsoleExporter` and `CsvExporter` uses these request and system metrics separation to construct table or write to a file.
4. `ProfileDataParser` can now parse profile data and compute base metrics (e.g. request latency, request throughput).
5. Fix/Add tests

Console output:
```bash
                           Embedding Metrics
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓
┃            Statistic ┃   avg ┃   min ┃   max ┃   p99 ┃   p90 ┃   p75 ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩
│ Request latency (ms) │ 23.23 │ 13.97 │ 99.42 │ 49.05 │ 25.90 │ 25.06 │
└──────────────────────┴───────┴───────┴───────┴───────┴───────┴───────┘
Request throughput (per sec): 42.75
```
JSON output:
```json
{
  "request_throughput": {
    "unit": "requests/sec",
    "avg": 42.75457320254329
  },
  "request_latency": {
    "unit": "ms",
    "avg": 23.23479570565302,
    "p99": 49.053525979999826,
    "p95": 26.614957,
    "p90": 25.899405199999997,
    "p75": 25.063774499999997,
    "p50": 23.942059999999998,
    "p25": 21.087379,
    "max": 99.423666,
    "min": 13.966885999999999,
    "std": 5.8619779283612825
  },
  "input_config": {
    "model": [
      "NV-Embed-QA"
    ],
    "model_selection_strategy": "round_robin",
    "backend": "tensorrtllm",
    "endpoint": "v1/embeddings",
    "endpoint_type": "embeddings",
    "service_kind": "openai",
    "streaming": false,
    "u": "localhost:12345",
    "batch_size": 1,
    "input_dataset": null,
    "num_prompts": 100,
    "output_tokens_mean": -1,
    "output_tokens_mean_deterministic": false,
    "output_tokens_stddev": 0,
    "random_seed": 0,
    "synthetic_input_tokens_mean": 550,
    "synthetic_input_tokens_stddev": 0,
    "concurrency": 1,
    "measurement_interval": 10000,
    "request_rate": null,
    "stability_percentage": 999,
    "artifact_dir": "artifacts/NV-Embed-QA-openai-embeddings-concurrency1",
    "generate_plots": false,
    "profile_export_file": "artifacts/NV-Embed-QA-openai-embeddings-concurrency1/profile_export.json",
    "tokenizer": "hf-internal-testing/llama-tokenizer",
    "verbose": true,
    "subcommand": null,
    "prompt_source": "file",
    "formatted_model_name": "NV-Embed-QA",
    "extra_inputs": {}
  }
```
CSV output:
```csv
Metric,avg,min,max,p99,p95,p90,p75,p50,p25
Request Latency (ms),23.23,13.97,99.42,49.05,26.61,25.90,25.06,23.94,21.09

Metric,Value
Request Throughput (per sec),42.75
```