### PR TITLE
fix: Preserve output datatype for empty (zero-element) tensors in Python client

### DIFF
--- a/src/python/library/tritonclient/grpc/_infer_result.py
+++ b/src/python/library/tritonclient/grpc/_infer_result.py
@@ -85,7 +85,7 @@ class InferResult:
                 elif len(output.contents.bytes_contents) != 0:
                     np_array = np.array(output.contents.bytes_contents, copy=False)
                 else:
-                    np_array = np.empty(0)
+                    np_array = np.empty(0, dtype=triton_to_np_dtype(datatype))
                 np_array = np_array.reshape(shape)
                 return np_array
             else:

--- a/src/python/library/tritonclient/http/_infer_result.py
+++ b/src/python/library/tritonclient/http/_infer_result.py
@@ -191,7 +191,9 @@ class InferResult:
                                         dtype=triton_to_np_dtype(datatype),
                                     )
                             else:
-                                np_array = np.empty(0)
+                                np_array = np.empty(
+                                    0, dtype=triton_to_np_dtype(datatype)
+                                )
                     if not has_binary_data:
                         np_array = np.array(
                             output["data"], dtype=triton_to_np_dtype(datatype)


### PR DESCRIPTION
#### What does the PR do?
`InferResult.as_numpy` built zero-element outputs with a bare `np.empty(0)`, which defaults to `float64` and silently drops the output's declared datatype. The non-empty binary path (`np.frombuffer`) and the JSON path (`np.array`) already pass `dtype=triton_to_np_dtype(datatype)`; this aligns the empty branch with that contract in both the HTTP and gRPC clients.

Empty `FP32` now returns `float32`, empty `BF16` returns `ml_dtypes.bfloat16`.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added succinct git squash message before merging ref.
- [x] All template sections are filled out.

#### Commit Type:
- [x] fix

#### Where should the reviewer start?
`src/python/library/tritonclient/http/_infer_result.py` and `src/python/library/tritonclient/grpc/_infer_result.py` — the `np.empty(0, dtype=triton_to_np_dtype(datatype))` change in the zero-element output branch.

#### Test plan:
Covered by the server-side `L0_backend_identity` test, whose strict `output_dtype == input_dtype` assertion surfaced this on the empty `identity_fp32 [1,0]` case. With this fix, empty outputs return their declared dtype across HTTP and gRPC.
- CI Pipeline ID: 55062265

#### Caveats:
Minor behavior change: callers that relied on getting `float64` back for an empty output now receive the declared dtype. This is the intended/correct behavior and matches non-empty results.

#### Background
The empty-output `np.empty(0)` dates back to the 2023 HTTP client restructure (#299); it was dormant because an empty array's dtype is essentially never inspected, until a strict dtype assertion was added to the QA test.