### PR TITLE
Enable support for Ubuntu 24.04

### DIFF
--- a/src/java-api-bindings/scripts/install_dependencies_and_build.sh
+++ b/src/java-api-bindings/scripts/install_dependencies_and_build.sh
@@ -121,7 +121,7 @@ if [ ${INCLUDE_DEVELOPER_TOOLS_SERVER} -ne 0 ]; then
         echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $UBUNTU_CODENAME main" | \
         tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
         apt-get update && \
-        apt-get install -y --no-install-recommends cmake=3.27.7* cmake-data=3.27.7* rapidjson-dev
+        apt-get install -y --no-install-recommends cmake=3.28.3* cmake-data=3.28.3* rapidjson-dev
 fi
 
 # Install jdk and maven


### PR DESCRIPTION
This PR enables support for Ubuntu 24.04 by adding a new job to the CI workflow.