### PR TITLE
Cancel the requests in streaming case by default when closing the connection

### DIFF
--- a/src/python/library/tritonclient/grpc/_client.py
+++ b/src/python/library/tritonclient/grpc/_client.py
@@ -256,12 +256,12 @@ class InferenceServerClient(InferenceServerClientBase):
     def __del__(self):
         self.close()
 
-    def close(self):
+    def close(self, cancel_requests=True):
         """Close the client. Any future calls to server
         will result in an Error.
 
         """
-        self.stop_stream()
+        self.stop_stream(cancel_requests)
         self._channel.close()
 
     def is_server_live(self, headers=None, client_timeout=None):


### PR DESCRIPTION
Match the behaviour of non-streaming case.