### PR TITLE
variable number of images per prompt

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -195,13 +195,7 @@ class LlmInputs:
         """
 
         cls._check_for_valid_args(
-            input_type,
-            dataset_name,
-            starting_index,
-            length,
-            tokenizer,
-            images_count_min,
-            images_count_max,
+            input_type, dataset_name, starting_index, length, tokenizer
         )
 
         random.seed(random_seed)
@@ -472,15 +466,12 @@ class LlmInputs:
         starting_index: int,
         length: int,
         tokenizer: Tokenizer,
-        images_count_min: int,
-        images_count_max: int,
     ) -> None:
         try:
             cls._check_for_dataset_name_if_input_type_is_url(input_type, dataset_name)
             cls._check_for_tokenzier_if_input_type_is_synthetic(input_type, tokenizer)
             cls._check_for_valid_starting_index(starting_index)
             cls._check_for_valid_length(length)
-            cls._check_for_valid_multimodal_args(images_count_min, images_count_max)
 
         except Exception as e:
             raise GenAIPerfException(e)
@@ -1567,29 +1558,6 @@ class LlmInputs:
         if length < cls.MINIMUM_LENGTH:
             raise GenAIPerfException(
                 f"starting_index: {length} must be larger than {cls.MINIMUM_LENGTH}."
-            )
-
-    @classmethod
-    def _check_for_valid_multimodal_args(
-        cls, images_count_min: int, images_count_max: int
-    ) -> None:
-        if not isinstance(images_count_min, int):
-            raise GenAIPerfException(
-                f"images_count_min: {images_count_min} must be an integer."
-            )
-
-        if images_count_min < 0:
-            raise GenAIPerfException(
-                f"images_count_min: {images_count_min} must be a positive number."
-            )
-        if not isinstance(images_count_max, int):
-            raise GenAIPerfException(
-                f"images_count_max: {images_count_max} must be an integer."
-            )
-
-        if images_count_max < images_count_min:
-            raise GenAIPerfException(
-                f"images_count_max: {images_count_max} must be greater than images_count_min {images_count_min}"
             )
 
     @classmethod

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/llm_inputs/llm_inputs.py
@@ -640,6 +640,7 @@ class LlmInputs:
         dataset_json["features"] = [{"name": "text_input"}]
         dataset_json["rows"] = []
         for prompt, image in zip(prompts, images):
+            # (TMA-2004) support variable images per request through input file
             content: Dict[str, Any] = {"text_input": prompt}
             content.update({"images": [image]} if image else {})
             dataset_json["rows"].append({"row": content})

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -132,9 +132,11 @@ def _check_image_input_args(
             "Both --image-width-stddev and --image-height-stddev values must be non-negative."
         )
     if args.images_count_min < 0:
-        parser.error("--images-count-min must be a positive integer.")
+        parser.error("--images-count-min must be a non-negative integer.")
     if args.images_count_max < args.images_count_min:
-        parser.error("--images-count-max must be greater than --images-count-min.")
+        parser.error(
+            "--images-count-max must be greater than or equal to --images-count-min."
+        )
 
     args = _convert_str_to_enum_entry(args, "image_format", ImageFormat)
     return args

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -131,6 +131,10 @@ def _check_image_input_args(
         parser.error(
             "Both --image-width-stddev and --image-height-stddev values must be non-negative."
         )
+    if args.images_count_min < 0:
+        parser.error("--images-count-min must be a positive integer.")
+    if args.images_count_max < args.images_count_min:
+        parser.error("--images-count-max must be greater than --images-count-min.")
 
     args = _convert_str_to_enum_entry(args, "image_format", ImageFormat)
     return args
@@ -479,6 +483,22 @@ def _add_image_input_args(parser):
         required=False,
         help=f"The compression format of the images. "
         "If format is not selected, format of generated image is selected at random",
+    )
+
+    input_group.add_argument(
+        "--images-count-min",
+        type=int,
+        default=LlmInputs.DEFAULT_IMAGES_COUNT_MIN,
+        required=False,
+        help=f"Minimum number of synthetic images to be added to a prompt.",
+    )
+
+    input_group.add_argument(
+        "--images-count-max",
+        type=int,
+        default=LlmInputs.DEFAULT_IMAGES_COUNT_MAX,
+        required=False,
+        help=f"Maximum number of synthetic images to be added to a prompt.",
     )
 
 

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -220,6 +220,8 @@ class LLMProfileDataParser(ProfileDataParser):
             return payload["prompt"]
         elif self._response_format == ResponseFormat.OPENAI_VISION:
             content = payload["messages"][0]["content"]
+            if isinstance(content, str):
+                return content
             return " ".join(c["text"] for c in content if c["type"] == "text")
         else:
             raise ValueError(

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -220,6 +220,8 @@ class LLMProfileDataParser(ProfileDataParser):
             return payload["prompt"]
         elif self._response_format == ResponseFormat.OPENAI_VISION:
             content = payload["messages"][0]["content"]
+            # When no images were included in the request input, the content
+            # is same as text-only chat completions format (e.g. string).
             if isinstance(content, str):
                 return content
             return " ".join(c["text"] for c in content if c["type"] == "text")

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -98,6 +98,8 @@ class Profiler:
             "image_height_mean",
             "image_height_stddev",
             "image_format",
+            "images_count_min",
+            "images_count_max",
         ]
 
         utils.remove_file(args.profile_export_file)

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -234,6 +234,10 @@ class TestCLIArguments:
                 {"image_height_stddev": 456},
             ),
             (["--image-format", "png"], {"image_format": ImageFormat.PNG}),
+            (
+                ["--images-count-min", "123", "--images-count-max", "321"],
+                {"images_count_min": 123, "images_count_max": 321},
+            ),
             (["-v"], {"verbose": True}),
             (["--verbose"], {"verbose": True}),
             (["-u", "test_url"], {"u": "test_url"}),

--- a/src/c++/perf_analyzer/genai-perf/tests/test_json_exporter.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_json_exporter.py
@@ -254,6 +254,8 @@ class TestJsonExporter:
           "image_height_mean": 100,
           "image_height_stddev": 0,
           "image_format": null,
+          "images_count_min": 0,
+          "images_count_max": 1,
           "concurrency": 1,
           "measurement_interval": 10000,
           "request_rate": null,

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_inputs.py
@@ -557,8 +557,8 @@ class TestLlmInputs:
     def test_add_image_inputs_openai_vision(self) -> None:
         generic_json = {
             "rows": [
-                {"text_input": "test input one", "image": "test_image1"},
-                {"text_input": "test input two", "image": "test_image2"},
+                {"text_input": "test input one", "images": ["test_image1"]},
+                {"text_input": "test input two", "images": ["test_image2"]},
             ]
         }
 
@@ -608,8 +608,12 @@ class TestLlmInputs:
             OutputFormat.TENSORRTLLM,
         ],
     )
+    @pytest.mark.parametrize(
+        "images_count",
+        [0, 5],
+    )
     def test_get_input_dataset_from_synthetic(
-        self, mock_prompt, mock_image, output_format
+        self, mock_prompt, mock_image, output_format, images_count
     ) -> None:
         _placeholder = 123  # dummy value
         num_prompts = 3
@@ -624,6 +628,8 @@ class TestLlmInputs:
             image_height_mean=_placeholder,
             image_height_stddev=_placeholder,
             image_format=ImageFormat.PNG,
+            images_count_min=images_count,
+            images_count_max=images_count,
             output_format=output_format,
         )
 
@@ -635,7 +641,7 @@ class TestLlmInputs:
             if output_format == OutputFormat.OPENAI_VISION:
                 assert row == {
                     "text_input": "This is test prompt",
-                    "image": "test_image_base64",
+                    "images": images_count * ["test_image_base64"],
                 }
             else:
                 assert row == {
@@ -805,7 +811,7 @@ class TestLlmInputs:
         assert len(dataset["rows"]) == len(expected_data)
         for i, data in enumerate(expected_data):
             assert dataset["rows"][i]["row"]["text_input"] == data.text_input
-            assert dataset["rows"][i]["row"]["image"] == data.image
+            assert dataset["rows"][i]["row"]["images"] == [data.image]
 
     @pytest.mark.parametrize(
         "seed, model_name_list, index,model_selection_strategy,expected_model",

--- a/src/c++/perf_analyzer/genai-perf/tests/test_llm_profile_data_parser.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_llm_profile_data_parser.py
@@ -649,7 +649,7 @@ class TestLLMProfileDataParser:
                     {
                         "timestamp": 2,
                         "request_inputs": {
-                            "payload": '{"messages":[{"role":"user","content":[{"type":"text","text":"This is test too"},{"type":"image_url","image_url":{"url":"data:image/png;base64,abcdef"}}]}],"model":"llava-1.6","stream":true}',
+                            "payload": '{"messages":[{"role":"user","content":"This is test too"}],"model":"llava-1.6","stream":true}',
                         },
                         # the first, and the last two responses will be ignored because they have no "content"
                         "response_timestamps": [4, 7, 11, 15, 18, 19],


### PR DESCRIPTION
With this MR, genai-perf can add random number of images per request. The number of images is sampled uniformly from a range controlled by `--images-count-min` and `--images-count-max` CLI arguments.