### PR TITLE
Removing maven installation as it causes side package installation

### DIFF
--- a/src/java-api-bindings/scripts/install_dependencies_and_build.sh
+++ b/src/java-api-bindings/scripts/install_dependencies_and_build.sh
@@ -127,6 +127,7 @@ fi
 # Install jdk and maven
 mkdir -p ${BUILD_HOME}
 cd ${BUILD_HOME}
+apt remove maven -y && apt autoremove -y
 apt update && apt install -y openjdk-11-jdk
 wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
 tar zxvf apache-maven-${MAVEN_VERSION}-bin.tar.gz


### PR DESCRIPTION
Preinstalled maven package in ubuntu 24.04 includes JRE 1.21 which no longer compatible with compiler options 1.7 which we rely on in: 
https://github.com/search?q=repo%3Abytedeco%2Fjavacpp-presets+1.7+language%3A%22Maven+POM%22+&type=code

Related to: https://github.com/triton-inference-server/server/pull/7808