### PR TITLE
Enable client-side batching for OpenAI

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -163,7 +163,7 @@ def _check_conditional_args(
     else:
         if args.batch_size != LlmInputs.DEFAULT_BATCH_SIZE:
             parser.error(
-                "The --batch-size option is only supported with the Triton service-kind."
+                "The --batch-size option is only supported with the OpenAPI service-kind."
             )
 
     _check_conditional_args_embeddings_rankings(parser, args)
@@ -307,7 +307,7 @@ def _add_input_args(parser):
         default=LlmInputs.DEFAULT_BATCH_SIZE,
         required=False,
         help=f"The batch size of the requests GenAI-Perf should send. "
-        "This is currently only supported with the embeddings and rankings endpoint types.",
+        "This is currently only supported with the OpenAI service-kind.",
     )
 
     input_group.add_argument(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -160,6 +160,11 @@ def _check_conditional_args(
             parser.error(
                 "The --output-tokens-mean-deterministic option is only supported with the Triton service-kind."
             )
+    else:
+        if args.batch_size != LlmInputs.DEFAULT_BATCH_SIZE:
+            parser.error(
+                "The --batch-size option is only supported with the Triton service-kind."
+            )
 
     _check_conditional_args_embeddings_rankings(parser, args)
 
@@ -182,11 +187,6 @@ def _check_conditional_args_embeddings_rankings(
         if args.generate_plots:
             parser.error(
                 f"The --generate-plots option is not currently supported with the {args.endpoint_type} endpoint type."
-            )
-    else:
-        if args.batch_size != LlmInputs.DEFAULT_BATCH_SIZE:
-            parser.error(
-                "The --batch-size option is currently only supported with the embeddings and rankings endpoint types."
             )
 
     if args.input_file:

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -510,16 +510,6 @@ class TestCLIArguments:
                     "genai-perf",
                     "-m",
                     "test_model",
-                    "--batch-size",
-                    "10",
-                ],
-                "The --batch-size option is currently only supported with the embeddings and rankings endpoint types",
-            ),
-            (
-                [
-                    "genai-perf",
-                    "-m",
-                    "test_model",
                     "--service-kind",
                     "openai",
                     "--endpoint-type",

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -557,6 +557,16 @@ class TestCLIArguments:
                 ],
                 "The --generate-plots option is not currently supported with the rankings endpoint type",
             ),
+            (
+                [
+                    "genai-perf",
+                    "-m",
+                    "test_model",
+                    "--batch-size",
+                    "2",
+                ],
+                "The --batch-size option is only supported with the OpenAPI service-kind",
+            ),
         ],
     )
     def test_conditional_errors(self, args, expected_output, monkeypatch, capsys):


### PR DESCRIPTION
Enable client-side batching with the `--batch-size` arg. GenAI-Perf will batch the requests for the OpenAI service kind.

Batching is already supported for rankings and embeddings. This PR expands this support to the completions and chat endpoints.

TODO:

- Add tests
- Parse input/output sequences (metrics) in a way that accounts for batches for the completions endpoint