### PR TITLE
Move GenAI-Perf profiling to its own subcommand

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/README.md
+++ b/src/c++/perf_analyzer/genai-perf/README.md
@@ -162,8 +162,7 @@ docker run -it --net=host --rm --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}
 2. Run GenAI-Perf:
 
 ```bash
-genai-perf \
-  profile \
+genai-perf profile \
   -m gpt2 \
   --service-kind triton \
   --backend tensorrtllm \
@@ -210,8 +209,7 @@ current profile run. This is disabled by default but users can easily enable it
 by passing the `--generate-plots` option when running the benchmark:
 
 ```bash
-genai-perf \
-  profile \
+genai-perf profile \
   -m gpt2 \
   --service-kind triton \
   --backend tensorrtllm \

--- a/src/c++/perf_analyzer/genai-perf/README.md
+++ b/src/c++/perf_analyzer/genai-perf/README.md
@@ -163,6 +163,7 @@ docker run -it --net=host --rm --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}
 
 ```bash
 genai-perf \
+  profile \
   -m gpt2 \
   --service-kind triton \
   --backend tensorrtllm \
@@ -210,6 +211,7 @@ by passing the `--generate-plots` option when running the benchmark:
 
 ```bash
 genai-perf \
+  profile \
   -m gpt2 \
   --service-kind triton \
   --backend tensorrtllm \

--- a/src/c++/perf_analyzer/genai-perf/docs/embeddings.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/embeddings.md
@@ -60,8 +60,7 @@ docker run -it --net=host --rm --gpus=all vllm/vllm-openai:latest --model intflo
 To profile embeddings models using GenAI-Perf, use the following command:
 
 ```bash
-genai-perf \
-    profile \
+genai-perf profile \
     -m intfloat/e5-mistral-7b-instruct \
     --service-kind openai \
     --endpoint-type embeddings \
@@ -74,8 +73,7 @@ additional arguments with the `--extra-inputs` [flag](../README.md#input-options
 For example, you could use this command:
 
 ```bash
-genai-perf \
-    profile \
+genai-perf profile \
     -m intfloat/e5-mistral-7b-instruct \
     --service-kind openai \
     --endpoint-type embeddings \

--- a/src/c++/perf_analyzer/genai-perf/docs/embeddings.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/embeddings.md
@@ -61,6 +61,7 @@ To profile embeddings models using GenAI-Perf, use the following command:
 
 ```bash
 genai-perf \
+    profile \
     -m intfloat/e5-mistral-7b-instruct \
     --service-kind openai \
     --endpoint-type embeddings \
@@ -74,6 +75,7 @@ For example, you could use this command:
 
 ```bash
 genai-perf \
+    profile \
     -m intfloat/e5-mistral-7b-instruct \
     --service-kind openai \
     --endpoint-type embeddings \

--- a/src/c++/perf_analyzer/genai-perf/docs/lora.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/lora.md
@@ -42,6 +42,7 @@ assigned to prompts using the `--model-selection-strategy` option:
 
 ```bash
 genai-perf \
+    profile \
     -m lora_adapter1 lora_adapter2 lora_adapter3 \
     --model-selection-strategy round_robin
 ```

--- a/src/c++/perf_analyzer/genai-perf/docs/lora.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/lora.md
@@ -41,8 +41,7 @@ When profiling with multiple models, you can specify how the models should be
 assigned to prompts using the `--model-selection-strategy` option:
 
 ```bash
-genai-perf \
-    profile \
+genai-perf profile \
     -m lora_adapter1 lora_adapter2 lora_adapter3 \
     --model-selection-strategy round_robin
 ```

