### PR TITLE
feat: Enforce `ml_dtypes.bfloat16` for BF16 I/O in Python client

### DIFF
--- a/src/python/library/requirements/requirements.txt
+++ b/src/python/library/requirements/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -24,6 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+ml_dtypes<=0.5.4
 numpy>=1.19.1
 python-rapidjson>=0.9.1
 urllib3>=2.0.7

--- a/src/python/library/tritonclient/grpc/_infer_input.py
+++ b/src/python/library/tritonclient/grpc/_infer_input.py
@@ -129,7 +129,7 @@ class InferInput:
         if self._input.datatype != dtype:
             error_message = f"got unexpected datatype {dtype} from numpy array, expected {self._input.datatype}."
             if self._input.datatype == "BF16":
-                error_message += " Since r26.05, BF16 inputs must use ml_dtypes.bfloat16 instead of np.float32 truncation; create a numpy array with `np.array(data, dtype=ml_dtypes.bfloat16)`."
+                error_message += " Since r26.06, BF16 inputs must use ml_dtypes.bfloat16 instead of np.float32 truncation; create a numpy array with `np.array(data, dtype=ml_dtypes.bfloat16)`."
             raise_error(error_message)
 
         valid_shape = True

--- a/src/python/library/tritonclient/grpc/_infer_input.py
+++ b/src/python/library/tritonclient/grpc/_infer_input.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -124,22 +124,18 @@ class InferInput:
         """
         if not isinstance(input_tensor, (np.ndarray,)):
             raise_error("input_tensor must be a numpy array")
-        # DLIS-3986: Special handling for bfloat16 until Numpy officially supports it
-        if self._input.datatype == "BF16":
-            if input_tensor.dtype != triton_to_np_dtype(self._input.datatype):
-                raise_error(
-                    "got unexpected datatype {} from numpy array, expected {} for BF16 type".format(
-                        input_tensor.dtype, triton_to_np_dtype(self._input.datatype)
-                    )
+
+        dtype = np_to_triton_dtype(input_tensor.dtype)
+        if self._input.datatype != dtype:
+            error_message = (
+                "got unexpected datatype {} from numpy array, expected {}.".format(
+                    dtype, self._input.datatype
                 )
-        else:
-            dtype = np_to_triton_dtype(input_tensor.dtype)
-            if self._input.datatype != dtype:
-                raise_error(
-                    "got unexpected datatype {} from numpy array, expected {}".format(
-                        dtype, self._input.datatype
-                    )
-                )
+            )
+            if self._input.datatype == "BF16":
+                error_message += " Since r26.05, BF16 inputs must use ml_dtypes.bfloat16 instead of np.float32 truncation; create a numpy array with `np.array(data, dtype=ml_dtypes.bfloat16)`."
+            raise_error(error_message)
+
         valid_shape = True
         if len(self._input.shape) != len(input_tensor.shape):
             valid_shape = False
@@ -159,12 +155,6 @@ class InferInput:
 
         if self._input.datatype == "BYTES":
             serialized_output = serialize_byte_tensor(input_tensor)
-            if serialized_output.size > 0:
-                self._raw_content = serialized_output.item()
-            else:
-                self._raw_content = b""
-        elif self._input.datatype == "BF16":
-            serialized_output = serialize_bf16_tensor(input_tensor)
             if serialized_output.size > 0:
                 self._raw_content = serialized_output.item()
             else:

--- a/src/python/library/tritonclient/grpc/_infer_input.py
+++ b/src/python/library/tritonclient/grpc/_infer_input.py
@@ -127,11 +127,7 @@ class InferInput:
 
         dtype = np_to_triton_dtype(input_tensor.dtype)
         if self._input.datatype != dtype:
-            error_message = (
-                "got unexpected datatype {} from numpy array, expected {}.".format(
-                    dtype, self._input.datatype
-                )
-            )
+            error_message = f"got unexpected datatype {dtype} from numpy array, expected {self._input.datatype}."
             if self._input.datatype == "BF16":
                 error_message += " Since r26.05, BF16 inputs must use ml_dtypes.bfloat16 instead of np.float32 truncation; create a numpy array with `np.array(data, dtype=ml_dtypes.bfloat16)`."
             raise_error(error_message)

--- a/src/python/library/tritonclient/grpc/_infer_result.py
+++ b/src/python/library/tritonclient/grpc/_infer_result.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -75,10 +75,6 @@ class InferResult:
                         # need to decode the raw bytes to convert into
                         # array elements.
                         np_array = deserialize_bytes_tensor(
-                            self._result.raw_output_contents[index]
-                        )
-                    elif datatype == "BF16":
-                        np_array = deserialize_bf16_tensor(
                             self._result.raw_output_contents[index]
                         )
                     else:

--- a/src/python/library/tritonclient/http/_infer_input.py
+++ b/src/python/library/tritonclient/http/_infer_input.py
@@ -129,7 +129,7 @@ class InferInput:
         if self._datatype != dtype:
             error_message = f"got unexpected datatype {dtype} from numpy array, expected {self._datatype}."
             if self._datatype == "BF16":
-                error_message += " Since r26.05, BF16 inputs must use ml_dtypes.bfloat16 instead of np.float32 truncation; create a numpy array with `np.array(data, dtype=ml_dtypes.bfloat16)`."
+                error_message += " Since r26.06, BF16 inputs must use ml_dtypes.bfloat16 instead of np.float32 truncation; create a numpy array with `np.array(data, dtype=ml_dtypes.bfloat16)`."
             raise_error(error_message)
 
         valid_shape = True

--- a/src/python/library/tritonclient/http/_infer_input.py
+++ b/src/python/library/tritonclient/http/_infer_input.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -25,14 +25,9 @@
 # OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import numpy as np
-from tritonclient.utils import (
-    np_to_triton_dtype,
-    raise_error,
-    serialize_bf16_tensor,
-    serialize_byte_tensor,
-    triton_to_np_dtype,
-)
+from tritonclient.utils import np_to_triton_dtype, raise_error, serialize_byte_tensor
 
 
 class InferInput:
@@ -129,22 +124,18 @@ class InferInput:
         """
         if not isinstance(input_tensor, (np.ndarray,)):
             raise_error("input_tensor must be a numpy array")
