### PR TITLE
feat: Treat HTTP request completion as final response

### DIFF
--- a/src/c++/perf_analyzer/client_backend/openai/openai_client.cc
+++ b/src/c++/perf_analyzer/client_backend/openai/openai_client.cc
@@ -181,8 +181,8 @@ ChatCompletionClient::AsyncInfer(
         triton::client::RequestTimers::Kind::REQUEST_END);
     UpdateInferStat(request->timer_);
 
-    // Send Response checks if a final
-    // response has already been sent
+    // Send final response on request completion
+    // Ignored if final response has already been sent
     // (in the case of seeing [DONE] in streaming case)
     request->SendResponse(true /* is_final */, false /* is_null */);
   };

--- a/src/c++/perf_analyzer/client_backend/openai/openai_client.h
+++ b/src/c++/perf_analyzer/client_backend/openai/openai_client.h
@@ -121,6 +121,7 @@ class ChatCompletionRequest : public HttpRequest {
         request_id_(request_id)
   {
   }
+  bool IsFinalResponseSent() { return final_response_sent_; };
   void SendResponse(bool is_final, bool is_null);
   bool is_stream_{false};
   std::function<void(InferResult*)> response_callback_{nullptr};


### PR DESCRIPTION
For HTTP streaming endpoints which do not explicitly send a `[DONE]` message, updated to treat the HTTP request completion as a final response. 

This is backwards compatible and doesn't effect endpoints that do explicitly send `[DONE]`.

This is one change needed for Triton Generate as well as some TGI interfaces / servers.

Checks are added to ensure only a single final response is sent. 