### PR TITLE
fix: Reject Triton reserved keys in parameters

### DIFF
--- a/src/python/library/tritonclient/grpc/_utils.py
+++ b/src/python/library/tritonclient/grpc/_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -116,12 +116,8 @@ def _get_inference_request(
 
     if parameters:
         for key, value in parameters.items():
-            if (
-                key == "sequence_id"
-                or key == "sequence_start"
-                or key == "sequence_end"
-                or key == "priority"
-                or key == "binary_data_output"
+            if key in TRITON_RESERVED_REQUEST_PARAMS or key.startswith(
+                TRITON_RESERVED_REQUEST_PARAMS_PREFIX
             ):
                 raise_error(
                     f'Parameter "{key}" is a reserved parameter and cannot be specified.'

--- a/src/python/library/tritonclient/http/_utils.py
+++ b/src/python/library/tritonclient/http/_utils.py
@@ -29,7 +29,7 @@ import struct
 from urllib.parse import quote_plus
 
 import rapidjson as json
-from tritonclient.utils import InferenceServerException, raise_error
+from tritonclient.utils import *
 
 
 def _get_error(response):
@@ -118,12 +118,8 @@ def _get_inference_request(
 
     if custom_parameters:
         for key, value in custom_parameters.items():
-            if (
-                key == "sequence_id"
-                or key == "sequence_start"
-                or key == "sequence_end"
-                or key == "priority"
-                or key == "binary_data_output"
+            if key in TRITON_RESERVED_REQUEST_PARAMS or key.startswith(
+                TRITON_RESERVED_REQUEST_PARAMS_PREFIX
             ):
                 raise_error(
                     f'Parameter "{key}" is a reserved parameter and cannot be specified.'

--- a/src/python/library/tritonclient/http/_utils.py
+++ b/src/python/library/tritonclient/http/_utils.py
@@ -29,7 +29,12 @@ import struct
 from urllib.parse import quote_plus
 
 import rapidjson as json
-from tritonclient.utils import *
+from tritonclient.utils import (
+    TRITON_RESERVED_REQUEST_PARAMS,
+    TRITON_RESERVED_REQUEST_PARAMS_PREFIX,
+    InferenceServerException,
+    raise_error,
+)
 
 
 def _get_error(response):

--- a/src/python/library/tritonclient/utils/__init__.py
+++ b/src/python/library/tritonclient/utils/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,6 +31,21 @@ import struct
 import numpy as np
 
 from ._shared_memory_tensor import SharedMemoryTensor
+
+# Reserved request parameters for Triton's usage.
+# Other locations:
+# - server/src/common.h
+# - server/docs/protocol/extension_parameters.md
+TRITON_RESERVED_REQUEST_PARAMS = [
+    "sequence_id",
+    "sequence_start",
+    "sequence_end",
+    "priority",
+    "timeout",
+    "headers",
+    "binary_data_output",
+]
+TRITON_RESERVED_REQUEST_PARAMS_PREFIX = "triton_"
 
 
 def raise_error(msg):


### PR DESCRIPTION
Reject Triton reserved keys in parameters in Python HTTP and gRPC clients.