### PR TITLE
Allow thread in grpc _InferStream be daemon

### DIFF
--- a/src/python/library/tritonclient/grpc/_client.py
+++ b/src/python/library/tritonclient/grpc/_client.py
@@ -1742,7 +1742,7 @@ class InferenceServerClient(InferenceServerClientBase):
 
     def start_stream(
         self, callback, stream_timeout=None, headers=None, compression_algorithm=None, 
-        daemon=False,
+        daemon=None,
     ):
         """Starts a grpc bi-directional stream to send streaming inferences.
         Note: When using stream, user must ensure the InferenceServerClient.close()
@@ -1770,7 +1770,7 @@ class InferenceServerClient(InferenceServerClientBase):
             Currently supports "deflate", "gzip" and None. By default, no
             compression is used.
         daemon : bool
-            Make internal thread daemonic if set True. By default set to False.
+            Make internal thread daemonic if set True. By default set to None.
 
         Raises
         ------

--- a/src/python/library/tritonclient/grpc/_infer_stream.py
+++ b/src/python/library/tritonclient/grpc/_infer_stream.py
@@ -53,10 +53,10 @@ class _InferStream:
     verbose : bool
         Enables verbose mode if set True.
     daemon : bool
-        Make handler thread daemonic if set True (default False).
+        Make handler thread daemonic if set True (default None).
     """
 
-    def __init__(self, callback, verbose, daemon=False):
+    def __init__(self, callback, verbose, daemon=None):
         self._callback = callback
         self._verbose = verbose
         self._request_queue = queue.Queue()


### PR DESCRIPTION
In some cases user can call `tritonclient.grpc.InferenceServerClient.start_stream()` but forget to call `tritonclient.grpc.InferenceServerClient.stop_stream()` later. `start_stream` created `_InferStream` object which internal also creates `threading.Thread()` instance. Because thread is not daemonic, the main process never stoped, if `stop_stream()` never called.
This PR allow user make internal thread daemonic, so main process can exit even if `stop_stream()` never called.