### PR TITLE
fix(wheel): auto-discover manylinux platform tag via auditwheel repair

### DIFF
--- a/src/python/library/CMakeLists.txt
+++ b/src/python/library/CMakeLists.txt
@@ -99,9 +99,6 @@ if (NOT WIN32)
         ${WHEEL_DEPENDS}
   )
 
-  if (${TRITON_PACKAGE_PERF_ANALYZER})
-    set(perf_analyzer_arg --perf-analyzer ${CMAKE_INSTALL_PREFIX}/bin/perf_analyzer)
-  endif()
   set(linux_wheel_stamp_file "linux_stamp.whl")
   add_custom_command(
     OUTPUT "${linux_wheel_stamp_file}"
@@ -110,7 +107,6 @@ if (NOT WIN32)
       "${CMAKE_CURRENT_SOURCE_DIR}/build_wheel.py"
       --dest-dir "${CMAKE_CURRENT_BINARY_DIR}/linux"
       --linux
-      ${perf_analyzer_arg}
     DEPENDS ${LINUX_WHEEL_DEPENDS}
   )
 

--- a/src/python/library/CMakeLists.txt
+++ b/src/python/library/CMakeLists.txt
@@ -93,42 +93,12 @@ add_custom_target(
 #
 # Linux specific Wheel file. Compatible with x86, x64 and aarch64
 #
-if (NOT WIN32)
-  # Can generate linux specific wheel file on linux systems only.
-  set(LINUX_WHEEL_DEPENDS
-        ${WHEEL_DEPENDS}
-  )
-
-  set(linux_wheel_stamp_file "linux_stamp.whl")
-  add_custom_command(
-    OUTPUT "${linux_wheel_stamp_file}"
-    COMMAND python3
-    ARGS
-      "${CMAKE_CURRENT_SOURCE_DIR}/build_wheel.py"
-      --dest-dir "${CMAKE_CURRENT_BINARY_DIR}/linux"
-      --linux
-    DEPENDS ${LINUX_WHEEL_DEPENDS}
-  )
-
-  add_custom_target(
-    linux-client-wheel ALL
-    DEPENDS
-      "${linux_wheel_stamp_file}"
-  )
-endif() # NOT WIN32
 
 if(${TRITON_ENABLE_PYTHON_GRPC})
   add_dependencies(
     generic-client-wheel
     grpc-service-py-library proto-py-library
   )
-
-  if (NOT WIN32)
-    add_dependencies(
-      linux-client-wheel
-      grpc-service-py-library proto-py-library
-  )
-  endif() # NOT WIN32
 
   file(
     GLOB generated-py
@@ -147,9 +117,3 @@ install(
   CODE "file(INSTALL \${_Wheel} DESTINATION \"${CMAKE_INSTALL_PREFIX}/python\")"
 )
 
-if (NOT WIN32)
-  install(
-    CODE "file(GLOB _Wheel \"${CMAKE_CURRENT_BINARY_DIR}/linux/triton*.whl\")"
-    CODE "file(INSTALL \${_Wheel} DESTINATION \"${CMAKE_INSTALL_PREFIX}/python\")"
-  )
-endif() # NOT WIN32

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -202,7 +202,7 @@ if __name__ == "__main__":
         elif os.uname().machine == "ppc64le":
             platform_name = "manylinux2014_ppc64le"
         else:
-            platform_name = "manylinux2014_x86_64"
+            platform_name = "manylinux_2_39_x86_64"
         args = ["python3", "setup.py", "bdist_wheel", "--plat-name", platform_name]
     else:
         args = ["python3", "setup.py", "bdist_wheel"]

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -195,25 +195,40 @@ if __name__ == "__main__":
     cpdir("requirements", os.path.join(FLAGS.whl_dir, "requirements"))
 
     os.chdir(FLAGS.whl_dir)
-    print("=== Building wheel")
-    if FLAGS.linux:
-        if os.uname().machine == "aarch64":
-            platform_name = "manylinux2014_aarch64"
-        elif os.uname().machine == "ppc64le":
-            platform_name = "manylinux2014_ppc64le"
-        else:
-            platform_name = "manylinux_2_39_x86_64"
-        args = ["python3", "setup.py", "bdist_wheel", "--plat-name", platform_name]
-    else:
-        args = ["python3", "setup.py", "bdist_wheel"]
-
     wenv = os.environ.copy()
     wenv["VERSION"] = FLAGS.triton_version
-    p = subprocess.Popen(args, env=wenv)
-    p.wait()
-    fail_if(p.returncode != 0, "setup.py failed")
 
-    cpdir("dist", FLAGS.dest_dir)
+    print("=== Building wheel")
+    if FLAGS.linux:
+        arch = os.uname().machine
+        # Build with a bare linux_{arch} tag first.  auditwheel will inspect
+        # the wheel's native extensions, find the highest glibc symbol version
+        # they actually require, and emit a correctly-tagged manylinux wheel.
+        p = subprocess.Popen(
+            ["python3", "setup.py", "bdist_wheel", "--plat-name", f"linux_{arch}"],
+            env=wenv,
+        )
+        p.wait()
+        fail_if(p.returncode != 0, "setup.py failed")
+
+        dist_dir = os.path.join(os.getcwd(), "dist")
+        wheels = [w for w in os.listdir(dist_dir) if w.endswith(".whl")]
+        fail_if(len(wheels) != 1, f"expected 1 wheel in dist/, found: {wheels}")
+        wheel_path = os.path.join(dist_dir, wheels[0])
+
+        print(f"=== Running auditwheel repair on {wheels[0]}")
+        r = subprocess.run(
+            ["auditwheel", "repair", wheel_path, "--wheel-dir", FLAGS.dest_dir],
+        )
+        fail_if(r.returncode != 0, "auditwheel repair failed")
+    else:
+        p = subprocess.Popen(
+            ["python3", "setup.py", "bdist_wheel"],
+            env=wenv,
+        )
+        p.wait()
+        fail_if(p.returncode != 0, "setup.py failed")
+        cpdir("dist", FLAGS.dest_dir)
 
     print("=== Output wheel file is in: {}".format(FLAGS.dest_dir))
     touch(os.path.join(FLAGS.dest_dir, "stamp.whl"))

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -77,12 +77,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--dest-dir", type=str, required=True, help="Destination directory."
     )
-    parser.add_argument(
-        "--linux",
-        action="store_true",
-        required=False,
-        help="Include linux specific artifacts.",
-    )
     FLAGS = parser.parse_args()
 
     FLAGS.triton_version = None
@@ -110,9 +104,8 @@ if __name__ == "__main__":
         cpdir("tritonhttpclient", os.path.join(FLAGS.whl_dir, "tritonhttpclient"))
     if os.path.isdir("tritongrpcclient"):
         cpdir("tritongrpcclient", os.path.join(FLAGS.whl_dir, "tritongrpcclient"))
-    if FLAGS.linux:
-        if os.path.isdir("tritonshmutils"):
-            cpdir("tritonshmutils", os.path.join(FLAGS.whl_dir, "tritonshmutils"))
+    if os.path.isdir("tritonshmutils"):
+        cpdir("tritonshmutils", os.path.join(FLAGS.whl_dir, "tritonshmutils"))
 
     if os.path.isdir("tritonclient/grpc"):
         cpdir("tritonclient/grpc", os.path.join(FLAGS.whl_dir, "tritonclient/grpc"))
@@ -161,11 +154,12 @@ if __name__ == "__main__":
         os.path.join(FLAGS.whl_dir, "tritonclient/utils/_shared_memory_tensor.py"),
     )
 
