### PR TITLE
Update default behavior for max threads PA async mode

### DIFF
--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1716,6 +1716,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
   // Overriding the max_threads default for request_rate search
   if (!params_->max_threads_specified && params_->targeting_concurrency()) {
     params_->max_threads = 16;
+    params_->max_threads =
+        std::max(params_->max_threads, params_->concurrency_range.end);
   }
 
   if (params_->using_custom_intervals) {

--- a/src/c++/perf_analyzer/command_line_parser.cc
+++ b/src/c++/perf_analyzer/command_line_parser.cc
@@ -1715,9 +1715,8 @@ CLParser::ParseCommandLine(int argc, char** argv)
 
   // Overriding the max_threads default for request_rate search
   if (!params_->max_threads_specified && params_->targeting_concurrency()) {
-    params_->max_threads = 16;
     params_->max_threads =
-        std::max(params_->max_threads, params_->concurrency_range.end);
+        std::max(DEFAULT_MAX_THREADS, params_->concurrency_range.end);
   }
 
   if (params_->using_custom_intervals) {

--- a/src/c++/perf_analyzer/constants.h
+++ b/src/c++/perf_analyzer/constants.h
@@ -41,6 +41,7 @@ constexpr static const uint32_t STABILITY_ERROR = 2;
 constexpr static const uint32_t OPTION_ERROR = 3;
 
 constexpr static const uint32_t GENERIC_ERROR = 99;
+constexpr static const size_t DEFAULT_MAX_THREADS = 16;
 
 const double DELAY_PCT_THRESHOLD{1.0};
 

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -371,12 +371,11 @@ class TestCLParser : public CLParser {
 void
 CheckValidRange(
     std::vector<char*>& args, char* option_name, TestCLParser& parser,
-    PAParamsPtr& act, bool& using_range, Range<uint64_t>& range,
-    PAParamsPtr& exp)
+    PAParamsPtr& act, bool& using_range, Range<uint64_t>& range,  size_t* max_threads)
 {
   SUBCASE("start:end provided")
   {
-    exp->max_threads = 400;
+    *max_threads = 400;
     args.push_back(option_name);
     args.push_back("100:400");  // start:end
 
@@ -394,7 +393,7 @@ CheckValidRange(
 
   SUBCASE("start:end:step provided")
   {
-    exp->max_threads = 400;
+    *max_threads = 400;
     args.push_back(option_name);
     args.push_back("100:400:10");  // start:end:step
 
@@ -1134,7 +1133,7 @@ TEST_CASE("Testing Command Line Parser")
 
     CheckValidRange(
         args, option_name, parser, act, exp->using_concurrency_range,
-        exp->concurrency_range, exp);
+        exp->concurrency_range, &(exp->max_threads));
     CheckInvalidRange(args, option_name, parser, act, check_params);
 
     SUBCASE("wrong separator")
@@ -1177,7 +1176,7 @@ TEST_CASE("Testing Command Line Parser")
       check_params = false;
     }
 
-    SUBCASE("concurrency-range.end < 16")
+    SUBCASE("Max threads set to default when concurrency-range < 16")
     {
       args.push_back(option_name);
       args.push_back("10:10");  // start
@@ -1195,7 +1194,7 @@ TEST_CASE("Testing Command Line Parser")
       exp->max_threads = 16;
     }
 
-    SUBCASE("concurrency-range.end == 16")
+    SUBCASE("Max_threads set to default when concurrency-range.end = 16")
     {
       args.push_back(option_name);
       args.push_back("10:16");  // start
@@ -1213,7 +1212,7 @@ TEST_CASE("Testing Command Line Parser")
       exp->max_threads = 16;
     }
 
-    SUBCASE("concurrency-range.end > 16")
+    SUBCASE("Max_threads set to concurrency-range.end when concurrency-range.end > 16")
     {
       args.push_back(option_name);
       args.push_back("10:40");  // start
@@ -1267,7 +1266,7 @@ TEST_CASE("Testing Command Line Parser")
 
     CheckValidRange(
         args, option_name, parser, act, exp->is_using_periodic_concurrency_mode,
-        exp->periodic_concurrency_range, exp);
+        exp->periodic_concurrency_range, &(exp->max_threads));
 
     CheckInvalidRange(args, option_name, parser, act, check_params);
 

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -371,7 +371,8 @@ class TestCLParser : public CLParser {
 void
 CheckValidRange(
     std::vector<char*>& args, char* option_name, TestCLParser& parser,
-    PAParamsPtr& act, bool& using_range, Range<uint64_t>& range,  size_t* max_threads)
+    PAParamsPtr& act, bool& using_range, Range<uint64_t>& range,
+    size_t* max_threads)
 {
   SUBCASE("start:end provided")
   {
@@ -1212,7 +1213,9 @@ TEST_CASE("Testing Command Line Parser")
       exp->max_threads = 16;
     }
 
-    SUBCASE("Max_threads set to concurrency-range.end when concurrency-range.end > 16")
+    SUBCASE(
+        "Max_threads set to concurrency-range.end when concurrency-range.end > "
+        "16")
     {
       args.push_back(option_name);
       args.push_back("10:40");  // start

--- a/src/c++/perf_analyzer/test_command_line_parser.cc
+++ b/src/c++/perf_analyzer/test_command_line_parser.cc
@@ -528,7 +528,7 @@ TEST_CASE("Testing Command Line Parser")
 
   // Most common defaults
   exp->model_name = model_name;  // model_name;
-  exp->max_threads = 16;
+  exp->max_threads = DEFAULT_MAX_THREADS;
 
   SUBCASE("with no parameters")
   {
@@ -1114,11 +1114,14 @@ TEST_CASE("Testing Command Line Parser")
   SUBCASE("Option : --concurrency-range")
   {
     char* option_name = "--concurrency-range";
+    uint64_t concurrency_range_start;
+    uint64_t concurrency_range_end;
 
     SUBCASE("start provided")
     {
+      concurrency_range_start = 100;
       args.push_back(option_name);
-      args.push_back("100");  // start
+      args.push_back(std::to_string(concurrency_range_start).data());  // start
 
       int argc = args.size();
       char* argv[argc];
@@ -1128,8 +1131,8 @@ TEST_CASE("Testing Command Line Parser")
       CHECK(!parser.UsageCalled());
 
       exp->using_concurrency_range = true;
-      exp->concurrency_range.start = 100;
-      exp->max_threads = 16;
+      exp->concurrency_range.start = concurrency_range_start;
+      exp->max_threads = DEFAULT_MAX_THREADS;
     }
 
     CheckValidRange(
@@ -1177,10 +1180,15 @@ TEST_CASE("Testing Command Line Parser")
       check_params = false;
     }
 
-    SUBCASE("Max threads set to default when concurrency-range < 16")
+    concurrency_range_start = 10;
+    SUBCASE("Max threads set to default when concurrency-range.end < 16")
     {
+      concurrency_range_end = 10;
+      std::string concurrency_range_str =
+          std::to_string(concurrency_range_start) + ":" +
+          std::to_string(concurrency_range_end);
       args.push_back(option_name);
-      args.push_back("10:10");  // start
+      args.push_back(concurrency_range_str.data());
 
       int argc = args.size();
       char* argv[argc];
@@ -1190,15 +1198,19 @@ TEST_CASE("Testing Command Line Parser")
       CHECK(!parser.UsageCalled());
 
       exp->using_concurrency_range = true;
-      exp->concurrency_range.start = 10;
-      exp->concurrency_range.end = 10;
-      exp->max_threads = 16;
+      exp->concurrency_range.start = concurrency_range_start;
+      exp->concurrency_range.end = concurrency_range_end;
+      exp->max_threads = DEFAULT_MAX_THREADS;
     }
 
     SUBCASE("Max_threads set to default when concurrency-range.end = 16")
     {
+      concurrency_range_end = 16;
+      std::string concurrency_range_str =
+          std::to_string(concurrency_range_start) + ":" +
+          std::to_string(concurrency_range_end);
       args.push_back(option_name);
-      args.push_back("10:16");  // start
+      args.push_back(concurrency_range_str.data());
 
       int argc = args.size();
       char* argv[argc];
@@ -1208,17 +1220,21 @@ TEST_CASE("Testing Command Line Parser")
       CHECK(!parser.UsageCalled());
 
       exp->using_concurrency_range = true;
-      exp->concurrency_range.start = 10;
-      exp->concurrency_range.end = 16;
-      exp->max_threads = 16;
+      exp->concurrency_range.start = concurrency_range_start;
+      exp->concurrency_range.end = concurrency_range_end;
+      exp->max_threads = DEFAULT_MAX_THREADS;
     }
 
     SUBCASE(
         "Max_threads set to concurrency-range.end when concurrency-range.end > "
         "16")
     {
+      concurrency_range_end = 40;
+      std::string concurrency_range_str =
+          std::to_string(concurrency_range_start) + ":" +
+          std::to_string(concurrency_range_end);
       args.push_back(option_name);
-      args.push_back("10:40");  // start
+      args.push_back(concurrency_range_str.data());
 
       int argc = args.size();
       char* argv[argc];
@@ -1228,9 +1244,9 @@ TEST_CASE("Testing Command Line Parser")
       CHECK(!parser.UsageCalled());
 
       exp->using_concurrency_range = true;
-      exp->concurrency_range.start = 10;
-      exp->concurrency_range.end = 40;
-      exp->max_threads = 40;
+      exp->concurrency_range.start = concurrency_range_start;
+      exp->concurrency_range.end = concurrency_range_end;
+      exp->max_threads = exp->concurrency_range.end;
     }
   }
 


### PR DESCRIPTION
Currently, max_threads in PA is by default set to 16 in async mode. While using genai-perf, concurrency value can be passed as a CLI argument. However, the max_threads used by PA is still 16 although concurrency is set to a higher value. This change sets max_threads to concurrency if concurrency > 16. If concurrency <= 16, max_threads is by default set to 16.