### PR TITLE
build: set OpenSSL3 paths on RHEL-like Linux (TRI-938)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ if(LINUX)
   file(STRINGS "/etc/os-release" DISTRO_ID_LIKE REGEX "ID_LIKE")
   if(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
     set (LIB_DIR "lib64")
+    set(OPENSSL_ROOT_DIR "/usr/lib64/openssl3")
+    set(OPENSSL_INCLUDE_DIR "/usr/include/openssl3")
   endif(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
 endif(LINUX)
 


### PR DESCRIPTION
## Description
Updates CMake so OpenSSL 3 library paths are set on RHEL-like Linux for manylinux/repack builds. Cross-repo change; related PRs are listed below.

## Changes
- bcb026c5 build: set OpenSSL3 paths on RHEL-like Linux (TRI-938)

## Affected Files
- CMakeLists.txt

#### Related PRs (other repositories)
- triton-inference-server/server#8731
- triton-inference-server/core#488
- triton-inference-server/third_party#73
- triton-inference-server/tensorrt_backend#119
- triton-inference-server/python_backend#434
- triton-inference-server/pytorch_backend#186

#### Test plan
- Confirm CI for this repository completes successfully.
- CI Pipeline ID: (fill when available)

#### Related Issues
- Resolves Linear issue: TRI-938
