### PR TITLE
Update GenAI-Perf metric unit assignment to avoid overwrites

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/statistics.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/metrics/statistics.py
@@ -129,12 +129,14 @@ class Statistics:
     def _add_units(self, key) -> None:
         if self._is_time_metric(key):
             self._stats_dict[key]["unit"] = "ms"
-        if key == "request_throughput":
+        elif key == "request_throughput":
             self._stats_dict[key]["unit"] = "requests/sec"
-        if key.startswith("output_token_throughput"):
+        elif key.startswith("output_token_throughput"):
             self._stats_dict[key]["unit"] = "tokens/sec"
-        if "sequence_length" in key:
+        elif "sequence_length" in key:
             self._stats_dict[key]["unit"] = "tokens"
+        else:
+            self._stats_dict[key]["unit"] = ""
 
     def __repr__(self) -> str:
         attr_strs = []


### PR DESCRIPTION
This PR updates the unit assignment for metrics in GenAI-Perf. It switches from if branching to if/elif/else to avoid overwrites with unexpected behavior. This should make no difference other than an efficiency in gain in the expected cases, but this will act as a stopgap to avoid unexpected behavior if a metric meets the criteria of multiple branches.

Long-term, we want to identify a consistent way to categorize metrics that makes it impossible for a metric to match the criteria of multiple branches.

Note: For ease, this PR will be rebased off of https://github.com/triton-inference-server/client/pull/715 once https://github.com/triton-inference-server/client/pull/719 is merged. It will not be merged until then. Rather than run CI for this small change, it will be easier to incorporate it into the CI run for the larger feature branch. This also avoids any potential conflicts in putting this directly in main with these lines of code being updated in #719 or #715.