### PR TITLE
ci: Add centralized add-license pre-commit hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,5 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5.0.0
+      with:
+        fetch-depth: 2
+    - name: Get modified files
+      id: modified-files
+      run: echo "modified_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
     - uses: actions/setup-python@v6.0.0
     - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --files ${{ steps.modified-files.outputs.modified_files }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
       (?x)
       ^(?!(src/c\+\+/perf_analyzer/genai-perf/)).*\.py$
 
-- repo: https://github.com/triton-inference-server/pre-commit-hooks
+- repo: https://github.com/triton-inference-server/developer_tools
   rev: v0.1.0
   hooks:
   - id: add-license

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -82,3 +82,8 @@ repos:
     exclude: >-
       (?x)
       ^(?!(src/c\+\+/perf_analyzer/genai-perf/)).*\.py$
+
+- repo: https://github.com/triton-inference-server/pre-commit-hooks
+  rev: v0.1.0
+  hooks:
+  - id: add-license

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions


### PR DESCRIPTION
Adds the centralized `add-license` pre-commit hook (sourced from `triton-inference-server/pre-commit-hooks`) to this repo's `.pre-commit-config.yaml`, standardizing copyright-header validation/insertion across Triton repos instead of maintaining per-repo copies. The hook also bumps the `LICENSE` copyright year range to 2026.
