### PR TITLE
Add support for Hugging Face Text Embeddings Interface's re-ranker API

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/README.md
+++ b/src/c++/perf_analyzer/genai-perf/README.md
@@ -373,7 +373,7 @@ model config to not echo the input tokens in the output. (default: tensorrtllm)
 
 Set a custom endpoint that differs from the OpenAI defaults. (default: `None`)
 
-##### `--endpoint-type {chat,completions,embeddings}`
+##### `--endpoint-type {chat,completions,embeddings,rankings}`
 
 The endpoint-type to send requests to on the server. This is only used with the
 `openai` service-kind. (default: `None`)
@@ -400,7 +400,8 @@ URL of the endpoint to target for benchmarking. (default: `None`)
 The batch size of the requests GenAI-Perf should send.
 This is currently only supported with the
 [embeddings endpoint type](docs/embeddings.md).
-(default: `1`)
+(default: `1`) and
+[rankings endpoint type](docs/rankings.md).
 
 ##### `--extra-inputs <str>`
 

--- a/src/c++/perf_analyzer/genai-perf/docs/embeddings.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/embeddings.md
@@ -26,12 +26,12 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-# Profiling Embeddings Models with GenAI-Perf
+# Profile Embeddings Models with GenAI-Perf
 
 GenAI-Perf allows you to profile embedding models running on an
 [OpenAI Embeddings API](https://platform.openai.com/docs/api-reference/embeddings)-compatible server.
 
-## Creating a Sample Embeddings Input File
+## Create a Sample Embeddings Input File
 
 To create a sample embeddings input file, use the following command:
 
@@ -50,13 +50,13 @@ This will generate a file named embeddings.jsonl with the following content:
 {"text": "In what state did they film Shrek 2?"}
 ```
 
-## Starting an OpenAI Embeddings-Compatible Server
+## Start an OpenAI Embeddings-Compatible Server
 To start an OpenAI embeddings-compatible server, run the following command:
 ```bash
 docker run -it --net=host --rm --gpus=all vllm/vllm-openai:latest --model intfloat/e5-mistral-7b-instruct --dtype float16 --max-model-len 1024
 ```
 
-## Running GenAI-Perf
+## Run GenAI-Perf
 To profile embeddings models using GenAI-Perf, use the following command:
 
 ```bash

--- a/src/c++/perf_analyzer/genai-perf/docs/lora.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/lora.md
@@ -26,17 +26,17 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-# Profiling Multiple LoRA Adapters
+# Profile Multiple LoRA Adapters
 GenAI-Perf allows you to profile multiple LoRA adapters on top of a base model.
 
-## Selecting LoRA Adapters
+## Select LoRA Adapters
 To do this, list multiple adapters after the model name option `-m`:
 
 ```bash
 genai-perf -m lora_adapter1 lora_adapter2 lora_adapter3
 ```
 
-## Choosing a Strategy for Selecting Models
+## Choose a Strategy for Selecting Models
 When profiling with multiple models, you can specify how the models should be
 assigned to prompts using the `--model-selection-strategy` option:
 

--- a/src/c++/perf_analyzer/genai-perf/docs/rankings.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/rankings.md
@@ -37,7 +37,9 @@ GenAI-Perf allows you to profile ranking models compatible with Hugging Face's
 To create a sample rankings input directory, follow these steps:
 
 Create a directory called rankings_jsonl:
-
+```bash
+genai-perf -m NV-Rerank-QA-MiniLM --service-kind openai --endpoint-type rankings --input-file rankings_jsonl/ -u localhost:1976 --batch-size 2
+```
 ```bash
 mkdir rankings_jsonl
 ```
@@ -92,9 +94,9 @@ Example output:
 
 Copy code
                           Rankings Metrics
-┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓
-┃ Statistic            ┃ avg   ┃ min   ┃ max    ┃ p99   ┃ p90   ┃ p75   ┃
-┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩
-│ Request latency (ms) │ 35.17 │ 22.34 │ 215.73 │ 47.89 │ 39.75 │ 34.56 │
-└──────────────────────┴───────┴───────┴────────┴───────┴───────┴───────┘
-Request throughput (per sec): 28.37
+┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━┳━━━━━━┓
+┃            Statistic ┃  avg ┃  min ┃   max ┃   p99 ┃  p90 ┃  p75 ┃
+┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━╇━━━━━━┩
+│ Request latency (ms) │ 5.48 │ 2.50 │ 23.91 │ 10.27 │ 8.34 │ 6.07 │
+└──────────────────────┴──────┴──────┴───────┴───────┴──────┴──────┘
+Request throughput (per sec): 180.11

--- a/src/c++/perf_analyzer/genai-perf/docs/rankings.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/rankings.md
@@ -54,10 +54,11 @@ echo '{"text": "What was the first car ever driven?"}
 Create another JSONL file named passages.jsonl with the following passages:
 
 ```bash
-echo '{"text": "Eric Anderson (born January 18, 1968) is an American sociologist and sexologist specializing in adolescent men's gender and sexualities. Anderson is an advocate for the inclusion of gay men in sport and is America's first openly gay high-school coach coming out at Huntington Beach High School, the same high-school that produced the nation's first openly gay, actively playing, professional team sport athlete, Robbie Rogers who currently plays for LA Galaxy."}
-{"text": "Kevin Loader is a British film and television producer. Since 1996, he and co-owner Roger Michell have run a London-based production company, Free Range Films, through which the pair have made several feature films directed by Michell, including 'The Mother', 'Enduring Love', 'Venus', 'Hyde Park on Hudson', and 'Le Week-end'."}
-{"text": "Francisco Antonio Zea Juan Francisco Antonio Hilari was a Colombian journalist, botanist, diplomat, politician, and statesman who served as the 1st Vice President of Colombia under then President Sim\u00f3n Bol\u00edvar. He was also Ambassador of Colombia to the United Kingdom where he tried in vain to gain recognition for the nascent nation of Colombia."}
-{"text": "Daddy's Home 2 Principal photography on the film began in Massachusetts in March 2017 and it was released in the United States by Paramount Pictures on November 10, 2017. Although the film received unfavorable reviews, it has grossed over $180 million worldwide on a $69 million budget."}' > rankings_jsonl/passages.jsonl
+echo '{"text": "Eric Anderson (born January 18, 1968) is an American sociologist and sexologist."}
+{"text": "Kevin Loader is a British film and television producer."}
+{"text": "Francisco Antonio Zea Juan Francisco Antonio Hilari was a Colombian journalist, botanist, diplomat, politician, and statesman who served as the 1st Vice President of Colombia."}
+{"text": "Daddys Home 2 Principal photography on the film began in Massachusetts in March 2017 and it was released in the United States by Paramount Pictures on November 10, 2017. Although the film received unfavorable reviews, it has grossed over $180 million worldwide on a $69 million budget."}' > rankings_jsonl/passages.jsonl
+```
 
 ## Starting a Hugging Face Re-Ranker-Compatible Server
 To start a Hugging Face re-ranker-compatible server, run the following commands:
@@ -73,7 +74,8 @@ docker run --gpus all -p 8080:80 -v $volume:/data --pull always ghcr.io/huggingf
 ## Running GenAI-Perf
 To profile ranking models using GenAI-Perf, use the following command:
 
-```genai-perf \
+```bash
+genai-perf \
     -m BAAI/bge-reranker-large \
     --service-kind openai \
     --endpoint-type rankings \

--- a/src/c++/perf_analyzer/genai-perf/docs/rankings.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/rankings.md
@@ -26,25 +26,22 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-# Profiling Ranking Models with GenAI-Perf
+# Profile Ranking Models with GenAI-Perf
 
 
 GenAI-Perf allows you to profile ranking models compatible with Hugging Face's
 [Text Embeddings Interface's re-ranker API](https://huggingface.co/docs/text-embeddings-inference/en/quick_tour#re-rankers).
 
-## Creating a Sample Rankings Input Directory
+## Create a Sample Rankings Input Directory
 
 To create a sample rankings input directory, follow these steps:
 
 Create a directory called rankings_jsonl:
 ```bash
-genai-perf -m NV-Rerank-QA-MiniLM --service-kind openai --endpoint-type rankings --input-file rankings_jsonl/ -u localhost:1976 --batch-size 2
-```
-```bash
 mkdir rankings_jsonl
 ```
-Inside this directory, create a JSONL file named queries.jsonl with the
-following queries:
+
+Inside this directory, create a JSONL file named queries.jsonl with queries data:
 
 ```bash
 echo '{"text": "What was the first car ever driven?"}
@@ -53,7 +50,7 @@ echo '{"text": "What was the first car ever driven?"}
 {"text": "In what state did they film Shrek 2?"}' > rankings_jsonl/queries.jsonl
 ```
 
-Create another JSONL file named passages.jsonl with the following passages:
+Create another JSONL file named passages.jsonl with passages data:
 
 ```bash
 echo '{"text": "Eric Anderson (born January 18, 1968) is an American sociologist and sexologist."}
@@ -62,7 +59,7 @@ echo '{"text": "Eric Anderson (born January 18, 1968) is an American sociologist
 {"text": "Daddys Home 2 Principal photography on the film began in Massachusetts in March 2017 and it was released in the United States by Paramount Pictures on November 10, 2017. Although the film received unfavorable reviews, it has grossed over $180 million worldwide on a $69 million budget."}' > rankings_jsonl/passages.jsonl
 ```
 
-## Starting a Hugging Face Re-Ranker-Compatible Server
+## Start a Hugging Face Re-Ranker-Compatible Server
 To start a Hugging Face re-ranker-compatible server, run the following commands:
 
 ```bash
@@ -73,7 +70,7 @@ volume=$PWD/data
 docker run --gpus all -p 8080:80 -v $volume:/data --pull always ghcr.io/huggingface/text-embeddings-inference:1.3 --model-id $model --revision $revision
 ```
 
-## Running GenAI-Perf
+## Run GenAI-Perf
 To profile ranking models using GenAI-Perf, use the following command:
 
 ```bash
@@ -92,7 +89,7 @@ This command specifies the use of Hugging Face's ranking API with `--endpoint re
 
 Example output:
 
-Copy code
+```
                           Rankings Metrics
 ┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━┳━━━━━━┓
 ┃            Statistic ┃  avg ┃  min ┃   max ┃   p99 ┃  p90 ┃  p75 ┃
@@ -100,3 +97,4 @@ Copy code
 │ Request latency (ms) │ 5.48 │ 2.50 │ 23.91 │ 10.27 │ 8.34 │ 6.07 │
 └──────────────────────┴──────┴──────┴───────┴───────┴──────┴──────┘
 Request throughput (per sec): 180.11
+```

--- a/src/c++/perf_analyzer/genai-perf/docs/rankings.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/rankings.md
@@ -1,0 +1,98 @@
+<!--
+Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+# Profiling Ranking Models with GenAI-Perf
+
+
+GenAI-Perf allows you to profile ranking models compatible with Hugging Face's
+[Text Embeddings Interface's re-ranker API](https://huggingface.co/docs/text-embeddings-inference/en/quick_tour#re-rankers).
+
+## Creating a Sample Rankings Input Directory
+
+To create a sample rankings input directory, follow these steps:
+
+Create a directory called rankings_jsonl:
+
+```bash
+mkdir rankings_jsonl
+```
+Inside this directory, create a JSONL file named queries.jsonl with the
+following queries:
+
+```bash
+echo '{"text": "What was the first car ever driven?"}
+{"text": "Who served as the 5th President of the United States of America?"}
+{"text": "Is the Sydney Opera House located in Australia?"}
+{"text": "In what state did they film Shrek 2?"}' > rankings_jsonl/queries.jsonl
+```
+
+Create another JSONL file named passages.jsonl with the following passages:
+
+```bash
+echo '{"text": "Eric Anderson (born January 18, 1968) is an American sociologist and sexologist specializing in adolescent men's gender and sexualities. Anderson is an advocate for the inclusion of gay men in sport and is America's first openly gay high-school coach coming out at Huntington Beach High School, the same high-school that produced the nation's first openly gay, actively playing, professional team sport athlete, Robbie Rogers who currently plays for LA Galaxy."}
+{"text": "Kevin Loader is a British film and television producer. Since 1996, he and co-owner Roger Michell have run a London-based production company, Free Range Films, through which the pair have made several feature films directed by Michell, including 'The Mother', 'Enduring Love', 'Venus', 'Hyde Park on Hudson', and 'Le Week-end'."}
+{"text": "Francisco Antonio Zea Juan Francisco Antonio Hilari was a Colombian journalist, botanist, diplomat, politician, and statesman who served as the 1st Vice President of Colombia under then President Sim\u00f3n Bol\u00edvar. He was also Ambassador of Colombia to the United Kingdom where he tried in vain to gain recognition for the nascent nation of Colombia."}
+{"text": "Daddy's Home 2 Principal photography on the film began in Massachusetts in March 2017 and it was released in the United States by Paramount Pictures on November 10, 2017. Although the film received unfavorable reviews, it has grossed over $180 million worldwide on a $69 million budget."}' > rankings_jsonl/passages.jsonl
+
+## Starting a Hugging Face Re-Ranker-Compatible Server
+To start a Hugging Face re-ranker-compatible server, run the following commands:
+
+```bash
+model=BAAI/bge-reranker-large
+revision=refs/pr/4
+volume=$PWD/data
+
+docker run --gpus all -p 8080:80 -v $volume:/data --pull always ghcr.io/huggingface/text-embeddings-inference:1.3 --model-id $model --revision $revision
+```
+
+## Running GenAI-Perf
+To profile ranking models using GenAI-Perf, use the following command:
+
+```genai-perf \
+    -m BAAI/bge-reranker-large \
+    --service-kind openai \
+    --endpoint-type rankings \
+    --endpoint rerank \
+    --input-file rankings_jsonl/ \
+    -u localhost:8080 \
+    --extra-inputs rankings:tei \
+    --batch-size 2
+```
+
+This command specifies the use of Hugging Face's ranking API with `--endpoint rerank` and `--extra-inputs rankings:tei`.
+
+Example output:
+
+Copy code
+                          Rankings Metrics
+┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓
+┃ Statistic            ┃ avg   ┃ min   ┃ max    ┃ p99   ┃ p90   ┃ p75   ┃
+┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩
+│ Request latency (ms) │ 35.17 │ 22.34 │ 215.73 │ 47.89 │ 39.75 │ 34.56 │
+└──────────────────────┴───────┴───────┴────────┴───────┴───────┴───────┘
+Request throughput (per sec): 28.37

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -139,7 +139,7 @@ class LlmInputs:
         output_tokens_deterministic:
             If true, the output tokens will set the minimum and maximum tokens to be equivalent.
         batch_size:
-            The number of inputs per request (currently only used for v1/embeddings)
+            The number of inputs per request (currently only used for the embeddings and rankings endpoints)
 
         Required Synthetic Prompt Generation Parameters
         -----------------------------------------------
@@ -236,7 +236,7 @@ class LlmInputs:
         num_of_output_prompts:
             The number of synthetic output prompts to generate
         batch_size:
-            The number of inputs per request (currently only used for v1/embeddings)
+            The number of inputs per request (currently only used for the embeddings and rankings endpoints)
         input_filename:
             The path to the input file containing the prompts in JSONL format.
         Returns

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -734,6 +734,16 @@ class LlmInputs:
         return pa_json
 
     @classmethod
+    def contains_rankings_tei(cls, extra_inputs: Optional[Dict]) -> bool:
+        """
+        Check if user specified that they are using the Hugging Face
+        Text Embeddings Interface for ranking models
+        """
+        if extra_inputs and extra_inputs.get("rankings") == "tei":
+            return True
+        return False
+
+    @classmethod
     def _convert_generic_json_to_rankings_format(
         cls,
         generic_dataset: Dict,
@@ -742,6 +752,7 @@ class LlmInputs:
         model_selection_strategy: ModelSelectionStrategy = ModelSelectionStrategy.ROUND_ROBIN,
     ) -> Dict[str, Any]:
         pa_json: Dict[str, Any] = {"data": []}
+        use_tei_format = cls.contains_rankings_tei(extra_inputs)
 
         for index, entry in enumerate(generic_dataset["rows"]):
             iter_model_name = cls._select_model_name(
@@ -749,25 +760,36 @@ class LlmInputs:
             )
             payload = entry.get("payload", {})
             query_values = payload.get("query")
-            passage_values = payload.get("passages")
+
+            if use_tei_format:
+                passage_values = payload.get("passages", [])
+                passage_values = [item.get("text", "") for item in passage_values]
+            else:
+                passage_values = payload.get("passages")
 
             if query_values is None:
                 raise ValueError("Missing required fields 'query' in dataset entry")
             if passage_values is None:
-                raise ValueError("Missing required fields 'passages' in dataset entry")
+                raise ValueError(
+                    f"Missing required fields '{'texts' if use_tei_format else 'passages'}' in dataset entry"
+                )
             if not isinstance(passage_values, list):
                 raise ValueError(
-                    f"Required field 'query' must be a list (actual: {type(query_values)})"
+                    f"Required field '{'texts' if use_tei_format else 'passages'}' must be a list (actual: {type(passage_values)})"
                 )
 
-            payload = {
-                "query": query_values,
-                "passages": passage_values,
-                "model": iter_model_name,
-            }
+            if use_tei_format:
+                payload = {"query": query_values["text"], "texts": passage_values}
+            else:
+                payload = {
+                    "query": query_values,
+                    "passages": passage_values,
+                    "model": iter_model_name,
+                }
 
             for key, value in extra_inputs.items():
-                payload[key] = value
+                if not (key == "rankings" and value == "tei"):
+                    payload[key] = value
 
             pa_json["data"].append({"payload": [payload]})
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -218,6 +218,8 @@ class LLMProfileDataParser(ProfileDataParser):
             return payload["messages"][0]["content"]
         elif self._response_format == ResponseFormat.OPENAI_COMPLETIONS:
             return payload["prompt"]
+        elif self._response_format == ResponseFormat.HUGGINGFACE_RANKINGS:
+            return payload["query"]
         else:
             raise ValueError(
                 "Failed to parse OpenAI request input in profile export file."

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
@@ -35,6 +35,7 @@ from genai_perf.utils import load_json
 
 
 class ResponseFormat(Enum):
+    HUGGINGFACE_RANKINGS = auto()
     OPENAI_CHAT_COMPLETIONS = auto()
     OPENAI_COMPLETIONS = auto()
     OPENAI_EMBEDDINGS = auto()
@@ -55,7 +56,9 @@ class ProfileDataParser:
     def _get_profile_metadata(self, data: dict) -> None:
         self._service_kind = data["service_kind"]
         if self._service_kind == "openai":
-            if data["endpoint"] == "v1/chat/completions":
+            if data["endpoint"] == "rerank":
+                self._response_format = ResponseFormat.HUGGINGFACE_RANKINGS
+            elif data["endpoint"] == "v1/chat/completions":
                 self._response_format = ResponseFormat.OPENAI_CHAT_COMPLETIONS
             elif data["endpoint"] == "v1/completions":
                 self._response_format = ResponseFormat.OPENAI_COMPLETIONS


### PR DESCRIPTION
Support Hugging Face Text Embeddings Interface's re-ranker API. This extends the ranking endpoint-type to Hugging Face TEI. If a user specifies "--extra-inputs rankings:tei", then the Hugging Face TEI is used.

Main changes:
- Added documentation on how to run the ranking endpoint with [Hugging Face's re-ranker API](https://huggingface.co/docs/text-embeddings-inference/en/quick_tour#re-rankers))
- When rankings:tei is passed in as an extra inputs, GenAI-Perf logic routes to use the HuggingFace TEI re-ranker API instead for benchmarking ranking
- The profile data JSON file now checks for the HuggingFace TEI re-ranker endpoint (`reranker`)
- Added profile unit parsing unit tests for this endpoint
- Updated our documentation to avoid the use of gerunds in the extra tutorials, consistent with Tim's [PR for the main tutorial](https://github.com/triton-inference-server/client/pull/725)