### PR TITLE
Support input payload generation for tensorrtllm engine

### DIFF
--- a/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/parser.py
@@ -191,10 +191,11 @@ def _check_conditional_args(
                 "The --output-tokens-mean option is required when using --output-tokens-mean-deterministic."
             )
 
-    if args.service_kind != "triton":
+    if args.service_kind not in ["triton", "tensorrtllm_engine"]:
         if args.output_tokens_mean_deterministic:
             parser.error(
-                "The --output-tokens-mean-deterministic option is only supported with the Triton service-kind."
+                "The --output-tokens-mean-deterministic option is only supported "
+                "with the Triton and TensorRT-LLM Engine service-kind."
             )
 
     _check_conditional_args_embeddings_rankings(parser, args)

--- a/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
+++ b/src/c++/perf_analyzer/genai-perf/genai_perf/wrapper.py
@@ -122,6 +122,13 @@ class Profiler:
                     cmd += [f"-{arg}"]
                 else:
                     cmd += [f"--{arg}"]
+
+            # (TPA-237) GAP needs to call PA using triton_c_api service kind.
+            # Currently, it just calls using triton service kind to verify that
+            # it runs.
+            elif arg == "service_kind" and value == "tensorrtllm_engine":
+                cmd += ["--service-kind", "triton"]
+                args.service_kind = "triton"
             else:
                 if len(arg) == 1:
                     cmd += [f"-{arg}", f"{value}"]

--- a/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
+++ b/src/c++/perf_analyzer/genai-perf/tests/test_cli.py
@@ -546,7 +546,7 @@ class TestCLIArguments:
                     "100",
                     "--output-tokens-mean-deterministic",
                 ],
-                "The --output-tokens-mean-deterministic option is only supported with the Triton service-kind",
+                "The --output-tokens-mean-deterministic option is only supported with the Triton and TensorRT-LLM Engine service-kind",
             ),
             (
                 [


### PR DESCRIPTION
Generates input json file for PA to directly send requests to tensorrtllm engine:
```
{
   "data":[
      {
         "input_ids":{
            "content":[
               1243,
               1881,
               697
            ],
            "shape":[
               3
            ]
         },
         "input_lengths":[
            3
         ],
         "request_output_len":[
            256
         ]
      },
      ...
}
```