--- a/src/c++/perf_analyzer/genai-perf/docs/rankings.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/rankings.md
@@ -75,6 +75,7 @@ To profile ranking models using GenAI-Perf, use the following command:
 
 ```bash
 genai-perf \
+    profile \
     -m BAAI/bge-reranker-large \
     --service-kind openai \
     --endpoint-type rankings \

--- a/src/c++/perf_analyzer/genai-perf/docs/rankings.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/rankings.md
@@ -74,8 +74,7 @@ docker run --gpus all -p 8080:80 -v $volume:/data --pull always ghcr.io/huggingf
 To profile ranking models using GenAI-Perf, use the following command:
 
 ```bash
-genai-perf \
-    profile \
+genai-perf profile \
     -m BAAI/bge-reranker-large \
     --service-kind openai \
     --endpoint-type rankings \

--- a/src/c++/perf_analyzer/genai-perf/docs/tutorial.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/tutorial.md
@@ -83,6 +83,7 @@ docker run -it --net=host --rm --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}
 
 ```bash
 genai-perf \
+  profile \
   -m gpt2 \
   --service-kind triton \
   --backend tensorrtllm \
@@ -167,6 +168,7 @@ docker run -it --net=host --rm --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}
 
 ```bash
 genai-perf \
+  profile \
   -m gpt2 \
   --service-kind triton \
   --backend vllm \
@@ -233,6 +235,7 @@ docker run -it --net=host --rm --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}
 
 ```bash
 genai-perf \
+  profile \
   -m gpt2 \
   --service-kind openai \
   --endpoint v1/chat/completions \
@@ -297,6 +300,7 @@ docker run -it --net=host --rm --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}
 
 ```bash
 genai-perf \
+  profile \
   -m gpt2 \
   --service-kind openai \
   --endpoint v1/completions \

--- a/src/c++/perf_analyzer/genai-perf/docs/tutorial.md
+++ b/src/c++/perf_analyzer/genai-perf/docs/tutorial.md
@@ -82,8 +82,7 @@ docker run -it --net=host --rm --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}
 2. Run GenAI-Perf:
 
 ```bash
-genai-perf \
-  profile \
+genai-perf profile \
   -m gpt2 \
   --service-kind triton \
   --backend tensorrtllm \
@@ -167,8 +166,7 @@ docker run -it --net=host --rm --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}
 2. Run GenAI-Perf:
 
 ```bash
-genai-perf \
-  profile \
+genai-perf profile \
   -m gpt2 \
   --service-kind triton \
   --backend vllm \
@@ -234,8 +232,7 @@ docker run -it --net=host --rm --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}
 2. Run GenAI-Perf:
 
 ```bash
-genai-perf \
-  profile \
+genai-perf profile \
   -m gpt2 \
   --service-kind openai \
   --endpoint v1/chat/completions \
@@ -299,8 +296,7 @@ docker run -it --net=host --rm --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}
 2. Run GenAI-Perf:
 
 ```bash
-genai-perf \
-  profile \
+genai-perf profile \
   -m gpt2 \
   --service-kind openai \
   --endpoint v1/completions \

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -573,13 +573,6 @@ def _add_other_args(parser):
         help="An option to enable verbose mode.",
     )
 
-    other_group.add_argument(
-        "--version",
-        action="version",
-        version="%(prog)s " + __version__,
-        help=f"An option to print the version and exit.",
-    )
-
 
 def get_extra_inputs_as_dict(args: argparse.Namespace) -> dict:
     request_inputs = {}
@@ -704,14 +697,12 @@ def parse_args():
         description="CLI to profile LLMs and Generative AI models with Perf Analyzer",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.set_defaults(func=profile_handler)
-
-    # Conceptually group args for easier visualization
-    _add_endpoint_args(parser)
-    _add_input_args(parser)
-    _add_profile_args(parser)
-    _add_output_args(parser)
-    _add_other_args(parser)
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s " + __version__,
+        help=f"An option to print the version and exit.",
+    )
 
     # Add subcommands
     subparsers = parser.add_subparsers(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -705,6 +705,18 @@ def parse_args():
     )
     compare_parser = _parse_compare_args(subparsers)
 