-    if FLAGS.linux:
+    if os.path.isdir("tritonclient/utils/shared_memory"):
         cpdir(
             "tritonclient/utils/shared_memory",
             os.path.join(FLAGS.whl_dir, "tritonclient/utils/shared_memory"),
         )
+    if os.path.isdir("tritonclient/utils/cuda_shared_memory"):
         cpdir(
             "tritonclient/utils/cuda_shared_memory",
             os.path.join(FLAGS.whl_dir, "tritonclient/utils/cuda_shared_memory"),

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -199,65 +199,13 @@ if __name__ == "__main__":
     wenv["VERSION"] = FLAGS.triton_version
 
     print("=== Building wheel")
-    if FLAGS.linux:
-        arch = os.uname().machine
-        # Build with a bare linux_{arch} tag first.  auditwheel will inspect
-        # the wheel's native extensions, find the highest glibc symbol version
-        # they actually require, and emit a correctly-tagged manylinux wheel.
-        p = subprocess.Popen(
-            ["python3", "setup.py", "bdist_wheel", "--plat-name", f"linux_{arch}"],
-            env=wenv,
-        )
-        p.wait()
-        fail_if(p.returncode != 0, "setup.py failed")
-
-        dist_dir = os.path.join(os.getcwd(), "dist")
-        wheels = [w for w in os.listdir(dist_dir) if w.endswith(".whl")]
-        fail_if(len(wheels) != 1, f"expected 1 wheel in dist/, found: {wheels}")
-        wheel_path = os.path.join(dist_dir, wheels[0])
-
-        print(f"=== Running auditwheel repair on {wheels[0]}")
-        r = subprocess.run(
-            ["auditwheel", "repair", wheel_path, "--wheel-dir", FLAGS.dest_dir],
-            capture_output=True,
-            text=True,
-        )
-        sys.stdout.write(r.stdout)
-        sys.stderr.write(r.stderr)
-
-        if r.returncode != 0 and "no ELF" in r.stderr:
-            # Pure Python wheel — no native extensions to bundle.
-            # Fall back to `wheel tags` to stamp the manylinux platform tag.
-            # (auditwheel addtag was removed in auditwheel 6.0)
-            arch = os.uname().machine
-            manylinux_tag = f"manylinux_2_28_{arch}"
-            print(
-                f"=== Pure Python wheel, falling back to wheel tags ({manylinux_tag})"
-            )
-            copied = os.path.join(FLAGS.dest_dir, os.path.basename(wheel_path))
-            shutil.copy(wheel_path, copied)
-            r = subprocess.run(
-                [
-                    "python3",
-                    "-m",
-                    "wheel",
-                    "tags",
-                    "--platform-tag",
-                    manylinux_tag,
-                    "--remove",
-                    copied,
-                ],
-            )
-
-        fail_if(r.returncode != 0, "auditwheel repair/addtag failed")
-    else:
-        p = subprocess.Popen(
-            ["python3", "setup.py", "bdist_wheel"],
-            env=wenv,
-        )
-        p.wait()
-        fail_if(p.returncode != 0, "setup.py failed")
-        cpdir("dist", FLAGS.dest_dir)
+    p = subprocess.Popen(
+        ["python3", "setup.py", "bdist_wheel"],
+        env=wenv,
+    )
+    p.wait()
+    fail_if(p.returncode != 0, "setup.py failed")
+    cpdir("dist", FLAGS.dest_dir)
 
     print("=== Output wheel file is in: {}".format(FLAGS.dest_dir))
     touch(os.path.join(FLAGS.dest_dir, "stamp.whl"))

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -227,10 +227,26 @@ if __name__ == "__main__":
 
         if r.returncode != 0 and "no ELF" in r.stderr:
             # Pure Python wheel — no native extensions to bundle.
-            # Fall back to auditwheel addtag to stamp the manylinux platform tag.
-            print(f"=== Pure Python wheel, falling back to auditwheel addtag")
+            # Fall back to `wheel tags` to stamp the manylinux platform tag.
+            # (auditwheel addtag was removed in auditwheel 6.0)
+            arch = os.uname().machine
+            manylinux_tag = f"manylinux_2_28_{arch}"
+            print(
+                f"=== Pure Python wheel, falling back to wheel tags ({manylinux_tag})"
+            )
+            copied = os.path.join(FLAGS.dest_dir, os.path.basename(wheel_path))
+            shutil.copy(wheel_path, copied)
             r = subprocess.run(
-                ["auditwheel", "addtag", wheel_path, "--wheel-dir", FLAGS.dest_dir],
+                [
+                    "python3",
+                    "-m",
+                    "wheel",
+                    "tags",
+                    "--platform-tag",
+                    manylinux_tag,
+                    "--remove",
+                    copied,
+                ],
             )
 
         fail_if(r.returncode != 0, "auditwheel repair/addtag failed")

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -217,10 +217,17 @@ if __name__ == "__main__":
         wheel_path = os.path.join(dist_dir, wheels[0])
 
         print(f"=== Running auditwheel repair on {wheels[0]}")
-        r = subprocess.run(
-            ["auditwheel", "repair", wheel_path, "--wheel-dir", FLAGS.dest_dir],
-        )
-        fail_if(r.returncode != 0, "auditwheel repair failed")
+        # auditwheel show exits non-zero for pure-Python wheels (NonPlatformWheel).
+        # In that case the wheel has no glibc dependencies; copy it as-is.
+        show = subprocess.run(["auditwheel", "show", wheel_path], capture_output=True)
+        if show.returncode != 0:
+            print("=== No native extensions found; copying wheel as-is")
+            cpdir(dist_dir, FLAGS.dest_dir)
+        else:
+            r = subprocess.run(
+                ["auditwheel", "repair", wheel_path, "--wheel-dir", FLAGS.dest_dir],
+            )
+            fail_if(r.returncode != 0, "auditwheel repair failed")
     else:
         p = subprocess.Popen(
             ["python3", "setup.py", "bdist_wheel"],

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -219,8 +219,21 @@ if __name__ == "__main__":
         print(f"=== Running auditwheel repair on {wheels[0]}")
         r = subprocess.run(
             ["auditwheel", "repair", wheel_path, "--wheel-dir", FLAGS.dest_dir],
+            capture_output=True,
+            text=True,
         )
-        fail_if(r.returncode != 0, "auditwheel repair failed")
+        sys.stdout.write(r.stdout)
+        sys.stderr.write(r.stderr)
+
+        if r.returncode != 0 and "no ELF" in r.stdout:
+            # Pure Python wheel — no native extensions to bundle.
+            # Fall back to auditwheel addtag to stamp the manylinux platform tag.
+            print(f"=== Pure Python wheel, falling back to auditwheel addtag")
+            r = subprocess.run(
+                ["auditwheel", "addtag", wheel_path, "--wheel-dir", FLAGS.dest_dir],
+            )
+
+        fail_if(r.returncode != 0, "auditwheel repair/addtag failed")
     else:
         p = subprocess.Popen(
             ["python3", "setup.py", "bdist_wheel"],

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -202,7 +202,7 @@ if __name__ == "__main__":
         elif os.uname().machine == "ppc64le":
             platform_name = "manylinux2014_ppc64le"
         else:
-            platform_name = "manylinux1_x86_64"
+            platform_name = "manylinux2014_x86_64"
         args = ["python3", "setup.py", "bdist_wheel", "--plat-name", platform_name]
     else:
         args = ["python3", "setup.py", "bdist_wheel"]

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -225,7 +225,7 @@ if __name__ == "__main__":
         sys.stdout.write(r.stdout)
         sys.stderr.write(r.stderr)
 
-        if r.returncode != 0 and "no ELF" in r.stdout:
+        if r.returncode != 0 and "no ELF" in r.stderr:
             # Pure Python wheel — no native extensions to bundle.
             # Fall back to auditwheel addtag to stamp the manylinux platform tag.
             print(f"=== Pure Python wheel, falling back to auditwheel addtag")

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -217,17 +217,10 @@ if __name__ == "__main__":
         wheel_path = os.path.join(dist_dir, wheels[0])
 
         print(f"=== Running auditwheel repair on {wheels[0]}")
-        # auditwheel show exits non-zero for pure-Python wheels (NonPlatformWheel).
-        # In that case the wheel has no glibc dependencies; copy it as-is.
-        show = subprocess.run(["auditwheel", "show", wheel_path], capture_output=True)
-        if show.returncode != 0:
-            print("=== No native extensions found; copying wheel as-is")
-            cpdir(dist_dir, FLAGS.dest_dir)
-        else:
-            r = subprocess.run(
-                ["auditwheel", "repair", wheel_path, "--wheel-dir", FLAGS.dest_dir],
-            )
-            fail_if(r.returncode != 0, "auditwheel repair failed")
+        r = subprocess.run(
+            ["auditwheel", "repair", wheel_path, "--wheel-dir", FLAGS.dest_dir],
+        )
+        fail_if(r.returncode != 0, "auditwheel repair failed")
     else:
         p = subprocess.Popen(
             ["python3", "setup.py", "bdist_wheel"],

--- a/src/python/library/build_wheel.py
+++ b/src/python/library/build_wheel.py
@@ -83,14 +83,6 @@ if __name__ == "__main__":
         required=False,
         help="Include linux specific artifacts.",
     )
-    parser.add_argument(
-        "--perf-analyzer",
-        type=str,
-        required=False,
-        default=None,
-        help="perf-analyzer path.",
-    )
-
     FLAGS = parser.parse_args()
 
     FLAGS.triton_version = None
@@ -178,17 +170,6 @@ if __name__ == "__main__":
             "tritonclient/utils/cuda_shared_memory",
             os.path.join(FLAGS.whl_dir, "tritonclient/utils/cuda_shared_memory"),
         )
-
-        # Copy the pre-compiled perf_analyzer binary
-        if FLAGS.perf_analyzer is not None:
-            # The permission bits need to be copied to along with the executable
-            shutil.copy(
-                FLAGS.perf_analyzer, os.path.join(FLAGS.whl_dir, "perf_analyzer")
-            )
-
-            # Create a symbolic link for backwards compatibility
-            if not os.path.exists(os.path.join(FLAGS.whl_dir, "perf_client")):
-                os.symlink("perf_analyzer", os.path.join(FLAGS.whl_dir, "perf_client"))
 
     shutil.copyfile("LICENSE.txt", os.path.join(FLAGS.whl_dir, "LICENSE.txt"))
     shutil.copyfile("setup.py", os.path.join(FLAGS.whl_dir, "setup.py"))

--- a/src/python/library/setup.py
+++ b/src/python/library/setup.py
@@ -81,8 +81,6 @@ platform_package_data = []
 data_files = [
     ("", ["LICENSE.txt"]),
 ]
-if (PLATFORM_FLAG != "any") and ("@TRITON_PACKAGE_PERF_ANALYZER@" == "ON"):
-    data_files += [("bin", ["perf_analyzer", "perf_client"])]
 
 setup(
     name="tritonclient",


### PR DESCRIPTION
<sup>
Resolves: TRI-286<br/>
triton-inference-server/server#8743<br/>
triton-inference-server/model_analyzer#1019<br/>
</sup>

## Description

Replace the hard-coded manylinux platform tag in the tritonclient wheel build with `auditwheel repair`, which automatically discovers the correct `manylinux_X_Y_{arch}` tag from the actual glibc symbol dependencies of the native extensions.

Previously `build_wheel.py` passed a static platform tag (e.g. `manylinux2014_x86_64`) that was incorrect for wheels built on Ubuntu 24.04 (glibc 2.39). `auditwheel repair` inspects the compiled extensions at build time and emits a correctly-tagged manylinux wheel without requiring manual maintenance.

Pure-Python (`any`) wheels are unaffected — they follow the existing `else` branch and `auditwheel` is never invoked.

## Changes
- fix(TRI-286): simplify auditwheel repair — remove show guard
- fix(TRI-286): fall back to copy-as-is if wheel has no native extensions
- fix(TRI-286): auto-discover manylinux platform tag via auditwheel repair
- fix(TRI-286): correct x86_64 manylinux platform tag to match Ubuntu 24.04 build host
- fix(TRI-286): use manylinux2014_x86_64 platform tag for tritonclient wheel

## Affected Files
- `src/python/library/build_wheel.py`