### PR TITLE
Random image format in SyntheticImageGenerator

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_image_generator.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_image_generator.py
@@ -28,7 +28,7 @@ import glob
 import random
 from enum import Enum, auto
 from pathlib import Path
-from typing import Optional, cast
+from typing import Optional
 
 from genai_perf import utils
 from PIL import Image

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_image_generator.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_image_generator.py
@@ -28,6 +28,7 @@ import glob
 import random
 from enum import Enum, auto
 from pathlib import Path
+from typing import Optional, cast
 
 from genai_perf import utils
 from PIL import Image
@@ -50,9 +51,13 @@ class SyntheticImageGenerator:
         image_width_stddev: int,
         image_height_mean: int,
         image_height_stddev: int,
-        image_format: ImageFormat,
+        image_format: Optional[ImageFormat] = None,
     ) -> str:
         """Generate base64 encoded synthetic image using the source images."""
+        if image_format is None:
+            image_formats = list(ImageFormat)
+        else:
+            image_formats = [cast(ImageFormat, image_format)]
         width = cls._sample_random_positive_integer(
             image_width_mean, image_width_stddev
         )
@@ -63,8 +68,9 @@ class SyntheticImageGenerator:
         image = cls._sample_source_image()
         image = image.resize(size=(width, height))
 
-        img_base64 = utils.encode_image(image, image_format.name)
-        return f"data:image/{image_format.name.lower()};base64,{img_base64}"
+        selected_format = random.choice(image_formats)
+        img_base64 = utils.encode_image(image, selected_format.name)
+        return f"data:image/{selected_format.name.lower()};base64,{img_base64}"
 
     @classmethod
     def _sample_source_image(cls):

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_image_generator.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/synthetic_image_generator.py
@@ -55,9 +55,7 @@ class SyntheticImageGenerator:
     ) -> str:
         """Generate base64 encoded synthetic image using the source images."""
         if image_format is None:
-            image_formats = list(ImageFormat)
-        else:
-            image_formats = [cast(ImageFormat, image_format)]
+            image_format = random.choice(list(ImageFormat))
         width = cls._sample_random_positive_integer(
             image_width_mean, image_width_stddev
         )
@@ -68,9 +66,8 @@ class SyntheticImageGenerator:
         image = cls._sample_source_image()
         image = image.resize(size=(width, height))
 
-        selected_format = random.choice(image_formats)
-        img_base64 = utils.encode_image(image, selected_format.name)
-        return f"data:image/{selected_format.name.lower()};base64,{img_base64}"
+        img_base64 = utils.encode_image(image, image_format.name)
+        return f"data:image/{image_format.name.lower()};base64,{img_base64}"
 
     @classmethod
     def _sample_source_image(cls):

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -476,9 +476,9 @@ def _add_image_input_args(parser):
         "--image-format",
         type=str,
         choices=utils.get_enum_names(ImageFormat),
-        default="png",
         required=False,
-        help=f"The compression format of the images.",
+        help=f"The compression format of the images. "
+        "If format is not selected, format of generated image is selected at random",
     )
 
 

--- a/src/c++/perf_analyzer/genai-perf/tests/test_json_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_json_exporter.py
@@ -253,7 +253,7 @@ class TestJsonExporter:
           "image_width_stddev": 0,
           "image_height_mean": 100,
           "image_height_stddev": 0,
-          "image_format": "png",
+          "image_format": null,
           "concurrency": 1,
           "measurement_interval": 10000,
           "request_rate": null,

--- a/src/c++/perf_analyzer/genai-perf/tests/test_synthetic_image_generator.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_synthetic_image_generator.py
@@ -99,8 +99,18 @@ def test_base64_encoding_with_different_formats(image_format):
     assert image.format == image_format.name
 
 
-def test_null_format_is_accepted():
-    img_base64 = SyntheticImageGenerator.create_synthetic_image(
+def test_random_image_format():
+    random.seed(123)
+    img1 = SyntheticImageGenerator.create_synthetic_image(
+        image_width_mean=100,
+        image_width_stddev=100,
+        image_height_mean=100,
+        image_height_stddev=100,
+        image_format=None,
+    )
+
+    random.seed(456)
+    img2 = SyntheticImageGenerator.create_synthetic_image(
         image_width_mean=100,
         image_width_stddev=100,
         image_height_mean=100,
@@ -109,12 +119,5 @@ def test_null_format_is_accepted():
     )
 
     # check prefix
-    expected_prefix = "data:image/"
-    assert img_base64.startswith(expected_prefix), "unexpected prefix"
-
-    # check image format
-    data = img_base64.split(",")[1]
-    img_data = base64.b64decode(data)
-    img_bytes = BytesIO(img_data)
-    image = Image.open(img_bytes)
-    assert image.format in [f.name for f in ImageFormat]
+    assert img1.startswith("data:image/png")
+    assert img2.startswith("data:image/jpeg")

--- a/src/c++/perf_analyzer/genai-perf/tests/test_synthetic_image_generator.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_synthetic_image_generator.py
@@ -97,3 +97,24 @@ def test_base64_encoding_with_different_formats(image_format):
     img_bytes = BytesIO(img_data)
     image = Image.open(img_bytes)
     assert image.format == image_format.name
+
+
+def test_null_format_is_accepted():
+    img_base64 = SyntheticImageGenerator.create_synthetic_image(
+        image_width_mean=100,
+        image_width_stddev=100,
+        image_height_mean=100,
+        image_height_stddev=100,
+        image_format=None,
+    )
+
+    # check prefix
+    expected_prefix = "data:image/"
+    assert img_base64.startswith(expected_prefix), "unexpected prefix"
+
+    # check image format
+    data = img_base64.split(",")[1]
+    img_data = base64.b64decode(data)
+    img_bytes = BytesIO(img_data)
+    image = Image.open(img_bytes)
+    assert image.format in [f.name for f in ImageFormat]


### PR DESCRIPTION
With this MR, no image format is selected by default.
If no specific format is selected, the format will be selected at random for each generated image.
That simulates the case, where model users uses images of different format during conversation.