### PR TITLE
fix: Partial fix for L0_https

### DIFF
--- a/src/python/library/requirements/requirements_http.txt
+++ b/src/python/library/requirements/requirements_http.txt
@@ -25,6 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 aiohttp>=3.8.1,<4.0.0
-geventhttpclient>=1.4.4,<=2.0.2
+geventhttpclient>=2.0.11
 numpy>=1.19.1,<2
 python-rapidjson>=0.9.1

--- a/src/python/library/requirements/requirements_http.txt
+++ b/src/python/library/requirements/requirements_http.txt
@@ -25,6 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 aiohttp>=3.8.1,<4.0.0
-geventhttpclient>=2.0.11
+geventhttpclient>=2.0.11,<2.1.0
 numpy>=1.19.1,<2
 python-rapidjson>=0.9.1


### PR DESCRIPTION
#### What does the PR do?
Partially fix `L0_https--base` by upgrading `geventhttpclient` version to support Python3.12 on Ubuntu 24.04.
"Try with incorrect key" tests are still failing because of changes in `geventhttpclient` newer version.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] fix

#### Related PRs:
<!-- Related PRs from other Repositories -->

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- CI Pipeline ID:
20604304

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx