### PR TITLE
build: Bump jackson-databind from 2.21.2 to 2.21.4

### DIFF
--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.2</version>
+            <version>2.21.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
#### What does the PR do?
Bumps `com.fasterxml.jackson.core:jackson-databind` from 2.21.2 to 2.21.4 in the Java client. The 26.07 SDK container security scan (Pulse) flags two HIGH advisories against jackson-databind bundled into the Java example fat-JARs (`SimpleInferClient.jar`, `SimpleInferPerf.jar`, `MemoryGrowthTest.jar`):

- GHSA-j3rv-43j4-c7qm (fixed in 2.21.4)
- GHSA-rmj7-2vxq-3g9f (fixed in 2.21.4)

#### Related Issues / PRs
- Related: TRI-1593
- Backport of the same bump to `r26.07`: triton-inference-server/client#910

#### Test plan
- One-line dependency version bump; examples are rebuilt by the SDK container build.
- Verification: for 26.07: rebuild the SDK container and re-run the `scan-container:py3-sdk` security job, which currently fails on these two advisories (internal pipeline 58029553, job 365259903).

#### Caveats
The remaining findings in the scan report (Go stdlib CVEs in the CUDA Nsight Systems `nic_sampler` plugin) are third-party toolkit content covered by a temporary GlobalVEX and are not addressable in this repo.

#### Checklist
- [x] PR title follows `<commit_type>: <Title>` (conventional commit — enforced by the `conventional-pre-commit` hook)
- [x] I ran `pre-commit install && pre-commit run --all-files` locally and it passes
- [x] Copyright header is correct on all changed files
- [ ] External contributors: I have read the [Contribution guidelines](../CONTRIBUTING.md) and signed the [Contributor License Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
