### PR TITLE
Guard GenAI-Perf plot generation

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -46,7 +46,8 @@ def create_artifacts_dirs(args: Namespace) -> None:
     # TMA-1911: support plots CLI option
     plot_dir = args.artifact_dir / "plots"
     os.makedirs(args.artifact_dir, exist_ok=True)
-    os.makedirs(plot_dir, exist_ok=True)
+    if args.generate_plots:
+        os.makedirs(plot_dir, exist_ok=True)
 
 
 def generate_inputs(args: Namespace, tokenizer: Tokenizer) -> None:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/main.py
@@ -43,10 +43,9 @@ from genai_perf.tokenizer import Tokenizer, get_tokenizer
 
 
 def create_artifacts_dirs(args: Namespace) -> None:
-    # TMA-1911: support plots CLI option
     plot_dir = args.artifact_dir / "plots"
     os.makedirs(args.artifact_dir, exist_ok=True)
-    if args.generate_plots:
+    if hasattr(args, "generate_plots") and args.generate_plots:
         os.makedirs(plot_dir, exist_ok=True)
 
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -178,6 +178,11 @@ def _check_conditional_args_embeddings_rankings(
             parser.error(
                 f"The --streaming option is not supported with the {args.endpoint_type} endpoint type."
             )
+
+        if args.generate_plots:
+            parser.error(
+                f"The --generate-plots option is not currently supported with the {args.endpoint_type} endpoint type."
+            )
     else:
         if args.batch_size != LlmInputs.DEFAULT_BATCH_SIZE:
             parser.error(

--- a/src/c++/perf_analyzer/genai-perf/tests/test_artifacts.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_artifacts.py
@@ -38,7 +38,7 @@ def mock_makedirs(mocker):
 
 def test_create_artifacts_dirs_custom_path(mock_makedirs):
     artifacts_dir_path = "/genai_perf_artifacts"
-    mock_args = Namespace(artifact_dir=Path(artifacts_dir_path))
+    mock_args = Namespace(artifact_dir=Path(artifacts_dir_path), generate_plots=True)
     create_artifacts_dirs(mock_args)
     mock_makedirs.assert_any_call(
         Path(artifacts_dir_path), exist_ok=True
@@ -47,3 +47,13 @@ def test_create_artifacts_dirs_custom_path(mock_makedirs):
         Path(artifacts_dir_path) / "plots", exist_ok=True
     ), f"Expected os.makedirs to create plots directory inside {artifacts_dir_path}/plots path."
     assert mock_makedirs.call_count == 2
+
+
+def test_create_artifacts_disable_generate_plots(mock_makedirs):
+    artifacts_dir_path = "/genai_perf_artifacts"
+    mock_args = Namespace(artifact_dir=Path(artifacts_dir_path))
+    create_artifacts_dirs(mock_args)
+    mock_makedirs.assert_any_call(
+        Path(artifacts_dir_path), exist_ok=True
+    ), f"Expected os.makedirs to create artifacts directory inside {artifacts_dir_path} path."
+    assert mock_makedirs.call_count == 1

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -515,6 +515,58 @@ class TestCLIArguments:
                 ],
                 "The --batch-size option is currently only supported with the embeddings and rankings endpoint types",
             ),
+            (
+                [
+                    "genai-perf",
+                    "-m",
+                    "test_model",
+                    "--service-kind",
+                    "openai",
+                    "--endpoint-type",
+                    "embeddings",
+                    "--streaming",
+                ],
+                "The --streaming option is not supported with the embeddings endpoint type",
+            ),
+            (
+                [
+                    "genai-perf",
+                    "-m",
+                    "test_model",
+                    "--service-kind",
+                    "openai",
+                    "--endpoint-type",
+                    "rankings",
+                    "--streaming",
+                ],
+                "The --streaming option is not supported with the rankings endpoint type",
+            ),
+            (
+                [
+                    "genai-perf",
+                    "-m",
+                    "test_model",
+                    "--service-kind",
+                    "openai",
+                    "--endpoint-type",
+                    "embeddings",
+                    "--generate-plots",
+                ],
+                "The --generate-plots option is not currently supported with the embeddings endpoint type",
+            ),
+            (
+                [
+                    "genai-perf",
+                    "-m",
+                    "test_model",
+                    "--service-kind",
+                    "openai",
+                    "--endpoint-type",
+                    "rankings",
+                    "--generate-plots",
+                ],
+                "The --generate-plots option is not currently supported with the rankings endpoint type",
+            ),
         ],
     )
     def test_conditional_errors(self, args, expected_output, monkeypatch, capsys):


### PR DESCRIPTION
This pull request:
- Prevents the plots directory from being created when --generate-plots is not called
- Protects the embeddings/rankings endpoints from using the --generate-plots option until it is supported
- Adds testing for parser errors (--streaming/--generate-plots)

Rankings can no longer be called with --generate-plots:
![image](https://github.com/triton-inference-server/client/assets/58150256/7f8ee670-3fb5-4029-a83e-16836f453ee2)

Embeddings can no longer be called with --generate-plots:
![image](https://github.com/triton-inference-server/client/assets/58150256/b23fcbb0-f114-4c0d-85cc-a7c502446fbd)

Plots directory not created without --generate-plots:
![image](https://github.com/triton-inference-server/client/assets/58150256/5376943e-051b-43ff-a0ab-8deffd4a7370)
