### PR TITLE
feat: Add request cancellation to C++ gRPC client

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ under-development version).
 
 ```bash
 $ git checkout main
+$ mkdir -p build && cd build
 ```
 
 If building the Java client you must first install Maven and a JDK
@@ -231,6 +232,22 @@ because Triton on Windows does not yet support all the build options.
 Use *cmake* to configure the build. You should adjust the flags depending on
 the components of Triton Client you are working and would like to build.
 
+```
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
+  -DTRITON_ENABLE_CC_HTTP=ON \
+  -DTRITON_ENABLE_CC_GRPC=ON \
+  -DTRITON_ENABLE_PYTHON_HTTP=ON \
+  -DTRITON_ENABLE_PYTHON_GRPC=ON \
+  -DTRITON_ENABLE_JAVA_HTTP=ON \
+  -DTRITON_ENABLE_EXAMPLES=ON \
+  -DTRITON_ENABLE_TESTS=ON \
+  -DTRITON_ENABLE_GPU=ON \
+  -DTRITON_ENABLE_ZLIB=ON \
+  ..
+```
+
 If you are building on a release branch (or on a development branch
 that is based off of a release branch), then you must also use
 additional cmake arguments to point to that release branch for repos
@@ -247,7 +264,7 @@ cmake flags:
 Then use *make* to build the clients and examples.
 
 ```
-$ make cc-clients python-clients java-clients
+$ make -j$(nproc)/ cc-clients python-clients java-clients
 ```
 
 When the build completes the libraries and examples can be found in
@@ -515,6 +532,7 @@ examples demonstrate how to infer with AsyncIO.
 
 
 ### Request Cancellation
+#### Python gRPC client
 
 Starting from r23.10, triton python gRPC client can issue cancellation
 to inflight requests. This can be done by calling `cancel()` on the
@@ -559,6 +577,61 @@ asynchronous iterator returned by `stream_infer()` API.
 
 See more details about these APIs in
 [grpc/aio/\__init__.py](src/python/library/tritonclient/grpc/aio/__init__.py).
+
+#### C++ gRPC client
+
+Starting from r26.05, triton python C++ client can issue cancellation to
+inflight requests. This can be done by passing an optional
+`CallContext** ctx_out` to `AsyncInfer()`; the returned `CallContext` exposes
+`Cancel()`.
+
+```cpp
+  tc::CallContext* ctx = nullptr;
+  client->AsyncInfer(
+      callback, options, inputs, outputs,
+      /*headers=*/{}, GRPC_COMPRESS_NONE, &ctx);
+  ctx->Cancel();
+  delete ctx;
+```
+
+For batch fan-out via `AsyncInferMulti()`, pass an optional
+`std::vector<CallContext*>* ctxs_out`; on return it is sized to `inputs.size()`
+with one `CallContext` per leaf request (or `nullptr` for any request that
+failed locally before the RPC started). Cancellation is per-request — siblings
+continue to completion, and the multi callback still fires exactly once.
+
+```cpp
+  std::vector<tc::CallContext*> ctxs;
+  client->AsyncInferMulti(
+      multi_callback, options, inputs, outputs,
+      /*headers=*/{}, GRPC_COMPRESS_NONE, &ctxs);
+  for (auto* ctx : ctxs) {
+    if (ctx != nullptr) {
+      ctx->Cancel();
+    }
+  }
+  for (auto* ctx : ctxs) {
+    delete ctx;
+  }
+```
+
+For streaming requests, pass `true` to `StopStream()`. Cancelling after the
+RPC has completed is a safe no-op. The caller owns the returned `CallContext`
+and must `delete` it. Call sites that omit `ctx_out` keep the previous,
+non-cancellable behavior.
+
+```cpp
+  client->StartStream(callback, ...);
+  for (...) {
+    client->AsyncStreamInfer(options, inputs, outputs);
+  }
+  client->StopStream(/*cancel_requests=*/true);
+```
+
+See more details about these APIs in
+[grpc_client.h](src/c++/library/grpc_client.h).
+
+#### Server-side behavior
 
 See [request_cancellation](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/request_cancellation.md)
 in the server user-guide to learn about how this is handled on the

--- a/src/c++/library/grpc_client.cc
+++ b/src/c++/library/grpc_client.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #include <future>
 #include <iostream>
 #include <mutex>
+#include <new>
 #include <sstream>
 #include <string>
 
@@ -172,7 +173,8 @@ SetTimeout(const uint64_t& client_timeout_ms, grpc::ClientContext* context)
 class GrpcInferRequest : public InferRequest {
  public:
   GrpcInferRequest(InferenceServerClient::OnCompleteFn callback = nullptr)
-      : InferRequest(callback), grpc_status_(),
+      : InferRequest(callback),
+        grpc_context_(std::make_shared<grpc::ClientContext>()), grpc_status_(),
         grpc_response_(std::make_shared<inference::ModelInferResponse>())
   {
   }
@@ -180,8 +182,10 @@ class GrpcInferRequest : public InferRequest {
   friend InferenceServerGrpcClient;
 
  private:
-  // Variables for GRPC call
-  grpc::ClientContext grpc_context_;
+  // Variables for GRPC call. The ClientContext is held by shared_ptr so that
+  // a CallContext returned to the caller can co-own it and safely call
+  // TryCancel() at any point during (or after) the RPC's lifetime.
+  std::shared_ptr<grpc::ClientContext> grpc_context_;
   grpc::Status grpc_status_;
   std::shared_ptr<inference::ModelInferResponse> grpc_response_;
 };
@@ -443,6 +447,17 @@ InferResultGrpc::InferResultGrpc(
     is_final_response_ = is_final_response_itr->second.bool_param();
   }
   is_null_response_ = response_->outputs().empty() && is_final_response_;
+}
+
+//==============================================================================
+
+Error
+CallContext::Cancel()
+{
+  if (grpc_context_) {
+    grpc_context_->TryCancel();
+  }
+  return Error::Success;
 }
 
 //==============================================================================
