### PR TITLE
Remove unnecessary linking of CUDA Runtime library

### DIFF
--- a/src/c++/library/CMakeLists.txt
+++ b/src/c++/library/CMakeLists.txt
@@ -291,10 +291,8 @@ if(TRITON_ENABLE_CC_GRPC)
     endif() # TRITON_ENABLE_GPU
 
     if(TRITON_ENABLE_GPU)
-      target_link_libraries(
-        ${_client_target}
-        PUBLIC CUDA::cudart
-      )
+      target_include_directories(${_client_target}
+                                 PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
     endif() # TRITON_ENABLE_GPU
   endforeach()
 
@@ -477,10 +475,8 @@ if(TRITON_ENABLE_CC_HTTP)
     endif() # TRITON_ENABLE_GPU
 
     if(TRITON_ENABLE_GPU)
-      target_link_libraries(
-        ${_client_target}
-        PUBLIC CUDA::cudart
-      )
+      target_include_directories(${_client_target}
+                                 PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
     endif() # TRITON_ENABLE_GPU
 
     if(${TRITON_ENABLE_ZLIB})


### PR DESCRIPTION
The Triton C++ client libraries do not actually use symbols in the CUDA Runtime library (`libcudart.so`).

So there's no need to `target_link_libraries()` to `CUDA::cudart`.

All they needed was access to `#include <cuda_runtime_api.h>` (which was implicitly being included by doing `target_link_libraries()`).

So I removed the `target_link_libraries ()`s and added `target_include_directories()`s.