+    profile_parser = subparsers.add_parser(
+        "profile",
+        description="Subcommand to profile LLMs and Generative AI models.",
+    )
+    subparsers.required = True
+    _add_endpoint_args(profile_parser)
+    _add_input_args(profile_parser)
+    _add_profile_args(profile_parser)
+    _add_output_args(profile_parser)
+    _add_other_args(profile_parser)
+    profile_parser.set_defaults(func=profile_handler)
+
     # Check for passthrough args
     if "--" in argv:
         passthrough_index = argv.index("--")

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -61,6 +61,14 @@ class PathType(Enum):
         return self.name.lower()
 
 
+class Subcommand(Enum):
+    PROFILE = auto()
+    COMPARE = auto()
+
+    def to_lowercase(self):
+        return self.name.lower()
+
+
 logger = logging.getLogger(__name__)
 
 _endpoint_type_map = {
@@ -102,9 +110,8 @@ def _check_compare_args(
     """
     Check compare subcommand args
     """
-    if args.subcommand == "compare":
-        if not args.config and not args.files:
-            parser.error("Either the --config or --files option must be specified.")
+    if not args.config and not args.files:
+        parser.error("Either the --config or --files option must be specified.")
     return args
 
 
@@ -619,10 +626,10 @@ def get_extra_inputs_as_dict(args: argparse.Namespace) -> dict:
 
 def _parse_compare_args(subparsers) -> argparse.ArgumentParser:
     compare = subparsers.add_parser(
-        "compare",
+        Subcommand.COMPARE.to_lowercase(),
         description="Subcommand to generate plots that compare multiple profile runs.",
     )
-    compare_group = compare.add_argument_group("Compare")
+    compare_group = compare.add_argument_group("Input")
     mx_group = compare_group.add_mutually_exclusive_group(required=False)
     mx_group.add_argument(
         "--config",
@@ -646,7 +653,7 @@ def _parse_compare_args(subparsers) -> argparse.ArgumentParser:
 
 def _parse_profile_args(subparsers) -> argparse.ArgumentParser:
     profile = subparsers.add_parser(
-        "profile",
+        Subcommand.PROFILE.to_lowercase(),
         description="Subcommand to profile LLMs and Generative AI models.",
     )
     _add_endpoint_args(profile)
@@ -726,13 +733,13 @@ def get_passthrough_args_index(argv: list) -> int:
 def refine_args(
     parser: argparse.ArgumentParser, args: argparse.Namespace
 ) -> argparse.Namespace:
-    if args.subcommand == "profile":
+    if args.subcommand == Subcommand.PROFILE.to_lowercase():
         args = _infer_prompt_source(args)
         args = _check_model_args(parser, args)
         args = _check_conditional_args(parser, args)
         args = _check_load_manager_args(args)
         args = _set_artifact_paths(args)
-    elif args.subcommand == "compare":
+    elif args.subcommand == Subcommand.COMPARE.to_lowercase():
         args = _check_compare_args(parser, args)
     else:
         raise ValueError(f"Unknown subcommand: {args.subcommand}")

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/test_end_to_end.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/test_end_to_end.py
@@ -10,7 +10,7 @@ import sys
 # For all cases but vllm_openai, it assumes that the server will be on port 9999
 #
 # This script will run a sweep of all combinations of values in the testing matrix
-# by appending those options on to the genai-pa base command
+# by appending those options on to the genai-perf base command
 #
 
 
@@ -20,11 +20,11 @@ testing_matrix = [
 ]
 
 base_commands = {
-    "nim_chat": "genai-perf -s 999 -p 20000 -m llama-2-7b-chat -u http://localhost:9999 --service-kind openai --endpoint-type chat",
-    "nim_completions": "genai-perf -s 999 -p 20000 -m llama-2-7b -u http://localhost:9999 --service-kind openai --endpoint-type completions",
-    "vllm_openai": "genai-perf -s 999 -p 20000 -m mistralai/Mistral-7B-v0.1 --service-kind openai --endpoint-type chat",
-    "triton_tensorrtllm": "genai-perf -s 999 -p 20000 -m llama-2-7b -u 0.0.0.0:9999 --service-kind triton --backend tensorrtllm",
-    "triton_vllm": "genai-perf -s 999 -p 20000 -m gpt2_vllm --service-kind triton --backend vllm",
+    "nim_chat": "genai-perf profile -s 999 -p 20000 -m llama-2-7b-chat -u http://localhost:9999 --service-kind openai --endpoint-type chat",
+    "nim_completions": "genai-perf profile -s 999 -p 20000 -m llama-2-7b -u http://localhost:9999 --service-kind openai --endpoint-type completions",
+    "vllm_openai": "genai-perf profile -s 999 -p 20000 -m mistralai/Mistral-7B-v0.1 --service-kind openai --endpoint-type chat",
+    "triton_tensorrtllm": "genai-perf profile -s 999 -p 20000 -m llama-2-7b -u 0.0.0.0:9999 --service-kind triton --backend tensorrtllm",
+    "triton_vllm": "genai-perf profile -s 999 -p 20000 -m gpt2_vllm --service-kind triton --backend vllm",
 }
 testname = ""
 

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -226,7 +226,7 @@ class TestCLIArguments:
     )
     def test_non_file_flags_parsed(self, monkeypatch, arg, expected_attributes, capsys):
         logging.init_logging()
-        combined_args = ["genai-perf", "--model", "test_model"] + arg
+        combined_args = ["genai-perf", "profile", "--model", "test_model"] + arg
         monkeypatch.setattr("sys.argv", combined_args)
         args, _ = parser.parse_args()
 
@@ -267,7 +267,7 @@ class TestCLIArguments:
         self, monkeypatch, models, expected_model_list, formatted_name, capsys
     ):
         logging.init_logging()
-        combined_args = ["genai-perf"] + models
+        combined_args = ["genai-perf", "profile"] + models
         monkeypatch.setattr("sys.argv", combined_args)
         args, _ = parser.parse_args()
 
@@ -287,6 +287,7 @@ class TestCLIArguments:
         _ = mocker.patch("os.path.isfile", return_value=True)
         combined_args = [
             "genai-perf",
+            "profile",
             "--model",
             "test_model",
             "--input-file",
@@ -340,7 +341,7 @@ class TestCLIArguments:
         self, monkeypatch, arg, expected_path, capsys
     ):
         logging.init_logging()
-        combined_args = ["genai-perf", "--model", "test_model"] + arg
+        combined_args = ["genai-perf", "profile", "--model", "test_model"] + arg
         monkeypatch.setattr("sys.argv", combined_args)
         args, _ = parser.parse_args()
 
@@ -380,7 +381,7 @@ class TestCLIArguments:
         self, monkeypatch, arg, expected_path, expected_output, capsys
     ):
         logging.init_logging()
