### PR TITLE
Update requirements.txt

### DIFF
--- a/src/python/library/requirements/requirements.txt
+++ b/src/python/library/requirements/requirements.txt
@@ -25,6 +25,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 numpy>=1.19.1
-perf-analyzer
 python-rapidjson>=0.9.1
 urllib3>=2.0.7


### PR DESCRIPTION
Remove requirement of `perf-analyzer` since there are issues with macOS, and technically perf-analyzer is not needed for tritonclient

Let's relnote the fact that tritonclient users need to manually install `perf-analyzer` if they want it.