### PR TITLE
build(dependencies): update Tomca version (#912)

### DIFF
--- a/src/grpc_generated/java/examples/pom.xml
+++ b/src/grpc_generated/java/examples/pom.xml
@@ -36,7 +36,7 @@
 		<dependency> <!-- necessary for Java 9+ -->
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-annotations-api</artifactId>
-			<version>11.0.21</version>
+			<version>11.0.24</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency> <!-- necessary for Java 11+ -->

--- a/src/grpc_generated/java/library/pom.xml
+++ b/src/grpc_generated/java/library/pom.xml
@@ -32,7 +32,7 @@
 		<dependency> <!-- necessary for Java 9+ -->
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-annotations-api</artifactId>
-			<version>11.0.21</version>
+			<version>11.0.24</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency> <!-- necessary for Java 11+ -->


### PR DESCRIPTION
#### What does the PR do?

Cherry-picks the Tomcat bump that landed on `r26.07` into `main` as part of the post-26.07
default-branch advance: `tomcat-annotations-api` 11.0.21 → 11.0.24 in the generated Java
example and library POMs.

The companion jackson-databind pick from `r26.07` (`33cc7d5`) is **not** included — `main`
already carries identical content via `9a5593f` "build(security): bump jackson-databind to
2.21.4 and @grpc/grpc-js to 1.14.4". `git cherry` flags it because `r26.07`'s
`package-lock.json` base differed, but `git diff origin/main 33cc7d5 --` over the three
affected files is empty.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/server#8909
- triton-inference-server/tutorials#165

#### Where should the reviewer start?

Both `pom.xml` files — a single `<version>` line each.

#### Test plan:

Dependency-only change; covered by the existing Java client build in CI.

- CI Pipeline ID: 60058404

#### Caveats:

None.

#### Background

Release step "[Before NGC Release] Advance master branch to next upstream release" — the
release branch accumulated dependency bumps that `main` must carry forward.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to: TRI-1601

<sup>
CI (internal): [#60058404](http://tritonserver.local/ci/pipelines/60058404)<br/>
</sup>
