### PR TITLE
Enabling Ninja build

### DIFF
--- a/src/c++/library/CMakeLists.txt
+++ b/src/c++/library/CMakeLists.txt
@@ -182,7 +182,7 @@ if(TRITON_ENABLE_CC_GRPC)
   #
   # libgrpcclient.so and libgrpcclient_static.a
   #
-  configure_file(libgrpcclient.ldscript libgrpcclient.ldscript COPYONLY)
+  configure_file(libgrpcclient.ldscript ${CMAKE_CURRENT_BINARY_DIR}/libgrpcclient.ldscript COPYONLY)
 
   # libgrpcclient object build
   set(
@@ -245,7 +245,7 @@ if(TRITON_ENABLE_CC_GRPC)
        grpcclient
        PROPERTIES
          LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libgrpcclient.ldscript
-         LINK_FLAGS "-Wl,--version-script=libgrpcclient.ldscript"
+         LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/libgrpcclient.ldscript"
      )
   endif() # NOT WIN32 AND NOT TRITON_KEEP_TYPEINFO
 


### PR DESCRIPTION
The current setup for the libgrpcclient.ldscript file may work fine with GNU make at the moment, but confuses [Ninja](https://ninja-build.org/). This will fix the build for Ninja, while hopefully letting the rest of the build work when using the GNU Makefile generator.