### PR TITLE
Revert "Remove unnecessary linking of CUDA Runtime library"

### DIFF
--- a/src/c++/library/CMakeLists.txt
+++ b/src/c++/library/CMakeLists.txt
@@ -291,8 +291,10 @@ if(TRITON_ENABLE_CC_GRPC)
     endif() # TRITON_ENABLE_GPU
 
     if(TRITON_ENABLE_GPU)
-      target_include_directories(${_client_target}
-                                 PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
+      target_link_libraries(
+        ${_client_target}
+        PUBLIC CUDA::cudart
+      )
     endif() # TRITON_ENABLE_GPU
   endforeach()
 
@@ -475,8 +477,10 @@ if(TRITON_ENABLE_CC_HTTP)
     endif() # TRITON_ENABLE_GPU
 
     if(TRITON_ENABLE_GPU)
-      target_include_directories(${_client_target}
-                                 PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
+      target_link_libraries(
+        ${_client_target}
+        PUBLIC CUDA::cudart
+      )
     endif() # TRITON_ENABLE_GPU
 
     if(${TRITON_ENABLE_ZLIB})


### PR DESCRIPTION
Reverts triton-inference-server/client#798