-        combined_args = ["genai-perf"] + arg
+        combined_args = ["genai-perf", "profile"] + arg
         monkeypatch.setattr("sys.argv", combined_args)
         args, _ = parser.parse_args()
 
@@ -390,7 +391,9 @@ class TestCLIArguments:
 
     def test_default_load_level(self, monkeypatch, capsys):
         logging.init_logging()
-        monkeypatch.setattr("sys.argv", ["genai-perf", "--model", "test_model"])
+        monkeypatch.setattr(
+            "sys.argv", ["genai-perf", "profile", "--model", "test_model"]
+        )
         args, _ = parser.parse_args()
         assert args.concurrency == 1
         captured = capsys.readouterr()
@@ -398,7 +401,8 @@ class TestCLIArguments:
 
     def test_load_level_mutually_exclusive(self, monkeypatch, capsys):
         monkeypatch.setattr(
-            "sys.argv", ["genai-perf", "--concurrency", "3", "--request-rate", "9.0"]
+            "sys.argv",
+            ["genai-perf", "profile", "--concurrency", "3", "--request-rate", "9.0"],
         )
         expected_output = (
             "argument --request-rate: not allowed with argument --concurrency"
@@ -412,7 +416,7 @@ class TestCLIArguments:
         assert expected_output in captured.err
 
     def test_model_not_provided(self, monkeypatch, capsys):
-        monkeypatch.setattr("sys.argv", ["genai-perf"])
+        monkeypatch.setattr("sys.argv", ["genai-perf", "profile"])
         expected_output = "The -m/--model option is required and cannot be empty."
 
         with pytest.raises(SystemExit) as excinfo:
@@ -423,7 +427,7 @@ class TestCLIArguments:
         assert expected_output in captured.err
 
     def test_pass_through_args(self, monkeypatch):
-        args = ["genai-perf", "-m", "test_model"]
+        args = ["genai-perf", "profile", "-m", "test_model"]
         other_args = ["--", "With", "great", "power"]
         monkeypatch.setattr("sys.argv", args + other_args)
         _, pass_through_args = parser.parse_args()
@@ -435,6 +439,7 @@ class TestCLIArguments:
             "sys.argv",
             [
                 "genai-perf",
+                "profile",
                 "-m",
                 "nonexistent_model",
                 "--wrong-arg",
@@ -453,12 +458,20 @@ class TestCLIArguments:
         "args, expected_output",
         [
             (
-                ["genai-perf", "-m", "test_model", "--service-kind", "openai"],
+                [
+                    "genai-perf",
+                    "profile",
+                    "-m",
+                    "test_model",
+                    "--service-kind",
+                    "openai",
+                ],
                 "The --endpoint-type option is required when using the 'openai' service-kind.",
             ),
             (
                 [
                     "genai-perf",
+                    "profile",
                     "-m",
                     "test_model",
                     "--service-kind",
@@ -469,12 +482,20 @@ class TestCLIArguments:
                 "The --endpoint-type option is required when using the 'openai' service-kind.",
             ),
             (
-                ["genai-perf", "-m", "test_model", "--output-tokens-stddev", "5"],
+                [
+                    "genai-perf",
+                    "profile",
+                    "-m",
+                    "test_model",
+                    "--output-tokens-stddev",
+                    "5",
+                ],
                 "The --output-tokens-mean option is required when using --output-tokens-stddev.",
             ),
             (
                 [
                     "genai-perf",
+                    "profile",
                     "-m",
                     "test_model",
                     "--output-tokens-mean-deterministic",
@@ -484,6 +505,7 @@ class TestCLIArguments:
             (
                 [
                     "genai-perf",
+                    "profile",
                     "-m",
                     "test_model",
                     "--output-tokens-mean-deterministic",
@@ -493,6 +515,7 @@ class TestCLIArguments:
             (
                 [
                     "genai-perf",
+                    "profile",
                     "-m",
                     "test_model",
                     "--service-kind",
@@ -508,6 +531,7 @@ class TestCLIArguments:
             (
                 [
                     "genai-perf",
+                    "profile",
                     "-m",
                     "test_model",
                     "--batch-size",
@@ -518,6 +542,7 @@ class TestCLIArguments:
             (
                 [
                     "genai-perf",
+                    "profile",
                     "-m",
                     "test_model",
                     "--service-kind",
@@ -531,6 +556,7 @@ class TestCLIArguments:
             (
                 [
                     "genai-perf",
+                    "profile",
                     "-m",
                     "test_model",
                     "--service-kind",
@@ -544,6 +570,7 @@ class TestCLIArguments:
             (
                 [
                     "genai-perf",
+                    "profile",
                     "-m",
                     "test_model",
                     "--service-kind",
@@ -557,6 +584,7 @@ class TestCLIArguments:
             (
                 [
                     "genai-perf",
+                    "profile",
                     "-m",
                     "test_model",
                     "--service-kind",
@@ -613,7 +641,9 @@ class TestCLIArguments:
         ],
     )
     def test_inferred_output_format(self, monkeypatch, args, expected_format):
-        monkeypatch.setattr("sys.argv", ["genai-perf", "-m", "test_model"] + args)
+        monkeypatch.setattr(
+            "sys.argv", ["genai-perf", "profile", "-m", "test_model"] + args
+        )
 
         parsed_args, _ = parser.parse_args()
         assert parsed_args.output_format == expected_format
@@ -644,7 +674,7 @@ class TestCLIArguments:
         ],
     )
     def test_repeated_extra_arg_warning(self, monkeypatch, args, expected_error):
-        combined_args = ["genai-perf", "-m", "test_model"] + args
+        combined_args = ["genai-perf", "profile", "-m", "test_model"] + args
         monkeypatch.setattr("sys.argv", combined_args)
 
         parsed_args, _ = parser.parse_args()
@@ -672,7 +702,7 @@ class TestCLIArguments:
         _ = mocker.patch("builtins.open", mocker.mock_open(read_data="data"))
         _ = mocker.patch("os.path.isfile", return_value=True)
         _ = mocker.patch("os.path.isdir", return_value=True)
-        combined_args = ["genai-perf", "--model", "test_model"] + args
+        combined_args = ["genai-perf", "profile", "--model", "test_model"] + args
         monkeypatch.setattr("sys.argv", combined_args)
         args, _ = parser.parse_args()
 
@@ -684,6 +714,7 @@ class TestCLIArguments:
         _ = mocker.patch("os.path.isdir", return_value=True)
         args = [
             "genai-perf",
+            "profile",
             "--model",
             "test_model",
             "--input-dataset",
@@ -757,20 +788,6 @@ class TestCLIArguments:
         assert excinfo.value.code != 0
         captured = capsys.readouterr()
         assert expected_output in captured.err
-
-    @pytest.mark.parametrize(
-        "args, expected_model",
-        [
-            (["--files", "profile1.json", "profile2.json", "profile3.json"], None),
-            (["--config", "config.yaml"], None),
-        ],
-    )
-    def test_compare_model_arg(self, monkeypatch, args, expected_model):
-        combined_args = ["genai-perf", "compare"] + args
-        monkeypatch.setattr("sys.argv", combined_args)
-        args, _ = parser.parse_args()
-
-        assert args.model == expected_model
 
     @pytest.mark.parametrize(
         "extra_inputs_list, expected_dict",

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -52,10 +52,7 @@ class TestCLIArguments:
         [
             (["-h"], expected_help_output),
             (["--help"], expected_help_output),
-            (["-m", "abc", "--help"], expected_help_output),
-            (["-m", "abc", "-h"], expected_help_output),
             (["--version"], expected_version_output),
-            (["-m", "abc", "--version"], expected_version_output),
         ],
     )
     def test_help_version_arguments_output_and_exit(

--- a/src/c++/perf_analyzer/genai-perf/tests/test_console_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_console_exporter.py
@@ -35,6 +35,7 @@ class TestConsoleExporter:
     def test_streaming_llm_output(self, monkeypatch, capsys) -> None:
         argv = [
             "genai-perf",
+            "profile",
             "-m",
             "model_name",
             "--service-kind",
@@ -86,6 +87,7 @@ class TestConsoleExporter:
     def test_nonstreaming_llm_output(self, monkeypatch, capsys) -> None:
         argv = [
             "genai-perf",
+            "profile",
             "-m",
             "model_name",
             "--service-kind",
@@ -135,6 +137,7 @@ class TestConsoleExporter:
     def test_embedding_output(self, monkeypatch, capsys) -> None:
         argv = [
             "genai-perf",
+            "profile",
             "-m",
             "model_name",
             "--service-kind",

--- a/src/c++/perf_analyzer/genai-perf/tests/test_csv_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_csv_exporter.py
@@ -71,6 +71,7 @@ class TestCsvExporter:
         """
         argv = [
             "genai-perf",
+            "profile",
             "-m",
             "model_name",
             "--service-kind",
@@ -126,6 +127,7 @@ class TestCsvExporter:
         """
         argv = [
             "genai-perf",
+            "profile",
             "-m",
             "model_name",
             "--service-kind",
@@ -174,6 +176,7 @@ class TestCsvExporter:
     ) -> None:
         argv = [
             "genai-perf",
+            "profile",
             "-m",
             "model_name",
             "--service-kind",

--- a/src/c++/perf_analyzer/genai-perf/tests/test_json_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_json_exporter.py
@@ -35,6 +35,7 @@ class TestJsonExporter:
     def test_generate_json(self, monkeypatch) -> None:
         cli_cmd = [
             "genai-perf",
+            "profile",
             "-m",
             "gpt2_vllm",
             "--backend",
@@ -257,7 +258,7 @@ class TestJsonExporter:
           "artifact_dir": "artifacts/gpt2_vllm-triton-vllm-concurrency1",
           "tokenizer": "hf-internal-testing/llama-tokenizer",
           "verbose": false,
-          "subcommand": null,
+          "subcommand": "profile",
           "prompt_source": "synthetic",
           "extra_inputs": {
             "max_tokens": 256,

--- a/src/c++/perf_analyzer/genai-perf/tests/test_wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_wrapper.py
@@ -43,7 +43,14 @@ class TestWrapper:
         ],
     )
     def test_url_exactly_once_triton(self, monkeypatch, arg):
-        args = ["genai-perf", "-m", "test_model", "--service-kind", "triton"] + arg
+        args = [
+            "genai-perf",
+            "profile",
+            "-m",
+            "test_model",
+            "--service-kind",
+            "triton",
+        ] + arg
         monkeypatch.setattr("sys.argv", args)
         args, extra_args = parser.parse_args()
         cmd = Profiler.build_cmd(args, extra_args)
@@ -70,7 +77,14 @@ class TestWrapper:
         ],
     )
     def test_profile_export_filepath(self, monkeypatch, arg, expected_filepath):
-        args = ["genai-perf", "-m", "test_model", "--service-kind", "triton"] + arg
+        args = [
+            "genai-perf",
+            "profile",
+            "-m",
+            "test_model",
+            "--service-kind",
+            "triton",
+        ] + arg
         monkeypatch.setattr("sys.argv", args)
         args, extra_args = parser.parse_args()
         cmd = Profiler.build_cmd(args, extra_args)
@@ -87,7 +101,14 @@ class TestWrapper:
         ],
     )
     def test_service_triton(self, monkeypatch, arg):
-        args = ["genai-perf", "-m", "test_model", "--service-kind", "triton"] + arg
+        args = [
+            "genai-perf",
+            "profile",
+            "-m",
+            "test_model",
+            "--service-kind",
+            "triton",
+        ] + arg
         monkeypatch.setattr("sys.argv", args)
         args, extra_args = parser.parse_args()
         cmd = Profiler.build_cmd(args, extra_args)
@@ -111,6 +132,7 @@ class TestWrapper:
     def test_service_openai(self, monkeypatch, arg):
         args = [
             "genai-perf",
+            "profile",
             "-m",
             "test_model",
             "--service-kind",


### PR DESCRIPTION
With compare being moved into a subcommand, there should be a profile subcommand for profiling with GenAI-Perf. Currently, those args just float so `genai-perf compare <args>` is used for compare but `genai-perf <args>` does not. This is inconsistent and can lead to special handling or errors with parsing.

With this change, `genai-perf <profile>` is the sole entryway for profiling models via GenAI-Perf. All documentation and tests are cleaned up as well.