-        # DLIS-3986: Special handling for bfloat16 until Numpy officially supports it
-        if self._datatype == "BF16":
-            if input_tensor.dtype != triton_to_np_dtype(self._datatype):
-                raise_error(
-                    "got unexpected datatype {} from numpy array, expected {} for BF16 type".format(
-                        input_tensor.dtype, triton_to_np_dtype(self._datatype)
-                    )
+
+        dtype = np_to_triton_dtype(input_tensor.dtype)
+        if self._datatype != dtype:
+            error_message = (
+                "got unexpected datatype {} from numpy array, expected {}.".format(
+                    dtype, self._datatype
                 )
-        else:
-            dtype = np_to_triton_dtype(input_tensor.dtype)
-            if self._datatype != dtype:
-                raise_error(
-                    "got unexpected datatype {} from numpy array, expected {}".format(
-                        dtype, self._datatype
-                    )
-                )
+            )
+            if self._datatype == "BF16":
+                error_message += " Since r26.05, BF16 inputs must use ml_dtypes.bfloat16 instead of np.float32 truncation; create a numpy array with `np.array(data, dtype=ml_dtypes.bfloat16)`."
+            raise_error(error_message)
+
         valid_shape = True
         if len(self._shape) != len(input_tensor.shape):
             valid_shape = False
@@ -198,12 +189,6 @@ class InferInput:
             self._data = None
             if self._datatype == "BYTES":
                 serialized_output = serialize_byte_tensor(input_tensor)
-                if serialized_output.size > 0:
-                    self._raw_data = serialized_output.item()
-                else:
-                    self._raw_data = b""
-            elif self._datatype == "BF16":
-                serialized_output = serialize_bf16_tensor(input_tensor)
                 if serialized_output.size > 0:
                     self._raw_data = serialized_output.item()
                 else:

--- a/src/python/library/tritonclient/http/_infer_input.py
+++ b/src/python/library/tritonclient/http/_infer_input.py
@@ -127,11 +127,7 @@ class InferInput:
 
         dtype = np_to_triton_dtype(input_tensor.dtype)
         if self._datatype != dtype:
-            error_message = (
-                "got unexpected datatype {} from numpy array, expected {}.".format(
-                    dtype, self._datatype
-                )
-            )
+            error_message = f"got unexpected datatype {dtype} from numpy array, expected {self._datatype}."
             if self._datatype == "BF16":
                 error_message += " Since r26.05, BF16 inputs must use ml_dtypes.bfloat16 instead of np.float32 truncation; create a numpy array with `np.array(data, dtype=ml_dtypes.bfloat16)`."
             raise_error(error_message)

--- a/src/python/library/tritonclient/http/_infer_result.py
+++ b/src/python/library/tritonclient/http/_infer_result.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,12 +30,7 @@ import zlib
 
 import numpy as np
 import rapidjson as json
-from tritonclient.utils import (
-    deserialize_bf16_tensor,
-    deserialize_bytes_tensor,
-    raise_error,
-    triton_to_np_dtype,
-)
+from tritonclient.utils import deserialize_bytes_tensor, raise_error, triton_to_np_dtype
 
 
 class InferResult:
@@ -188,10 +183,6 @@ class InferResult:
                                     # need to decode the raw bytes to convert into
                                     # array elements.
                                     np_array = deserialize_bytes_tensor(
-                                        self._buffer[start_index:end_index]
-                                    )
-                                elif datatype == "BF16":
-                                    np_array = deserialize_bf16_tensor(
                                         self._buffer[start_index:end_index]
                                     )
                                 else:

--- a/src/python/library/tritonclient/utils/__init__.py
+++ b/src/python/library/tritonclient/utils/__init__.py
@@ -28,9 +28,8 @@
 
 import struct
 
+import ml_dtypes
 import numpy as np
-
-from ._shared_memory_tensor import SharedMemoryTensor
 
 # Reserved request parameters for Triton's usage.
 # Other locations:
@@ -168,6 +167,10 @@ def np_to_triton_dtype(np_dtype):
         return "FP16"
     elif np_dtype == np.float32:
         return "FP32"
+    # DLIS-3986: numpy has no native BF16 dtype, so BF16 inputs must use
+    # ml_dtypes.bfloat16.
+    elif np_dtype == ml_dtypes.bfloat16:
+        return "BF16"
     elif np_dtype == np.float64:
         return "FP64"
     elif np_dtype == np.object_ or np_dtype.type == np.bytes_:
@@ -196,8 +199,12 @@ def triton_to_np_dtype(dtype):
         return np.uint64
     elif dtype == "FP16":
         return np.float16
-    elif dtype == "FP32" or dtype == "BF16":
+    elif dtype == "FP32":
         return np.float32
+    # DLIS-3986: numpy has no native BF16 dtype, so BF16 inputs must use
+    # ml_dtypes.bfloat16.
+    elif dtype == "BF16":
+        return ml_dtypes.bfloat16
     elif dtype == "FP64":
         return np.float64
     elif dtype == "BYTES":
@@ -289,75 +296,3 @@ def deserialize_bytes_tensor(encoded_tensor):
         offset += l
         strs.append(sb)
     return np.array(strs, dtype=np.object_)
-
-
-def serialize_bf16_tensor(input_tensor):
-    """
-    Serializes a bfloat16 tensor into a flat numpy array of bytes.
-    The numpy array should use dtype of np.float32.
-
-    Parameters
-    ----------
-    input_tensor : np.array
-        The bfloat16 tensor to serialize.
-
-    Returns
-    -------
-    serialized_bf16_tensor : np.array
-        The 1-D numpy array of type uint8 containing the serialized bytes in row-major form.
-
-    Raises
-    ------
-    InferenceServerException
-        If unable to serialize the given tensor.
-    """
-
-    if input_tensor.size == 0:
-        return np.empty([0], dtype=np.object_)
-
-    # If the input is a tensor of float32, then must flatten those into
-    # a 1-dimensional array containing the element bytes. All elements
-    # are concatenated together in row-major order.
-
-    if input_tensor.dtype != np.float32:
-        raise_error("cannot serialize bf16 tensor: invalid datatype")
-
-    flattened_ls = []
-    # 'C' order is row-major.
-    for obj in np.nditer(input_tensor, flags=["refs_ok"], order="C"):
-        # To truncate the float32 to a bfloat16, we need the high-order bits.
-        obj_bytes = struct.pack("<f", obj)[2:4]
-        flattened_ls.append(obj_bytes)
-    flattened = b"".join(flattened_ls)
-    flattened_array = np.asarray(flattened, dtype=np.object_)
-    if not flattened_array.flags["C_CONTIGUOUS"]:
-        flattened_array = np.ascontiguousarray(flattened_array, dtype=np.object_)
-    return flattened_array
-
-
-def deserialize_bf16_tensor(encoded_tensor):
-    """
-    Deserializes an encoded bf16 tensor into a
-    numpy array of dtype of python objects
-
-    Parameters
-    ----------
-    encoded_tensor : bytes
-        The encoded bytes tensor where each element
-        is 2 bytes (size of bfloat16)
-    Returns
-    -------
-    string_tensor : np.array
-        The 1-D numpy array of type float32 containing the
-        deserialized bytes in row-major form.
-
-    """
-    strs = list()
-    offset = 0
-    val_buf = encoded_tensor
-    while offset < len(val_buf):
-        sb = struct.unpack_from("<2s", val_buf, offset)[0]
-        # Bfloat16 contains 2 bytes
-        offset += 2
-        strs.append(struct.unpack("<f", (b"\x00\x00" + sb)))
-    return np.array(strs, dtype=np.float32)


### PR DESCRIPTION
## Summary
NumPy has no native BF16. Currently, casting FP32 <=> BF16 magnifies accuracy loss. Enforce using `ml_dtypes.bfloat16` for native BF16 support.

## Example
For 0.01 + 0.01, BF16 <=> FP32 will lose precision during truncating, making the output value biases from the true result 0.02.
```
0.01(BF16) + 0.01(BF16) => 0.0200195 (BF16)
0.01(FP32->BF16) + 0.01(FP32->BF16) => 0.01989746 (BF16->FP32)
```