### PR TITLE
fix: Make CUDA shared memory stream cache thread-safe in Python client

### DIFF
--- a/src/python/library/tritonclient/utils/cuda_shared_memory/__init__.py
+++ b/src/python/library/tritonclient/utils/cuda_shared_memory/__init__.py
@@ -39,6 +39,7 @@ except ModuleNotFoundError as error:
 import base64
 import ctypes
 import struct
+import threading
 
 import numpy as np
 
@@ -58,14 +59,16 @@ allocated_shm_regions = []
 # and be reused throughout the process. May revisit for stream pool if
 # asynchronous write on CUDA shared memory region is requested
 _dlpack_stream = {}
+_dlpack_stream_lock = threading.Lock()
 
 
 # Helper function to retrieve internally managed CUDA stream
 def _get_or_create_global_cuda_stream(device_id):
     global _dlpack_stream
-    if device_id not in _dlpack_stream:
-        _dlpack_stream[device_id] = CudaStream(device_id)
-    return _dlpack_stream[device_id]._stream
+    with _dlpack_stream_lock:
+        if device_id not in _dlpack_stream:
+            _dlpack_stream[device_id] = CudaStream(device_id)
+        return _dlpack_stream[device_id]._stream
 
 
 def _support_uva(shm_device_id, ext_device_id):


### PR DESCRIPTION
I opened this draft to discuss possible solutions to issue #914.

The simplest possible solution is just adding a lock inside the `_get_or_create_global_cuda_stream`. With this lock, just one thread enters the global cuda stream creation clause at a time. And, of course, operations in a cuda stream are guaranteed to be serialized, so no problem in two python threads "owning" it.

I also considered changing the return to an actual `CudaStream` instance, but then it would change the intention of a unique cuda stream per device, as it is written right now, and I would need to change the callers as well.

I opened this as a draft because there are comments in the `__del__` methods in the wrappers of some cuda resources at `cuda_shared_memory._utils` and `CudaSharedMemoryRegion` could also suffer from the same problem. 

If you run the same reproducing script in the respective issue, it will run without errors. I don't know if this could be implemented as a test because it need GPUs.