### PR TITLE
Remove unnecessary OpenAI rankings parsing branch

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -218,8 +218,6 @@ class LLMProfileDataParser(ProfileDataParser):
             return payload["messages"][0]["content"]
         elif self._response_format == ResponseFormat.OPENAI_COMPLETIONS:
             return payload["prompt"]
-        elif self._response_format == ResponseFormat.HUGGINGFACE_RANKINGS:
-            return payload["query"]
         else:
             raise ValueError(
                 "Failed to parse OpenAI request input in profile export file."


### PR DESCRIPTION
Context: https://github.com/triton-inference-server/client/pull/728/files#r1664451669

Rankings support is only for request-level metrics, so the conditional branch specifying its input text is unnecessary. This commit was not merged as part of the original PR.