### PR TITLE
build: Bump jackson-databind from 2.21.2 to 2.21.4

### DIFF
--- a/src/grpc_generated/javascript/package-lock.json
+++ b/src/grpc_generated/javascript/package-lock.json
@@ -8,14 +8,14 @@
       "name": "simple-grpc-tritonclient",
       "version": "1.0.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.8.20",
+        "@grpc/grpc-js": "^1.14.4",
         "@grpc/proto-loader": "^0.8.1"
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",

--- a/src/grpc_generated/javascript/package.json
+++ b/src/grpc_generated/javascript/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Simple gRPC client for NVIDIA Triton in Node.js",
   "dependencies": {
-    "@grpc/grpc-js": "^1.8.20",
+    "@grpc/grpc-js": "^1.14.4",
     "@grpc/proto-loader": "^0.8.1"
   },
   "overrides": {

--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.2</version>
+            <version>2.21.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
#### What does the PR do?
Backports the security-relevant dependency bumps from the `main` dependency-alignment PR to `r26.07`:

- `com.fasterxml.jackson.core:jackson-databind` 2.21.2 → 2.21.4 (Java client). The 26.07 SDK container security scan (Pulse) flags two HIGH advisories against jackson-databind bundled into the Java example fat-JARs (`SimpleInferClient.jar`, `SimpleInferPerf.jar`, `MemoryGrowthTest.jar`):
  - GHSA-j3rv-43j4-c7qm (fixed in 2.21.4)
  - GHSA-rmj7-2vxq-3g9f (fixed in 2.21.4)
- `@grpc/grpc-js` floor ^1.8.20 → ^1.14.4 in the Node.js gRPC example (`src/grpc_generated/javascript`), matching the same bump on `main`. Not flagged by the current scan; included for parity/hardening.

#### Related Issues / PRs
- Related: TRI-1593
- Same bumps on `main` (part of the gRPC v1.81.1 alignment): triton-inference-server/client#908

#### Test plan
- Dependency version bumps only; examples are rebuilt by the SDK container build.
- Verification: rebuild the 26.07 SDK container and re-run the `scan-container:py3-sdk` security job, which currently fails on the two jackson advisories (internal pipeline 58029553, job 365259903).

#### Caveats
The remaining findings in the scan report (Go stdlib CVEs in the CUDA Nsight Systems `nic_sampler` plugin) are third-party toolkit content covered by a temporary GlobalVEX and are not addressable in this repo.

#### Checklist
- [x] PR title follows `<commit_type>: <Title>` (conventional commit — enforced by the `conventional-pre-commit` hook)
- [x] I ran `pre-commit install && pre-commit run --all-files` locally and it passes
- [x] Copyright header is correct on all changed files
- [ ] External contributors: I have read the [Contribution guidelines](../CONTRIBUTING.md) and signed the [Contributor License Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
