### PR TITLE
When JSON parsing fails, return the failed string

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -24,6 +24,7 @@ from genai_perf.constants import CNN_DAILY_MAIL, DEFAULT_INPUT_DATA_JSON, OPEN_O
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.llm_inputs.synthetic_prompt_generator import SyntheticPromptGenerator
 from genai_perf.tokenizer import DEFAULT_TOKENIZER, Tokenizer, get_tokenizer
+from genai_perf.utils import load_json_str
 from requests import Response
 
 
@@ -315,7 +316,7 @@ class LlmInputs:
         cls, input_filename: Path, batch_size: int, num_prompts: int
     ) -> Dict[str, Any]:
         with open(input_filename, "r") as file:
-            file_content = [json.loads(line) for line in file]
+            file_content = [load_json_str(line) for line in file]
 
         texts = [item["text"] for item in file_content]
 
@@ -344,11 +345,11 @@ class LlmInputs:
     ) -> Dict[str, Any]:
 
         with open(queries_filename, "r") as file:
-            queries_content = [json.loads(line) for line in file]
+            queries_content = [load_json_str(line) for line in file]
         queries_texts = [item for item in queries_content]
 
         with open(passages_filename, "r") as file:
-            passages_content = [json.loads(line) for line in file]
+            passages_content = [load_json_str(line) for line in file]
         passages_texts = [item for item in passages_content]
 
         if batch_size > len(passages_texts):
@@ -363,7 +364,7 @@ class LlmInputs:
         for _ in range(num_prompts):
             sampled_texts = random.sample(passages_texts, batch_size)
             query_sample = random.choice(queries_texts)
-            entry_dict = {}
+            entry_dict: Dict = {}
             entry_dict["query"] = query_sample
             entry_dict["passages"] = sampled_texts
             dataset_json["rows"].append({"row": {"payload": entry_dict}})
@@ -536,7 +537,7 @@ class LlmInputs:
         with open(input_filename, mode="r", newline=None) as file:
             for line in file:
                 if line.strip():
-                    prompts.append(json.loads(line).get("text_input", "").strip())
+                    prompts.append(load_json_str(line).get("text_input", "").strip())
         return prompts
 
     @classmethod

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -586,7 +586,7 @@ def get_extra_inputs_as_dict(args: argparse.Namespace) -> dict:
     if args.extra_inputs:
         for input_str in args.extra_inputs:
             if input_str.startswith("{") and input_str.endswith("}"):
-                request_inputs.update(json.loads(input_str))
+                request_inputs.update(utils.load_json_str(input_str))
             else:
                 semicolon_count = input_str.count(":")
                 if semicolon_count != 1:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -37,7 +37,7 @@ from genai_perf.profile_data_parser.profile_data_parser import (
     ResponseFormat,
 )
 from genai_perf.tokenizer import Tokenizer
-from genai_perf.utils import remove_sse_prefix
+from genai_perf.utils import load_json_str, remove_sse_prefix
 
 
 class LLMProfileDataParser(ProfileDataParser):
@@ -178,7 +178,7 @@ class LLMProfileDataParser(ProfileDataParser):
                 response = res_outputs[i]["response"]
                 responses = response.strip().split("\n\n")
                 if len(responses) > 1:
-                    merged_response = json.loads(remove_sse_prefix(responses[0]))
+                    merged_response = load_json_str(remove_sse_prefix(responses[0]))
                     if (
                         merged_response["choices"][0]["delta"].get("content", None)
                         is None
@@ -213,7 +213,7 @@ class LLMProfileDataParser(ProfileDataParser):
 
     def _get_openai_input_text(self, req_inputs: dict) -> str:
         """Tokenize the OpenAI request input texts."""
-        payload = json.loads(req_inputs["payload"])
+        payload = load_json_str(req_inputs["payload"])
         if self._response_format == ResponseFormat.OPENAI_CHAT_COMPLETIONS:
             return payload["messages"][0]["content"]
         elif self._response_format == ResponseFormat.OPENAI_COMPLETIONS:
@@ -268,7 +268,7 @@ class LLMProfileDataParser(ProfileDataParser):
         if response == "[DONE]":
             return ""
 
-        data = json.loads(response)
+        data = load_json_str(response)
         completions = data["choices"][0]
 
         text_output = ""

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
@@ -54,12 +54,7 @@ def load_yaml(filepath: Path) -> Dict[str, Any]:
 def load_json(filepath: Path) -> Dict[str, Any]:
     with open(str(filepath), encoding="utf-8", errors="ignore") as f:
         content = f.read()
-        try:
-            return json.loads(content)
-        except json.JSONDecodeError:
-            snippet = content[:200] + ("..." if len(content) > 200 else "")
-            logger.error("Failed to parse JSON string: '%s'", snippet)
-            raise
+        load_json_str(content)
 
 
 def load_json_str(json_str: str) -> Dict[str, Any]:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
@@ -29,9 +29,13 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type
 
+import genai_perf.logging as logging
+
 # Skip type checking to avoid mypy error
 # Issue: https://github.com/python/mypy/issues/10632
 import yaml  # type: ignore
+
+logger = logging.getLogger(__name__)
 
 
 def remove_sse_prefix(msg: str) -> str:
@@ -49,7 +53,13 @@ def load_yaml(filepath: Path) -> Dict[str, Any]:
 
 def load_json(filepath: Path) -> Dict[str, Any]:
     with open(str(filepath), encoding="utf-8", errors="ignore") as f:
-        return json.load(f)
+        content = f.read()
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            snippet = content[:200] + ("..." if len(content) > 200 else "")
+            logger.error("Failed to parse JSON string: '%s'", snippet)
+            raise
 
 
 def remove_file(file: Path) -> None:

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
@@ -62,6 +62,15 @@ def load_json(filepath: Path) -> Dict[str, Any]:
             raise
 
 
+def load_json_str(json_str: str) -> Dict[str, Any]:
+    try:
+        return json.loads(json_str)
+    except json.JSONDecodeError:
+        snippet = json_str[:200] + ("..." if len(json_str) > 200 else "")
+        logger.error("Failed to parse JSON string: '%s'", snippet)
+        raise
+
+
 def remove_file(file: Path) -> None:
     if file.is_file():
         file.unlink()

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/utils.py
@@ -54,7 +54,7 @@ def load_yaml(filepath: Path) -> Dict[str, Any]:
 def load_json(filepath: Path) -> Dict[str, Any]:
     with open(str(filepath), encoding="utf-8", errors="ignore") as f:
         content = f.read()
-        load_json_str(content)
+        return load_json_str(content)
 
 
 def load_json_str(json_str: str) -> Dict[str, Any]:


### PR DESCRIPTION
When JSON parsing fails in GenAI-Perf, return the string that failed to be parsed (up to 200 characters). This will help with debugging when the string is not in the format JSON expects.

Before changes:
![image](https://github.com/triton-inference-server/client/assets/58150256/39452fb9-e111-476f-8c6c-d29e49d8ee90)

After changes:
![image](https://github.com/triton-inference-server/client/assets/58150256/c1ea5390-6c49-4cf9-b137-a2d4e00ee47e)

Note: This would be more useful for shorter strings (e.g. invalid response formats).