@@ -1154,7 +1169,8 @@ InferenceServerGrpcClient::AsyncInfer(
     OnCompleteFn callback, const InferOptions& options,
     const std::vector<InferInput*>& inputs,
     const std::vector<const InferRequestedOutput*>& outputs,
-    const Headers& headers, grpc_compression_algorithm compression_algorithm)
+    const Headers& headers, grpc_compression_algorithm compression_algorithm,
+    CallContext** ctx_out)
 {
   if (callback == nullptr) {
     return Error(
@@ -1170,13 +1186,14 @@ InferenceServerGrpcClient::AsyncInfer(
   async_request->Timer().CaptureTimestamp(RequestTimers::Kind::REQUEST_START);
   async_request->Timer().CaptureTimestamp(RequestTimers::Kind::SEND_START);
   for (const auto& it : headers) {
-    async_request->grpc_context_.AddMetadata(it.first, it.second);
+    async_request->grpc_context_->AddMetadata(it.first, it.second);
   }
 
   if (options.client_timeout_ != 0) {
-    SetTimeout(options.client_timeout_, &(async_request->grpc_context_));
+    SetTimeout(options.client_timeout_, async_request->grpc_context_.get());
   }
-  async_request->grpc_context_.set_compression_algorithm(compression_algorithm);
+  async_request->grpc_context_->set_compression_algorithm(
+      compression_algorithm);
 
   Error err = PreRunProcessing(options, inputs, outputs);
   if (!err.IsOk()) {
@@ -1189,7 +1206,7 @@ InferenceServerGrpcClient::AsyncInfer(
   std::unique_ptr<
       grpc::ClientAsyncResponseReader<inference::ModelInferResponse>>
       rpc(stub_->PrepareAsyncModelInfer(
-          &async_request->grpc_context_, infer_request_,
+          async_request->grpc_context_.get(), infer_request_,
           &async_request_completion_queue_));
 
   rpc->StartCall();
@@ -1197,6 +1214,13 @@ InferenceServerGrpcClient::AsyncInfer(
   rpc->Finish(
       async_request->grpc_response_.get(), &async_request->grpc_status_,
       (void*)async_request);
+
+  // Hand the caller a cancellation handle co-owning the same ClientContext.
+  // Placed after StartCall/Finish so *ctx_out is only set on success; the
+  // earlier validation failure paths leave *ctx_out unchanged (nullptr).
+  if (ctx_out != nullptr) {
+    *ctx_out = new CallContext(async_request->grpc_context_);
+  }
 
   if (verbose_) {
     std::cout << "Sent request";
@@ -1255,7 +1279,8 @@ InferenceServerGrpcClient::AsyncInferMulti(
     OnMultiCompleteFn callback, const std::vector<InferOptions>& options,
     const std::vector<std::vector<InferInput*>>& inputs,
     const std::vector<std::vector<const InferRequestedOutput*>>& outputs,
-    const Headers& headers, grpc_compression_algorithm compression_algorithm)
+    const Headers& headers, grpc_compression_algorithm compression_algorithm,
+    std::vector<CallContext*>* ctxs_out)
 {
   // Sanity check
   if ((inputs.size() != options.size()) && (options.size() != 1)) {
@@ -1284,6 +1309,13 @@ InferenceServerGrpcClient::AsyncInferMulti(
       new std::atomic<size_t>(inputs.size()));
   std::shared_ptr<std::vector<InferResult*>> responses(
       new std::vector<InferResult*>(inputs.size()));
+
+  // Pre-size so AsyncInfer() can write slot i directly; slots stay
+  // nullptr for requests that fail before the RPC starts.
+  if (ctxs_out != nullptr) {
+    ctxs_out->assign(inputs.size(), nullptr);
+  }
+
   for (int64_t i = 0; i < (int64_t)inputs.size(); ++i) {
     const auto& request_options = options[std::min(max_option_idx, i)];
     const auto& request_output = (max_output_idx == -1)
@@ -1301,9 +1333,10 @@ InferenceServerGrpcClient::AsyncInferMulti(
       }
     };
 
+    CallContext** ctx = (ctxs_out != nullptr) ? &(*ctxs_out)[i] : nullptr;
     auto err = AsyncInfer(
         cb, request_options, inputs[i], request_output, headers,
-        compression_algorithm);
+        compression_algorithm, ctx);
     if (!err.IsOk()) {
       // Create response with error as other requests may be sent and their
       // responses may not be accessed outside the callback.
@@ -1336,6 +1369,12 @@ InferenceServerGrpcClient::StartStream(
         "Callback function must be provided along with StartStream() call.");
   }
 
+  // Reset grpc_context_ in place: a previous StopStream(cancel_requests=
+  // true) leaves it cancelled, and ClientContext deletes operator= so we
+  // can't just reassign it.
+  grpc_context_.~ClientContext();
+  new (&grpc_context_) grpc::ClientContext();
+
   stream_callback_ = callback;
   enable_stream_stats_ = enable_stats;
 
@@ -1360,12 +1399,18 @@ InferenceServerGrpcClient::StartStream(
 }
 
 Error
-InferenceServerGrpcClient::StopStream()
+InferenceServerGrpcClient::StopStream(bool cancel_requests)
 {
   if (stream_worker_.joinable()) {
-    grpc_stream_->WritesDone();
-    // The reader thread will drain the stream properly
+    if (cancel_requests) {
+      stream_cancel_requested_.store(true, std::memory_order_release);
+      grpc_context_.TryCancel();
+    } else {
+      grpc_stream_->WritesDone();
+    }
+    // The reader thread drains the stream and completes the RPC (Finish).
     stream_worker_.join();
+    stream_cancel_requested_.store(false, std::memory_order_release);
     if (verbose_) {
       std::cout << "Stopped stream..." << std::endl;
     }
@@ -1603,7 +1648,14 @@ InferenceServerGrpcClient::AsyncTransfer()
       InferResult* async_result;
       Error err;
       if (!async_request->grpc_status_.ok()) {
-        err = Error(async_request->grpc_status_.error_message());
+        // Map gRPC CANCELLED to the same message the streaming-cancel path
+        // emits, matching tritonclient.grpc._utils.get_cancelled_error().
+        if (async_request->grpc_status_.error_code() ==
+            grpc::StatusCode::CANCELLED) {
+          err = Error("Locally cancelled by application!");
+        } else {
+          err = Error(async_request->grpc_status_.error_message());
+        }
       }
       async_request->Timer().CaptureTimestamp(RequestTimers::Kind::RECV_START);
       InferResultGrpc::Create(
@@ -1668,6 +1720,16 @@ InferenceServerGrpcClient::AsyncStreamTransfer()
     }
     stream_callback_(stream_result);
     response = std::make_shared<inference::ModelStreamInferResponse>();
+  }
+  // After StopStream(cancel_requests=true), Read() drains without a status,
+  // so synthesize one final callback carrying the Python-parity message.
+  if (stream_cancel_requested_.load(std::memory_order_acquire) && !exiting_) {
+    InferResult* cancel_result = nullptr;
+    auto cancel_response =
+        std::make_shared<inference::ModelStreamInferResponse>();
+    cancel_response->set_error_message("Locally cancelled by application!");
+    InferResultGrpc::Create(&cancel_result, cancel_response);
+    stream_callback_(cancel_result);
   }
   grpc_stream_->Finish();
 }

--- a/src/c++/library/grpc_client.h
+++ b/src/c++/library/grpc_client.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include <grpcpp/grpcpp.h>
 
+#include <atomic>
 #include <queue>
 
 #include "common.h"
@@ -79,6 +80,28 @@ struct KeepAliveOptions {
   // frame to be sent. gRPC Core will not continue sending pings if we run over
   // the limit. Setting it to 0 allows sending pings without such a restriction.
   int http2_max_pings_without_data;
+};
+
+//==============================================================================
+/// A handle returned by AsyncInfer for per-request cancellation.
+///
+/// The caller owns the returned CallContext and must `delete` it.
+class CallContext {
+ public:
+  /// Triggers grpc::ClientContext::TryCancel() on the underlying RPC. After
+  /// cancellation the AsyncInfer callback fires once with a status whose
+  /// message contains "Locally cancelled by application!". Safe to call
+  /// after the RPC has completed (no-op).
+  /// \return Error object indicating success or failure.
+  Error Cancel();
+
+ private:
+  friend class InferenceServerGrpcClient;
+  explicit CallContext(std::shared_ptr<grpc::ClientContext> ctx)
+      : grpc_context_(std::move(ctx))
+  {
+  }
+  std::shared_ptr<grpc::ClientContext> grpc_context_;
 };
 
 //==============================================================================
@@ -494,6 +517,10 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// in the metadata of gRPC request.
   /// \param compression_algorithm The compression algorithm to be used
   /// by gRPC when sending requests. By default compression is not used.
+  /// \param ctx_out If not nullptr, on Error::Success this is set to a
+  /// newly heap-allocated CallContext for cancelling the in-flight RPC.
+  /// The caller owns the returned object and must `delete` it. When
+  /// ctx_out is nullptr (the default) the request cannot be cancelled.
   /// \return Error object indicating success or failure of the request.
   Error AsyncInfer(
       OnCompleteFn callback, const InferOptions& options,
@@ -501,7 +528,8 @@ class InferenceServerGrpcClient : public InferenceServerClient {
       const std::vector<const InferRequestedOutput*>& outputs =
           std::vector<const InferRequestedOutput*>(),
       const Headers& headers = Headers(),
-      grpc_compression_algorithm compression_algorithm = GRPC_COMPRESS_NONE);
+      grpc_compression_algorithm compression_algorithm = GRPC_COMPRESS_NONE,
+      CallContext** ctx_out = nullptr);
 
   /// Run multiple synchronous inferences on server.
   /// \param results Returns the results of the inferences.
@@ -550,6 +578,13 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// in the metadata of gRPC request.
   /// \param compression_algorithm The compression algorithm to be used
   /// by gRPC when sending requests. By default compression is not used.
+  /// \param ctxs_out If not nullptr, on return the vector is sized to
+  /// inputs.size() and each slot is set to a newly heap-allocated
+  /// CallContext for the corresponding in-flight RPC, or nullptr if that
+  /// request failed locally before the RPC started. Cancellation is
+  /// per-request; the multi callback still fires exactly once. The caller
+  /// owns each non-null entry and must `delete` it. When ctxs_out is
+  /// nullptr (the default) the requests cannot be cancelled.
   /// \return Error object indicating success or failure of the request.
   Error AsyncInferMulti(
       OnMultiCompleteFn callback, const std::vector<InferOptions>& options,
@@ -557,7 +592,8 @@ class InferenceServerGrpcClient : public InferenceServerClient {
       const std::vector<std::vector<const InferRequestedOutput*>>& outputs =
           std::vector<std::vector<const InferRequestedOutput*>>(),
       const Headers& headers = Headers(),
-      grpc_compression_algorithm compression_algorithm = GRPC_COMPRESS_NONE);
+      grpc_compression_algorithm compression_algorithm = GRPC_COMPRESS_NONE,
+      std::vector<CallContext*>* ctxs_out = nullptr);
 
   /// Starts a grpc bi-directional stream to send streaming inferences.
   /// \param callback The callback function to be invoked on receiving a
@@ -582,8 +618,16 @@ class InferenceServerGrpcClient : public InferenceServerClient {
       grpc_compression_algorithm compression_algorithm = GRPC_COMPRESS_NONE);
 
   /// Stops an active grpc bi-directional stream, if one available.
+  /// \param cancel_requests If true, cancels the streaming RPC (via
+  /// grpc::ClientContext::TryCancel) instead of gracefully ending the write
+  /// side with WritesDone. Cancellation frees the client to start a new
+  /// stream without waiting for the server to finish all in-flight work, and
+  /// typically triggers Triton server-side request cancellation for work
+  /// already accepted on that stream. When true, the stream callback may be
+  /// invoked one additional time with an error result whose message contains
+  /// "Locally cancelled by application!".
   /// \return Error object indicating success or failure of the request.
-  Error StopStream();
+  Error StopStream(bool cancel_requests = false);
 
   /// Runs an asynchronous inference over gRPC bi-directional streaming
   /// API. A stream must be established with a call to StartStream()
@@ -630,6 +674,7 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   bool enable_stream_stats_;
   std::queue<std::unique_ptr<RequestTimers>> ongoing_stream_request_timers_;
   std::mutex stream_mutex_;
+  std::atomic<bool> stream_cancel_requested_{false};
 
   // GRPC end point.
   std::shared_ptr<inference::GRPCInferenceService::Stub> stub_;

--- a/src/c++/tests/CMakeLists.txt
+++ b/src/c++/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -86,6 +86,28 @@ target_link_libraries(
 )
 install(
   TARGETS cc_client_test
+  RUNTIME DESTINATION bin
+)
+
+#
+# grpc_cancellation_test
+#
+add_executable(
+  grpc_cancellation_test
+  grpc_cancellation_test.cc
+)
+target_include_directories(
+  grpc_cancellation_test PRIVATE ${GTEST_INCLUDE_DIRS}
+)
+target_link_libraries(
+  grpc_cancellation_test
+  PRIVATE
+    grpcclient_static
+    gtest
+    ${GTEST_LIBRARY}
+)
+install(
+  TARGETS grpc_cancellation_test
   RUNTIME DESTINATION bin
 )
 

--- a/src/c++/tests/grpc_cancellation_test.cc
+++ b/src/c++/tests/grpc_cancellation_test.cc
@@ -1,0 +1,470 @@
+// Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "grpc_client.h"
+#include "gtest/gtest.h"
+
+namespace tc = triton::client;
+
+namespace {
+
+constexpr char kServerUrl[] = "localhost:8001";
+constexpr char kLocalCancelMessage[] = "Locally cancelled by application!";
+
+// Time we sleep after sending the request before issuing Cancel().
+constexpr auto kInflightWait = std::chrono::seconds(2);
+
+// Generous upper bound for callback delivery once Cancel() has been called.
+// The cancel itself should arrive much faster than the 10s model delay.
+constexpr auto kCallbackTimeout = std::chrono::seconds(5);
+
+// Upper bound for natural (non-cancelled) completion. The model's per-
+// request delay is 10s, so this leaves ~5s of headroom for jitter.
+constexpr auto kCompletionTimeout = std::chrono::seconds(15);
+
+class GrpcCancellationTest : public ::testing::Test {
+ public:
+  void SetUp() override
+  {
+    auto err = tc::InferenceServerGrpcClient::Create(&client_, kServerUrl);
+    ASSERT_TRUE(err.IsOk())
+        << "failed to create GRPC client: " << err.Message();
+  }
+
+  // Blocks up to `timeout` for callback_ to capture the first result.
+  // Returns true if a result was received within the timeout, false on
+  // timeout.
+  bool WaitForResult(std::chrono::milliseconds timeout)
+  {
+    std::unique_lock<std::mutex> lk(mutex_);
+    return cv_.wait_for(lk, timeout, [this] { return result_ != nullptr; });
+  }
+
+  // Returns the number of times callback_ has been invoked. Safe to
+  // call from the test thread at any time.
+  int GetCallbackCount()
+  {
+    std::lock_guard<std::mutex> lk(mutex_);
+    return callback_count_;
+  }
+
+  // Clears the captured result and counter so a single test can reuse the
+  // fixture across multiple phases (e.g., the cancel-then-restart test).
+  void ResetCapturedResult()
+  {
+    std::lock_guard<std::mutex> lk(mutex_);
+    result_.reset();
+    callback_count_ = 0;
+  }
+
+  // Builds a single INPUT0/OUTPUT0 pair matching the Python suite's
+  // _prepare_request(). Caller owns the returned pointers.
+  tc::Error PrepareRequest(
+      std::vector<tc::InferInput*>* inputs,
+      std::vector<const tc::InferRequestedOutput*>* outputs)
+  {
+    inputs->emplace_back();
+    auto err =
+        tc::InferInput::Create(&inputs->back(), "INPUT0", shape_, dtype_);
+    if (!err.IsOk()) {
+      return err;
+    }
+    err = inputs->back()->AppendRaw(
+        reinterpret_cast<const uint8_t*>(input_data_.data()),
+        input_data_.size() * sizeof(int32_t));
+    if (!err.IsOk()) {
+      return err;
+    }
+    tc::InferRequestedOutput* out0 = nullptr;
+    err = tc::InferRequestedOutput::Create(&out0, "OUTPUT0");
+    if (!err.IsOk()) {
+      return err;
+    }
+    outputs->push_back(out0);
+    return tc::Error::Success;
+  }
+
+  static void CleanupRequest(
+      std::vector<tc::InferInput*>* inputs,
+      std::vector<const tc::InferRequestedOutput*>* outputs)
+  {
+    for (auto* in : *inputs) {
+      delete in;
+    }
+    for (auto* out : *outputs) {
+      delete const_cast<tc::InferRequestedOutput*>(out);
+    }
+    inputs->clear();
+    outputs->clear();
+  }
+
+  tc::InferOptions MakeOptions() const
+  {
+    tc::InferOptions options(model_name_);
+    options.model_version_ = model_version_;
+    return options;
+  }
+
+  // Verifies a successful response echoes input_data_ on OUTPUT0 with
+  // matching shape and dtype. Run on the test thread after the callback
+  // has stashed the result.
+  void ExpectEchoOutput(tc::InferResult* result) const
+  {
+    ASSERT_NE(result, nullptr);
+    ASSERT_TRUE(result->RequestStatus().IsOk())
+        << "request failed: " << result->RequestStatus().Message();
+
+    std::vector<int64_t> out_shape;
+    EXPECT_TRUE(result->Shape("OUTPUT0", &out_shape).IsOk());
+    EXPECT_EQ(out_shape, shape_);
+
+    std::string out_dtype;
+    EXPECT_TRUE(result->Datatype("OUTPUT0", &out_dtype).IsOk());
+    EXPECT_EQ(out_dtype, dtype_);
+
+    const uint8_t* buf = nullptr;
+    size_t byte_size = 0;
+    ASSERT_TRUE(result->RawData("OUTPUT0", &buf, &byte_size).IsOk());
+    const size_t expected_bytes = input_data_.size() * sizeof(int32_t);
+    ASSERT_EQ(byte_size, expected_bytes);
+    ASSERT_NE(buf, nullptr);
+    std::vector<int32_t> out_data(input_data_.size());
+    std::memcpy(out_data.data(), buf, byte_size);
+    EXPECT_EQ(out_data, input_data_);
+  }
+
+  static void ExpectLocalCancel(tc::InferResult* result)
+  {
+    ASSERT_NE(result, nullptr);
+    const tc::Error st = result->RequestStatus();
+    EXPECT_FALSE(st.IsOk())
+        << "expected cancellation, but request reported success";
+    EXPECT_NE(st.Message().find(kLocalCancelMessage), std::string::npos)
+        << "expected '" << kLocalCancelMessage
+        << "' in status, got: " << st.Message();
+  }
+
+  const std::string model_name_ = "custom_identity_int32";
+  const std::string model_version_ = "1";
+  const std::vector<int32_t> input_data_ = {10};
+  const std::vector<int64_t> shape_ = {1, 1};
+  const std::string dtype_ = "INT32";
+  std::unique_ptr<tc::InferenceServerGrpcClient> client_;
+
+  // Synchronization for callbacks fired on the gRPC worker thread. Tests
+  // pass callback_ into AsyncInfer/StartStream and then either call
+  // WaitForResult() or sleep before inspecting result_/callback_count_.
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  std::unique_ptr<tc::InferResult> result_;
+  int callback_count_ = 0;
+
+  // Stashes the first InferResult into result_ and counts every invocation.
+  // Subsequent results are deleted so a buggy double-callback doesn't leak;
+  // tests then catch it by checking GetCallbackCount().
+  tc::InferenceServerClient::OnCompleteFn callback_ =
+      [this](tc::InferResult* r) {
+        std::lock_guard<std::mutex> lk(mutex_);
+        if (result_ == nullptr) {
+          result_.reset(r);
+        } else {
+          delete r;
+        }
+        ++callback_count_;
+        cv_.notify_one();
+      };
+};
+
+// ---------------------------------------------------------------------------
+// Unary cancellation tests.
+// ---------------------------------------------------------------------------
+
+// Launch an async inference, sleep briefly so the RPC is in flight, call
+// Cancel() on the returned CallContext, and assert the callback received a
+// CANCELLED status the cancellation message.
+TEST_F(GrpcCancellationTest, TestGrpcAsyncInfer)
+{
+  std::vector<tc::InferInput*> inputs;
+  std::vector<const tc::InferRequestedOutput*> outputs;
+  ASSERT_TRUE(PrepareRequest(&inputs, &outputs).IsOk());
+
+  tc::CallContext* raw_ctx = nullptr;
+  ASSERT_TRUE(client_
+                  ->AsyncInfer(
+                      callback_, MakeOptions(), inputs, outputs,
+                      /*headers=*/{}, GRPC_COMPRESS_NONE, &raw_ctx)
+                  .IsOk());
+  ASSERT_NE(raw_ctx, nullptr);
+  std::unique_ptr<tc::CallContext> ctx(raw_ctx);
+
+  std::this_thread::sleep_for(kInflightWait);
+  ASSERT_TRUE(ctx->Cancel().IsOk());
+
+  ASSERT_TRUE(WaitForResult(kCallbackTimeout))
+      << "callback was never invoked after Cancel()";
+  ExpectLocalCancel(result_.get());
+
+  CleanupRequest(&inputs, &outputs);
+}
+
+// C++-specific lifetime check: the CallContext co-owns the ClientContext
+// and may outlive the RPC. Cancel() after natural completion must be a safe
+// no-op and must not double-fire the callback.
+TEST_F(GrpcCancellationTest, TestGrpcAsyncInferCancelAfterCompletionIsNoOp)
+{
+  std::vector<tc::InferInput*> inputs;
+  std::vector<const tc::InferRequestedOutput*> outputs;
+  ASSERT_TRUE(PrepareRequest(&inputs, &outputs).IsOk());
+
+  tc::CallContext* raw_ctx = nullptr;
+  ASSERT_TRUE(client_
+                  ->AsyncInfer(
+                      callback_, MakeOptions(), inputs, outputs,
+                      /*headers=*/{}, GRPC_COMPRESS_NONE, &raw_ctx)
+                  .IsOk());
+  ASSERT_NE(raw_ctx, nullptr);
+  std::unique_ptr<tc::CallContext> ctx(raw_ctx);
+
+  ASSERT_TRUE(WaitForResult(kCompletionTimeout)) << "inference never completed";
+  ExpectEchoOutput(result_.get());
+
+  ASSERT_TRUE(ctx->Cancel().IsOk());
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  ASSERT_EQ(GetCallbackCount(), 1)
+      << "Cancel() after completion produced an extra callback";
+
+  CleanupRequest(&inputs, &outputs);
+}
+
+// Backwards-compat: AsyncInfer() called without ctx_out (the default arg)
+// keeps its previous behavior and does not return a handle.
+TEST_F(GrpcCancellationTest, TestGrpcAsyncInferWithoutContextStillCompletes)
+{
+  std::vector<tc::InferInput*> inputs;
+  std::vector<const tc::InferRequestedOutput*> outputs;
+  ASSERT_TRUE(PrepareRequest(&inputs, &outputs).IsOk());
+
+  ASSERT_TRUE(
+      client_->AsyncInfer(callback_, MakeOptions(), inputs, outputs).IsOk());
+
+  ASSERT_TRUE(WaitForResult(kCompletionTimeout))
+      << "inference never completed without CallContext";
+  ExpectEchoOutput(result_.get());
+
+  CleanupRequest(&inputs, &outputs);
+}
+
+// ---------------------------------------------------------------------------
+// AsyncInferMulti cancellation tests.
+// ---------------------------------------------------------------------------
+
+// C++-specific: AsyncInferMulti fans one logical batch out to N AsyncInfer
+// calls and fires its OnMultiCompleteFn once after all leaves complete.
+// Cancel requests 0 and 2 while letting request 1 complete naturally to
+// verify cancellation is per-request (siblings unaffected), result order
+// matches input order, and the multi callback fires exactly once.
+TEST_F(GrpcCancellationTest, TestGrpcAsyncInferMulti)
+{
+  constexpr size_t kNumRequests = 3;
+  constexpr size_t kSucceedIndex = 1;
+
+  std::vector<std::vector<tc::InferInput*>> inputs(kNumRequests);
+  std::vector<std::vector<const tc::InferRequestedOutput*>> outputs(
+      kNumRequests);
+  for (size_t i = 0; i < kNumRequests; ++i) {
+    ASSERT_TRUE(PrepareRequest(&inputs[i], &outputs[i]).IsOk());
+  }
+
+  // OnMultiCompleteFn signature differs from the fixture's callback_,
+  // so synchronize locally.
+  std::mutex local_mutex;
+  std::condition_variable local_cv;
+  std::vector<tc::InferResult*> captured_results;
+  int multi_callback_count = 0;
+  auto multi_callback =
+      [&local_mutex, &local_cv, &captured_results,
+       &multi_callback_count](std::vector<tc::InferResult*> results) {
+        std::lock_guard<std::mutex> lk(local_mutex);
+        captured_results = std::move(results);
+        ++multi_callback_count;
+        local_cv.notify_one();
+      };
+
+  std::vector<tc::CallContext*> raw_ctxs;
+  std::vector<tc::InferOptions> options = {MakeOptions()};
+  ASSERT_TRUE(client_
+                  ->AsyncInferMulti(
+                      multi_callback, options, inputs, outputs,
+                      /*headers=*/{}, GRPC_COMPRESS_NONE, &raw_ctxs)
+                  .IsOk());
+  ASSERT_EQ(raw_ctxs.size(), kNumRequests);
+
+  // Own the returned contexts so they get deleted even if an ASSERT fires.
+  std::vector<std::unique_ptr<tc::CallContext>> ctxs;
+  ctxs.reserve(raw_ctxs.size());
+  for (auto* raw : raw_ctxs) {
+    ASSERT_NE(raw, nullptr);
+    ctxs.emplace_back(raw);
+  }
+
+  std::this_thread::sleep_for(kInflightWait);
+  for (size_t i = 0; i < ctxs.size(); ++i) {
+    if (i != kSucceedIndex) {
+      ASSERT_TRUE(ctxs[i]->Cancel().IsOk());
+    }
+  }
+
+  {
+    // Multi callback fires only after every leaf completes, so the
+    // uncancelled request must run the full model delay; use the
+    // completion-sized timeout, not the cancel-sized one.
+    std::unique_lock<std::mutex> lk(local_mutex);
+    ASSERT_TRUE(local_cv.wait_for(lk, kCompletionTimeout, [&] {
+      return multi_callback_count > 0;
+    })) << "multi callback was never invoked";
+    EXPECT_EQ(multi_callback_count, 1) << "multi callback fired more than once";
+    ASSERT_EQ(captured_results.size(), kNumRequests);
+    for (size_t i = 0; i < captured_results.size(); ++i) {
+      if (i == kSucceedIndex) {
+        ExpectEchoOutput(captured_results[i]);
+      } else {
+        ExpectLocalCancel(captured_results[i]);
+      }
+    }
+  }
+
+  for (auto* r : captured_results) {
+    delete r;
+  }
+  for (size_t i = 0; i < kNumRequests; ++i) {
+    CleanupRequest(&inputs[i], &outputs[i]);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming cancellation tests.
+// ---------------------------------------------------------------------------
+
+// Start a stream, send 3 inferences, sleep so the requests are in flight on
+// the server, then call StopStream(cancel_requests=true) and assert the
+// callback received the cancellation message.
+TEST_F(GrpcCancellationTest, TestGrpcStreamInfer)
+{
+  constexpr int kNumStreamRequests = 3;
+
+  ASSERT_TRUE(client_->StartStream(callback_, /*enable_stats=*/false).IsOk());
+
+  std::vector<std::vector<tc::InferInput*>> inputs(kNumStreamRequests);
+  std::vector<std::vector<const tc::InferRequestedOutput*>> outputs(
+      kNumStreamRequests);
+  for (int i = 0; i < kNumStreamRequests; ++i) {
+    ASSERT_TRUE(PrepareRequest(&inputs[i], &outputs[i]).IsOk());
+    ASSERT_TRUE(
+        client_->AsyncStreamInfer(MakeOptions(), inputs[i], outputs[i]).IsOk());
+  }
+
+  std::this_thread::sleep_for(kInflightWait);
+  ASSERT_TRUE(client_->StopStream(/*cancel_requests=*/true).IsOk());
+
+  ASSERT_TRUE(WaitForResult(kCallbackTimeout))
+      << "stream callback was never invoked after StopStream(cancel)";
+  ExpectLocalCancel(result_.get());
+  EXPECT_EQ(GetCallbackCount(), 1)
+      << "expected exactly one synthesized cancel callback per stream, got "
+      << GetCallbackCount();
+
+  for (int i = 0; i < kNumStreamRequests; ++i) {
+    CleanupRequest(&inputs[i], &outputs[i]);
+  }
+}
+
+// C++-specific safety check: cancelling a freshly-started stream that has
+// never sent a request should still surface cancellation message via the
+// callback exactly once.
+TEST_F(GrpcCancellationTest, TestGrpcStreamCancelWithoutInfer)
+{
+  ASSERT_TRUE(client_->StartStream(callback_, /*enable_stats=*/false).IsOk());
+  ASSERT_TRUE(client_->StopStream(/*cancel_requests=*/true).IsOk());
+
+  ASSERT_TRUE(WaitForResult(kCallbackTimeout))
+      << "stream callback was never invoked after StopStream(cancel)";
+  ExpectLocalCancel(result_.get());
+}
+
+// C++-specific lifecycle check: after a cancelled stream, the client must
+// be able to start a fresh stream and run a successful inference. Mirrors
+// the rebind-grpc_context_ behavior added in StartStream().
+TEST_F(GrpcCancellationTest, TestGrpcStreamCancelThenRestart)
+{
+  // ---- Phase 1: start a stream and cancel it before sending any request.
+  ASSERT_TRUE(client_->StartStream(callback_, /*enable_stats=*/false).IsOk());
+  ASSERT_TRUE(client_->StopStream(/*cancel_requests=*/true).IsOk());
+  ASSERT_TRUE(WaitForResult(kCallbackTimeout))
+      << "stream callback was never invoked after StopStream(cancel)";
+  ExpectLocalCancel(result_.get());
+
+  // ---- Phase 2: start a fresh stream and run a successful inference.
+  // Clear fixture state so WaitForResult() observes the new callback, not
+  // the leftover phase-1 result.
+  ResetCapturedResult();
+
+  ASSERT_TRUE(client_->StartStream(callback_, /*enable_stats=*/false).IsOk());
+
+  std::vector<tc::InferInput*> inputs;
+  std::vector<const tc::InferRequestedOutput*> outputs;
+  ASSERT_TRUE(PrepareRequest(&inputs, &outputs).IsOk());
+  ASSERT_TRUE(client_->AsyncStreamInfer(MakeOptions(), inputs, outputs).IsOk());
+
+  // Graceful close: WritesDone + drain. Blocks until the slow model's
+  // response arrives, so the success callback has fired by the time the
+  // call below returns.
+  ASSERT_TRUE(client_->StopStream(/*cancel_requests=*/false).IsOk());
+
+  ASSERT_TRUE(WaitForResult(kCompletionTimeout))
+      << "expected successful inference after restarting stream";
+  ExpectEchoOutput(result_.get());
+
+  CleanupRequest(&inputs, &outputs);
+}
+
+}  // namespace
+
+int
+main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/c++/tests/grpc_cancellation_test.cc
+++ b/src/c++/tests/grpc_cancellation_test.cc
@@ -246,50 +246,6 @@ TEST_F(GrpcCancellationTest, TestGrpcAsyncInferCancelExecutingRequest)
   CleanupInputs(&inputs);
 }
 
-// C++-specific lifetime check: the CallContext co-owns the ClientContext and
-// may outlive the RPC. Cancel() after natural completion must be a safe no-op
-// and must not invoke the callback again.
-TEST_F(GrpcCancellationTest, TestGrpcAsyncInferCancelAfterCompletionIsNoOp)
-{
-  std::vector<tc::InferInput*> inputs;
-  ASSERT_TRUE(PrepareInputs(&inputs).IsOk());
-
-  tc::CallContext* raw_ctx = nullptr;
-  ASSERT_TRUE(client_
-                  ->AsyncInfer(
-                      callback_, MakeOptions(), inputs, /*outputs=*/{},
-                      /*headers=*/{}, GRPC_COMPRESS_NONE, &raw_ctx)
-                  .IsOk());
-  ASSERT_NE(raw_ctx, nullptr);
-  std::unique_ptr<tc::CallContext> ctx(raw_ctx);
-
-  ASSERT_TRUE(WaitForResult(kCompletionTimeout)) << "inference never completed";
-  ExpectEchoOutput(result_.get());
-
-  ASSERT_TRUE(ctx->Cancel().IsOk());
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
-  ASSERT_EQ(GetCallbackCount(), 1)
-      << "Cancel() after completion produced an extra callback";
-
-  CleanupInputs(&inputs);
-}
-
-// Backwards-compat: AsyncInfer() called without ctx_out (the default arg)
-// keeps its previous behavior and does not return a handle.
-TEST_F(GrpcCancellationTest, TestGrpcAsyncInferWithoutContextStillCompletes)
-{
-  std::vector<tc::InferInput*> inputs;
-  ASSERT_TRUE(PrepareInputs(&inputs).IsOk());
-
-  ASSERT_TRUE(client_->AsyncInfer(callback_, MakeOptions(), inputs).IsOk());
-
-  ASSERT_TRUE(WaitForResult(kCompletionTimeout))
-      << "inference never completed without CallContext";
-  ExpectEchoOutput(result_.get());
-
-  CleanupInputs(&inputs);
-}
-
 // Two consecutive unary AsyncInfer calls on a single-instance delayed model:
 // the first runs, the second queues. Cancel the second, assert local cancel,
 // then cancel the first so the test does not wait for the full model delay.
@@ -342,6 +298,50 @@ TEST_F(GrpcCancellationTest, TestGrpcAsyncInferCancelQueuedRequest)
 
   CleanupInputs(&inputs0);
   CleanupInputs(&inputs1);
+}
+
+// C++-specific lifetime check: the CallContext co-owns the ClientContext and
+// may outlive the RPC. Cancel() after natural completion must be a safe no-op
+// and must not invoke the callback again.
+TEST_F(GrpcCancellationTest, TestGrpcAsyncInferCancelAfterCompletionIsNoOp)
+{
+  std::vector<tc::InferInput*> inputs;
+  ASSERT_TRUE(PrepareInputs(&inputs).IsOk());
+
+  tc::CallContext* raw_ctx = nullptr;
+  ASSERT_TRUE(client_
+                  ->AsyncInfer(
+                      callback_, MakeOptions(), inputs, /*outputs=*/{},
+                      /*headers=*/{}, GRPC_COMPRESS_NONE, &raw_ctx)
+                  .IsOk());
+  ASSERT_NE(raw_ctx, nullptr);
+  std::unique_ptr<tc::CallContext> ctx(raw_ctx);
+
+  ASSERT_TRUE(WaitForResult(kCompletionTimeout)) << "inference never completed";
+  ExpectEchoOutput(result_.get());
+
+  ASSERT_TRUE(ctx->Cancel().IsOk());
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  ASSERT_EQ(GetCallbackCount(), 1)
+      << "Cancel() after completion produced an extra callback";
+
+  CleanupInputs(&inputs);
+}
+
+// Backwards-compat: AsyncInfer() called without ctx_out (the default arg)
+// keeps its previous behavior and does not return a handle.
+TEST_F(GrpcCancellationTest, TestGrpcAsyncInferWithoutContextStillCompletes)
+{
+  std::vector<tc::InferInput*> inputs;
+  ASSERT_TRUE(PrepareInputs(&inputs).IsOk());
+
+  ASSERT_TRUE(client_->AsyncInfer(callback_, MakeOptions(), inputs).IsOk());
+
+  ASSERT_TRUE(WaitForResult(kCompletionTimeout))
+      << "inference never completed without CallContext";
+  ExpectEchoOutput(result_.get());
+
+  CleanupInputs(&inputs);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/c++/tests/grpc_cancellation_test.cc
+++ b/src/c++/tests/grpc_cancellation_test.cc
@@ -51,8 +51,8 @@ constexpr auto kInflightWait = std::chrono::seconds(2);
 // The cancel itself should arrive much faster than the 10s model delay.
 constexpr auto kCallbackTimeout = std::chrono::seconds(5);
 
-// Upper bound for natural (non-cancelled) completion. The model's per-
-// request delay is 10s, so this leaves ~5s of headroom for jitter.
+// Upper bound for natural (non-cancelled) completion. The model's per-request
+// delay is 10s, so this leaves ~5s of headroom for jitter.
 constexpr auto kCompletionTimeout = std::chrono::seconds(15);
 
 class GrpcCancellationTest : public ::testing::Test {
@@ -64,37 +64,45 @@ class GrpcCancellationTest : public ::testing::Test {
         << "failed to create GRPC client: " << err.Message();
   }
 
-  // Blocks up to `timeout` for callback_ to capture the first result.
-  // Returns true if a result was received within the timeout, false on
-  // timeout.
+  // Blocks up to `timeout` until callback_ has captured a result.
+  // Returns true if a result was received within the timeout, false on timeout.
   bool WaitForResult(std::chrono::milliseconds timeout)
   {
     std::unique_lock<std::mutex> lk(mutex_);
     return cv_.wait_for(lk, timeout, [this] { return result_ != nullptr; });
   }
 
-  // Returns the number of times callback_ has been invoked. Safe to
-  // call from the test thread at any time.
+  // Blocks up to `timeout` until multi_callback_ has captured any result.
+  // Returns true if any result was received within the timeout, false on
+  // timeout.
+  bool WaitForMultiResult(std::chrono::milliseconds timeout)
+  {
+    std::unique_lock<std::mutex> lk(mutex_);
+    return cv_.wait_for(
+        lk, timeout, [this] { return !multi_results_.empty(); });
+  }
+
+  // Returns the number of times a callback has been invoked. Safe to call from
+  // the test thread at any time.
   int GetCallbackCount()
   {
     std::lock_guard<std::mutex> lk(mutex_);
     return callback_count_;
   }
 
-  // Clears the captured result and counter so a single test can reuse the
-  // fixture across multiple phases (e.g., the cancel-then-restart test).
+  // Clears captured results and counter so a single test can reuse the fixture
+  // across multiple phases (e.g., the cancel-then-restart test).
   void ResetCapturedResult()
   {
     std::lock_guard<std::mutex> lk(mutex_);
     result_.reset();
+    multi_results_.clear();
     callback_count_ = 0;
   }
 
-  // Builds a single INPUT0/OUTPUT0 pair matching the Python suite's
-  // _prepare_request(). Caller owns the returned pointers.
-  tc::Error PrepareRequest(
-      std::vector<tc::InferInput*>* inputs,
-      std::vector<const tc::InferRequestedOutput*>* outputs)
+  // Builds the INPUT0 tensor with input_data_. Caller owns the returned
+  // pointers and must release them via CleanupInputs().
+  tc::Error PrepareInputs(std::vector<tc::InferInput*>* inputs)
   {
     inputs->emplace_back();
     auto err =
@@ -102,33 +110,17 @@ class GrpcCancellationTest : public ::testing::Test {
     if (!err.IsOk()) {
       return err;
     }
-    err = inputs->back()->AppendRaw(
+    return inputs->back()->AppendRaw(
         reinterpret_cast<const uint8_t*>(input_data_.data()),
         input_data_.size() * sizeof(int32_t));
-    if (!err.IsOk()) {
-      return err;
-    }
-    tc::InferRequestedOutput* out0 = nullptr;
-    err = tc::InferRequestedOutput::Create(&out0, "OUTPUT0");
-    if (!err.IsOk()) {
-      return err;
-    }
-    outputs->push_back(out0);
-    return tc::Error::Success;
   }
 
-  static void CleanupRequest(
-      std::vector<tc::InferInput*>* inputs,
-      std::vector<const tc::InferRequestedOutput*>* outputs)
+  static void CleanupInputs(std::vector<tc::InferInput*>* inputs)
   {
     for (auto* in : *inputs) {
       delete in;
     }
-    for (auto* out : *outputs) {
-      delete const_cast<tc::InferRequestedOutput*>(out);
-    }
     inputs->clear();
-    outputs->clear();
   }
 
   tc::InferOptions MakeOptions() const
@@ -138,9 +130,9 @@ class GrpcCancellationTest : public ::testing::Test {
     return options;
   }
 
-  // Verifies a successful response echoes input_data_ on OUTPUT0 with
-  // matching shape and dtype. Run on the test thread after the callback
-  // has stashed the result.
+  // Verifies a successful response echoes input_data_ on OUTPUT0 with matching
+  // shape and dtype. Run on the test thread after the callback has stashed the
+  // result.
   void ExpectEchoOutput(tc::InferResult* result) const
   {
     ASSERT_NE(result, nullptr);
@@ -184,17 +176,19 @@ class GrpcCancellationTest : public ::testing::Test {
   const std::string dtype_ = "INT32";
   std::unique_ptr<tc::InferenceServerGrpcClient> client_;
 
-  // Synchronization for callbacks fired on the gRPC worker thread. Tests
-  // pass callback_ into AsyncInfer/StartStream and then either call
-  // WaitForResult() or sleep before inspecting result_/callback_count_.
+  // Synchronization for callbacks fired on the gRPC worker thread. The unary
+  // callback_ writes to result_ and the multi callback_ writes to
+  // multi_results_; both share mutex_ / cv_ / callback_count_ because tests
+  // use one path or the other, never both at once.
   std::mutex mutex_;
   std::condition_variable cv_;
   std::unique_ptr<tc::InferResult> result_;
+  std::vector<std::unique_ptr<tc::InferResult>> multi_results_;
   int callback_count_ = 0;
 
   // Stashes the first InferResult into result_ and counts every invocation.
-  // Subsequent results are deleted so a buggy double-callback doesn't leak;
-  // tests then catch it by checking GetCallbackCount().
+  // Subsequent results are deleted; tests inspect GetCallbackCount() for the
+  // expected number of invocations.
   tc::InferenceServerClient::OnCompleteFn callback_ =
       [this](tc::InferResult* r) {
         std::lock_guard<std::mutex> lk(mutex_);
@@ -206,25 +200,37 @@ class GrpcCancellationTest : public ::testing::Test {
         ++callback_count_;
         cv_.notify_one();
       };
+
+  // Stores the received batch into multi_results_ and counts the invocation.
+  tc::InferenceServerClient::OnMultiCompleteFn multi_callback_ =
+      [this](std::vector<tc::InferResult*> results) {
+        std::lock_guard<std::mutex> lk(mutex_);
+        multi_results_.clear();
+        multi_results_.reserve(results.size());
+        for (auto* r : results) {
+          multi_results_.emplace_back(r);
+        }
+        ++callback_count_;
+        cv_.notify_one();
+      };
 };
 
 // ---------------------------------------------------------------------------
 // Unary cancellation tests.
 // ---------------------------------------------------------------------------
 
-// Launch an async inference, sleep briefly so the RPC is in flight, call
-// Cancel() on the returned CallContext, and assert the callback received a
-// CANCELLED status the cancellation message.
-TEST_F(GrpcCancellationTest, TestGrpcAsyncInfer)
+// Launch an async inference, sleep briefly so the backend is executing the
+// request, call Cancel() on the returned CallContext, and assert the callback
+// received a CANCELLED status in the cancellation message.
+TEST_F(GrpcCancellationTest, TestGrpcAsyncInferCancelExecutingRequest)
 {
   std::vector<tc::InferInput*> inputs;
-  std::vector<const tc::InferRequestedOutput*> outputs;
-  ASSERT_TRUE(PrepareRequest(&inputs, &outputs).IsOk());
+  ASSERT_TRUE(PrepareInputs(&inputs).IsOk());
 
   tc::CallContext* raw_ctx = nullptr;
   ASSERT_TRUE(client_
                   ->AsyncInfer(
-                      callback_, MakeOptions(), inputs, outputs,
+                      callback_, MakeOptions(), inputs, /*outputs=*/{},
                       /*headers=*/{}, GRPC_COMPRESS_NONE, &raw_ctx)
                   .IsOk());
   ASSERT_NE(raw_ctx, nullptr);
@@ -237,22 +243,21 @@ TEST_F(GrpcCancellationTest, TestGrpcAsyncInfer)
       << "callback was never invoked after Cancel()";
   ExpectLocalCancel(result_.get());
 
-  CleanupRequest(&inputs, &outputs);
+  CleanupInputs(&inputs);
 }
 
-// C++-specific lifetime check: the CallContext co-owns the ClientContext
-// and may outlive the RPC. Cancel() after natural completion must be a safe
-// no-op and must not double-fire the callback.
+// C++-specific lifetime check: the CallContext co-owns the ClientContext and
+// may outlive the RPC. Cancel() after natural completion must be a safe no-op
+// and must not invoke the callback again.
 TEST_F(GrpcCancellationTest, TestGrpcAsyncInferCancelAfterCompletionIsNoOp)
 {
   std::vector<tc::InferInput*> inputs;
-  std::vector<const tc::InferRequestedOutput*> outputs;
-  ASSERT_TRUE(PrepareRequest(&inputs, &outputs).IsOk());
+  ASSERT_TRUE(PrepareInputs(&inputs).IsOk());
 
   tc::CallContext* raw_ctx = nullptr;
   ASSERT_TRUE(client_
                   ->AsyncInfer(
-                      callback_, MakeOptions(), inputs, outputs,
+                      callback_, MakeOptions(), inputs, /*outputs=*/{},
                       /*headers=*/{}, GRPC_COMPRESS_NONE, &raw_ctx)
                   .IsOk());
   ASSERT_NE(raw_ctx, nullptr);
@@ -266,7 +271,7 @@ TEST_F(GrpcCancellationTest, TestGrpcAsyncInferCancelAfterCompletionIsNoOp)
   ASSERT_EQ(GetCallbackCount(), 1)
       << "Cancel() after completion produced an extra callback";
 
-  CleanupRequest(&inputs, &outputs);
+  CleanupInputs(&inputs);
 }
 
 // Backwards-compat: AsyncInfer() called without ctx_out (the default arg)
@@ -274,60 +279,95 @@ TEST_F(GrpcCancellationTest, TestGrpcAsyncInferCancelAfterCompletionIsNoOp)
 TEST_F(GrpcCancellationTest, TestGrpcAsyncInferWithoutContextStillCompletes)
 {
   std::vector<tc::InferInput*> inputs;
-  std::vector<const tc::InferRequestedOutput*> outputs;
-  ASSERT_TRUE(PrepareRequest(&inputs, &outputs).IsOk());
+  ASSERT_TRUE(PrepareInputs(&inputs).IsOk());
 
-  ASSERT_TRUE(
-      client_->AsyncInfer(callback_, MakeOptions(), inputs, outputs).IsOk());
+  ASSERT_TRUE(client_->AsyncInfer(callback_, MakeOptions(), inputs).IsOk());
 
   ASSERT_TRUE(WaitForResult(kCompletionTimeout))
       << "inference never completed without CallContext";
   ExpectEchoOutput(result_.get());
 
-  CleanupRequest(&inputs, &outputs);
+  CleanupInputs(&inputs);
+}
+
+// Two consecutive unary AsyncInfer calls on a single-instance delayed model:
+// the first runs, the second queues. Cancel the second, assert local cancel,
+// then cancel the first so the test does not wait for the full model delay.
+TEST_F(GrpcCancellationTest, TestGrpcAsyncInferCancelQueuedRequest)
+{
+  std::vector<tc::InferInput*> inputs0, inputs1;
+  ASSERT_TRUE(PrepareInputs(&inputs0).IsOk());
+  ASSERT_TRUE(PrepareInputs(&inputs1).IsOk());
+
+  tc::CallContext* executing_ctx_raw = nullptr;
+  ASSERT_TRUE(client_
+                  ->AsyncInfer(
+                      callback_, MakeOptions(), inputs0, /*outputs=*/{},
+                      /*headers=*/{}, GRPC_COMPRESS_NONE, &executing_ctx_raw)
+                  .IsOk());
+  ASSERT_NE(executing_ctx_raw, nullptr);
+  std::unique_ptr<tc::CallContext> executing_ctx(executing_ctx_raw);
+
+  // Wait for the first request to be received by the server and dispatched
+  // to the single instance before issuing the second; otherwise the two
+  // RPCs race and either may end up executing.
+  std::this_thread::sleep_for(kInflightWait);
+
+  tc::CallContext* queued_ctx_raw = nullptr;
+  ASSERT_TRUE(client_
+                  ->AsyncInfer(
+                      callback_, MakeOptions(), inputs1, /*outputs=*/{},
+                      /*headers=*/{}, GRPC_COMPRESS_NONE, &queued_ctx_raw)
+                  .IsOk());
+  ASSERT_NE(queued_ctx_raw, nullptr);
+  std::unique_ptr<tc::CallContext> queued_ctx(queued_ctx_raw);
+
+  // Wait for the second request to reach the server and be enqueued (the
+  // only instance is still busy with the first request) before cancelling.
+  std::this_thread::sleep_for(kInflightWait);
+
+  // Cancel the queued request first.
+  ASSERT_TRUE(queued_ctx->Cancel().IsOk());
+  ASSERT_TRUE(WaitForResult(kCallbackTimeout))
+      << "queued request callback not invoked after Cancel()";
+  ExpectLocalCancel(result_.get());
+
+  // Then cancel the executing request so the test does not wait for the
+  // full model delay.
+  ResetCapturedResult();
+  ASSERT_TRUE(executing_ctx->Cancel().IsOk());
+  ASSERT_TRUE(WaitForResult(kCallbackTimeout))
+      << "executing request callback not invoked after Cancel()";
+  ExpectLocalCancel(result_.get());
+
+  CleanupInputs(&inputs0);
+  CleanupInputs(&inputs1);
 }
 
 // ---------------------------------------------------------------------------
 // AsyncInferMulti cancellation tests.
 // ---------------------------------------------------------------------------
 
-// C++-specific: AsyncInferMulti fans one logical batch out to N AsyncInfer
-// calls and fires its OnMultiCompleteFn once after all leaves complete.
-// Cancel requests 0 and 2 while letting request 1 complete naturally to
-// verify cancellation is per-request (siblings unaffected), result order
+// C++-specific: AsyncInferMulti sends N AsyncInfer calls and fires its
+// OnMultiCompleteFn once when all leaves complete. Cancel requests 0 and 2
+// (both executing on the server) while letting request 1 complete naturally
+// to verify per-request cancellation (siblings unaffected), result order
 // matches input order, and the multi callback fires exactly once.
-TEST_F(GrpcCancellationTest, TestGrpcAsyncInferMulti)
+TEST_F(GrpcCancellationTest, TestGrpcAsyncInferMultiCancelExecutingRequests)
 {
   constexpr size_t kNumRequests = 3;
   constexpr size_t kSucceedIndex = 1;
 
   std::vector<std::vector<tc::InferInput*>> inputs(kNumRequests);
-  std::vector<std::vector<const tc::InferRequestedOutput*>> outputs(
-      kNumRequests);
   for (size_t i = 0; i < kNumRequests; ++i) {
-    ASSERT_TRUE(PrepareRequest(&inputs[i], &outputs[i]).IsOk());
+    ASSERT_TRUE(PrepareInputs(&inputs[i]).IsOk());
   }
-
-  // OnMultiCompleteFn signature differs from the fixture's callback_,
-  // so synchronize locally.
-  std::mutex local_mutex;
-  std::condition_variable local_cv;
-  std::vector<tc::InferResult*> captured_results;
-  int multi_callback_count = 0;
-  auto multi_callback =
-      [&local_mutex, &local_cv, &captured_results,
-       &multi_callback_count](std::vector<tc::InferResult*> results) {
-        std::lock_guard<std::mutex> lk(local_mutex);
-        captured_results = std::move(results);
-        ++multi_callback_count;
-        local_cv.notify_one();
-      };
 
   std::vector<tc::CallContext*> raw_ctxs;
   std::vector<tc::InferOptions> options = {MakeOptions()};
   ASSERT_TRUE(client_
                   ->AsyncInferMulti(
-                      multi_callback, options, inputs, outputs,
+                      multi_callback_, options, inputs, /*outputs=*/{},
                       /*headers=*/{}, GRPC_COMPRESS_NONE, &raw_ctxs)
                   .IsOk());
   ASSERT_EQ(raw_ctxs.size(), kNumRequests);
@@ -347,30 +387,76 @@ TEST_F(GrpcCancellationTest, TestGrpcAsyncInferMulti)
     }
   }
 
+  // Multi callback fires only after every leaf completes, so the uncancelled
+  // request must run the full model delay; use the completion-sized timeout,
+  // not the cancel-sized one.
+  ASSERT_TRUE(WaitForMultiResult(kCompletionTimeout))
+      << "multi callback was never invoked";
   {
-    // Multi callback fires only after every leaf completes, so the
-    // uncancelled request must run the full model delay; use the
-    // completion-sized timeout, not the cancel-sized one.
-    std::unique_lock<std::mutex> lk(local_mutex);
-    ASSERT_TRUE(local_cv.wait_for(lk, kCompletionTimeout, [&] {
-      return multi_callback_count > 0;
-    })) << "multi callback was never invoked";
-    EXPECT_EQ(multi_callback_count, 1) << "multi callback fired more than once";
-    ASSERT_EQ(captured_results.size(), kNumRequests);
-    for (size_t i = 0; i < captured_results.size(); ++i) {
+    std::lock_guard<std::mutex> lk(mutex_);
+    EXPECT_EQ(callback_count_, 1)
+        << "expected exactly one multi callback invocation";
+    ASSERT_EQ(multi_results_.size(), kNumRequests);
+    for (size_t i = 0; i < multi_results_.size(); ++i) {
       if (i == kSucceedIndex) {
-        ExpectEchoOutput(captured_results[i]);
+        ExpectEchoOutput(multi_results_[i].get());
       } else {
-        ExpectLocalCancel(captured_results[i]);
+        ExpectLocalCancel(multi_results_[i].get());
       }
     }
   }
 
-  for (auto* r : captured_results) {
-    delete r;
-  }
   for (size_t i = 0; i < kNumRequests; ++i) {
-    CleanupRequest(&inputs[i], &outputs[i]);
+    CleanupInputs(&inputs[i]);
+  }
+}
+
+// AsyncInferMulti sends two requests to a single-instance delayed model: one
+// is executed, the other is queued. Cancel both per-request CallContexts;
+// the multi callback must fire exactly once with both results locally cancelled
+// regardless of which request was queued vs executed.
+TEST_F(GrpcCancellationTest, TestGrpcAsyncInferMultiCancelQueuedRequest)
+{
+  constexpr size_t kNumRequests = 2;
+
+  std::vector<std::vector<tc::InferInput*>> inputs(kNumRequests);
+  for (size_t i = 0; i < kNumRequests; ++i) {
+    ASSERT_TRUE(PrepareInputs(&inputs[i]).IsOk());
+  }
+
+  std::vector<tc::CallContext*> raw_ctxs;
+  std::vector<tc::InferOptions> options = {MakeOptions()};
+  ASSERT_TRUE(client_
+                  ->AsyncInferMulti(
+                      multi_callback_, options, inputs, /*outputs=*/{},
+                      /*headers=*/{}, GRPC_COMPRESS_NONE, &raw_ctxs)
+                  .IsOk());
+  ASSERT_EQ(raw_ctxs.size(), kNumRequests);
+
+  std::vector<std::unique_ptr<tc::CallContext>> ctxs;
+  ctxs.reserve(raw_ctxs.size());
+  for (auto* raw : raw_ctxs) {
+    ASSERT_NE(raw, nullptr);
+    ctxs.emplace_back(raw);
+  }
+
+  std::this_thread::sleep_for(kInflightWait);
+  ASSERT_TRUE(ctxs[1]->Cancel().IsOk());
+  ASSERT_TRUE(ctxs[0]->Cancel().IsOk());
+
+  ASSERT_TRUE(WaitForMultiResult(kCallbackTimeout))
+      << "multi callback was never invoked";
+  {
+    std::lock_guard<std::mutex> lk(mutex_);
+    EXPECT_EQ(callback_count_, 1)
+        << "expected exactly one multi callback invocation";
+    ASSERT_EQ(multi_results_.size(), kNumRequests);
+    ExpectLocalCancel(multi_results_[0].get());
+    ExpectLocalCancel(multi_results_[1].get());
+  }
+
+  for (size_t i = 0; i < kNumRequests; ++i) {
+    CleanupInputs(&inputs[i]);
   }
 }
 
@@ -378,22 +464,19 @@ TEST_F(GrpcCancellationTest, TestGrpcAsyncInferMulti)
 // Streaming cancellation tests.
 // ---------------------------------------------------------------------------
 
-// Start a stream, send 3 inferences, sleep so the requests are in flight on
-// the server, then call StopStream(cancel_requests=true) and assert the
-// callback received the cancellation message.
-TEST_F(GrpcCancellationTest, TestGrpcStreamInfer)
+// Start a stream, send 3 inferences, sleep so the requests are executing
+// on the server, then call StopStream(cancel_requests=true) and assert the
+// callback received the cancellation message exactly once.
+TEST_F(GrpcCancellationTest, TestGrpcStreamInferCancelExecutingRequest)
 {
   constexpr int kNumStreamRequests = 3;
 
   ASSERT_TRUE(client_->StartStream(callback_, /*enable_stats=*/false).IsOk());
 
   std::vector<std::vector<tc::InferInput*>> inputs(kNumStreamRequests);
-  std::vector<std::vector<const tc::InferRequestedOutput*>> outputs(
-      kNumStreamRequests);
   for (int i = 0; i < kNumStreamRequests; ++i) {
-    ASSERT_TRUE(PrepareRequest(&inputs[i], &outputs[i]).IsOk());
-    ASSERT_TRUE(
-        client_->AsyncStreamInfer(MakeOptions(), inputs[i], outputs[i]).IsOk());
+    ASSERT_TRUE(PrepareInputs(&inputs[i]).IsOk());
+    ASSERT_TRUE(client_->AsyncStreamInfer(MakeOptions(), inputs[i]).IsOk());
   }
 
   std::this_thread::sleep_for(kInflightWait);
@@ -407,7 +490,37 @@ TEST_F(GrpcCancellationTest, TestGrpcStreamInfer)
       << GetCallbackCount();
 
   for (int i = 0; i < kNumStreamRequests; ++i) {
-    CleanupRequest(&inputs[i], &outputs[i]);
+    CleanupInputs(&inputs[i]);
+  }
+}
+
+// Two consecutive stream inferences; with a single delayed instance the second
+// should queue. StopStream(cancel) tears down the stream and cancels pending
+// work including the queued request.
+TEST_F(GrpcCancellationTest, TestGrpcStreamInferCancelQueuedRequest)
+{
+  constexpr int kNumStreamRequests = 2;
+
+  ASSERT_TRUE(client_->StartStream(callback_, /*enable_stats=*/false).IsOk());
+
+  std::vector<std::vector<tc::InferInput*>> inputs(kNumStreamRequests);
+  for (int i = 0; i < kNumStreamRequests; ++i) {
+    ASSERT_TRUE(PrepareInputs(&inputs[i]).IsOk());
+    ASSERT_TRUE(client_->AsyncStreamInfer(MakeOptions(), inputs[i]).IsOk());
+  }
+
+  std::this_thread::sleep_for(kInflightWait);
+  ASSERT_TRUE(client_->StopStream(/*cancel_requests=*/true).IsOk());
+
+  ASSERT_TRUE(WaitForResult(kCallbackTimeout))
+      << "stream callback was never invoked after StopStream(cancel)";
+  ExpectLocalCancel(result_.get());
+  EXPECT_EQ(GetCallbackCount(), 1)
+      << "expected exactly one synthesized cancel callback per stream, got "
+      << GetCallbackCount();
+
+  for (int i = 0; i < kNumStreamRequests; ++i) {
+    CleanupInputs(&inputs[i]);
   }
 }
 
@@ -444,9 +557,8 @@ TEST_F(GrpcCancellationTest, TestGrpcStreamCancelThenRestart)
   ASSERT_TRUE(client_->StartStream(callback_, /*enable_stats=*/false).IsOk());
 
   std::vector<tc::InferInput*> inputs;
-  std::vector<const tc::InferRequestedOutput*> outputs;
-  ASSERT_TRUE(PrepareRequest(&inputs, &outputs).IsOk());
-  ASSERT_TRUE(client_->AsyncStreamInfer(MakeOptions(), inputs, outputs).IsOk());
+  ASSERT_TRUE(PrepareInputs(&inputs).IsOk());
+  ASSERT_TRUE(client_->AsyncStreamInfer(MakeOptions(), inputs).IsOk());
 
   // Graceful close: WritesDone + drain. Blocks until the slow model's
   // response arrives, so the success callback has fired by the time the
@@ -457,7 +569,7 @@ TEST_F(GrpcCancellationTest, TestGrpcStreamCancelThenRestart)
       << "expected successful inference after restarting stream";
   ExpectEchoOutput(result_.get());
 
-  CleanupRequest(&inputs, &outputs);
+  CleanupInputs(&inputs);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
Adds per-request cancellation to the C++ gRPC client, mirroring the existing Python `tritonclient.grpc` cancellation interfaces.
- `AsyncInfer` gains an optional trailing `CallContext** ctx_out`. On `Error::Success`, the caller receives a heap-allocated `CallContext` whose `Cancel()` method calls `grpc::ClientContext::TryCancel()`. `Cancel()` after natural completion is a safe no-op.
- `AsyncInferMulti` gains an optional trailing `std::vector<CallContext*>* ctxs_out` — one handle per fanned-out request. Cancellation is per-request; the multi callback still fires exactly once after every leaf produces a result.
- `StopStream` gains a `bool cancel_requests = false`. When true, the streaming RPC is `TryCancel`'d and the stream callback receives one final `InferResult` whose status contains `Locally cancelled by application!`.
- After a cancelled stream, `StartStream` can be called again — `grpc_context_` is rebuilt in place because `grpc::ClientContext` is non-movable and a cancelled context cannot be reused.
- All cancellation paths surface the same Python-parity message `Locally cancelled by application!`, matching `tritonclient.grpc._utils.get_cancelled_error()` in the Python client.

## Backwards compatibility
Every new parameter defaults to `nullptr` / `false`. Existing call sites compile and behave exactly as before; cancellation is strictly opt-in.

## Testing
New `src/c++/tests/grpc_cancellation_test.cc` (gtest) with 7 cases:
| Test | Covers |
| --- | --- |
| `TestGrpcAsyncInferCancelExecutingRequest` | Python `test_grpc_async_infer` parity (1:1) |
| `TestGrpcAsyncInferCancelQueuedRequest` | Two unary requests on a single-instance delayed model; cancels the queued one (before the backend executes it), then the executing one |
| `TestGrpcAsyncInferCancelAfterCompletionIsNoOp` | Cancel-after-finish is safe, no double callback |
| `TestGrpcAsyncInferWithoutContextStillCompletes` | Default arg path is unchanged |
| `TestGrpcAsyncInferMultiCancelExecutingRequests` | Cancels requests 0 and 2, lets request 1 complete; verifies per-request cancel + result-order preservation + single multi-callback fire |
| `TestGrpcAsyncInferMultiCancelQueuedRequest` | Multi: one executing + one queued; cancel both per-request CallContexts; multi callback fires exactly once with both results locally cancelled |
| `TestGrpcStreamInferCancelExecutingRequest` | Python `test_grpc_stream_infer` parity (1:1) |
| `TestGrpcStreamInferCancelQueuedRequest` | StopStream(cancel) tears down the stream and cancels the queued request |
| `TestGrpcStreamCancelWithoutInfer` | Cancel an empty stream still emits the cancel message |
| `TestGrpcStreamCancelThenRestart` | Cancelled stream → fresh stream → successful inference |

## Related
https://github.com/triton-inference-server/server/pull/8775