### PR TITLE
Fix C/C++ libb64 ABI incompatibility bug

### DIFF
--- a/src/c++/library/CMakeLists.txt
+++ b/src/c++/library/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -364,7 +364,7 @@ if(TRITON_ENABLE_CC_HTTP)
   # libhttpclient object build
   set(
       REQUEST_SRCS
-      http_client.cc common.cc cencode.c
+      http_client.cc common.cc cencode.cc
   )
 
   set(
@@ -379,7 +379,7 @@ if(TRITON_ENABLE_CC_HTTP)
 
   if (NOT WIN32)
     set_property(
-      SOURCE cencode.c
+      SOURCE cencode.cc
       PROPERTY COMPILE_FLAGS -Wno-implicit-fallthrough
     )
   endif() # NOT WIN32

--- a/src/c++/library/cencode.cc
+++ b/src/c++/library/cencode.cc
@@ -7,6 +7,8 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include "cencode.h"
 
+namespace triton::client::libb64 {
+
 const int CHARS_PER_LINE = 72;
 
 void
@@ -107,3 +109,5 @@ base64_encode_blockend(char* code_out, base64_encodestate* state_in)
 
   return codechar - code_out;
 }
+
+}  // namespace triton::client::libb64

--- a/src/c++/library/cencode.h
+++ b/src/c++/library/cencode.h
@@ -8,6 +8,8 @@ For details, see http://sourceforge.net/projects/libb64
 #ifndef BASE64_CENCODE_H
 #define BASE64_CENCODE_H
 
+namespace triton::client::libb64 {
+
 typedef enum { step_A, step_B, step_C } base64_encodestep;
 
 typedef struct {
@@ -25,5 +27,7 @@ int base64_encode_block(
     base64_encodestate* state_in);
 
 int base64_encode_blockend(char* code_out, base64_encodestate* state_in);
+
+}  // namespace triton::client::libb64
 
 #endif /* BASE64_CENCODE_H */

--- a/src/c++/library/http_client.cc
+++ b/src/c++/library/http_client.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -44,9 +44,7 @@
 #include <zlib.h>
 #endif
 
-extern "C" {
 #include "cencode.h"
-}
 
 #define TRITONJSON_STATUSTYPE triton::client::Error
 #define TRITONJSON_STATUSRETURN(M) return triton::client::Error(M)
@@ -132,11 +130,13 @@ Base64Encode(
     int* encoded_size)
 {
   // Encode the handle object to base64
-  base64_encodestate es;
+  libb64::base64_encodestate es;
   base64_init_encodestate(&es);
   *encoded_ptr = (char*)malloc(raw_size * 2); /* ~4/3 x raw_size */
-  *encoded_size = base64_encode_block(raw_ptr, raw_size, *encoded_ptr, &es);
-  int padding_size = base64_encode_blockend(*encoded_ptr + *encoded_size, &es);
+  *encoded_size =
+      libb64::base64_encode_block(raw_ptr, raw_size, *encoded_ptr, &es);
+  int padding_size =
+      libb64::base64_encode_blockend(*encoded_ptr + *encoded_size, &es);
   *encoded_size += padding_size;
 }
 


### PR DESCRIPTION
I tested that it builds correctly and that PA can compile and run correctly with it.