### PR TITLE
build: remove -Werror from library build options

### DIFF
--- a/src/c++/CMakeLists.txt
+++ b/src/c++/CMakeLists.txt
@@ -113,9 +113,7 @@ if(TRITON_ENABLE_CC_GRPC)
   set(protobuf_MODULE_COMPATIBLE TRUE CACHE BOOL "protobuf_MODULE_COMPATIBLE" FORCE)
   find_package(Protobuf CONFIG REQUIRED)
   message(STATUS "Using protobuf ${Protobuf_VERSION}")
-  # SYSTEM so header-internal deprecation warnings in protobuf do not
-  # fail the -Werror build.
-  include_directories(SYSTEM ${Protobuf_INCLUDE_DIRS})
+  include_directories(${Protobuf_INCLUDE_DIRS})
 endif() # TRITON_ENABLE_CC_GRPC
 
 #
@@ -124,10 +122,7 @@ endif() # TRITON_ENABLE_CC_GRPC
 if(TRITON_ENABLE_CC_GRPC)
   find_package(gRPC CONFIG REQUIRED)
   message(STATUS "Using gRPC ${gRPC_VERSION}")
-  # SYSTEM so header-internal deprecation warnings in gRPC do not fail
-  # the -Werror build.
-  include_directories(
-    SYSTEM $<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>)
+  include_directories($<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>)
 endif() # TRITON_ENABLE_CC_GRPC
 
 if(TRITON_ENABLE_CC_HTTP OR TRITON_ENABLE_CC_GRPC)

--- a/src/c++/library/CMakeLists.txt
+++ b/src/c++/library/CMakeLists.txt
@@ -75,7 +75,7 @@ if(TRITON_ENABLE_CC_HTTP OR TRITON_ENABLE_EXAMPLES)
     target_compile_options(
       ${_json_target} PRIVATE
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-        -Wall -Wextra -Werror>
+        -Wall -Wextra>
       $<$<CXX_COMPILER_ID:MSVC>:/W0 /D_WIN32_WINNT=0x0A00 /EHsc>
     )
 
@@ -141,7 +141,7 @@ if(NOT WIN32)
     target_compile_options(
       ${_shm_target} PRIVATE
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-        -Wall -Wextra -Werror>
+        -Wall -Wextra>
       $<$<CXX_COMPILER_ID:MSVC>:/W0 /D_WIN32_WINNT=0x0A00 /EHsc>
     )
 
@@ -262,7 +262,7 @@ if(TRITON_ENABLE_CC_GRPC)
     target_compile_options(
       ${_client_target} PRIVATE
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-        -Wall -Wextra -Werror>
+        -Wall -Wextra>
       $<$<CXX_COMPILER_ID:MSVC>:/W0 /D_WIN32_WINNT=0x0A00 /EHsc>
     )
 
@@ -443,7 +443,7 @@ if(TRITON_ENABLE_CC_HTTP)
     target_compile_options(
       ${_client_target} PRIVATE
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-        -Wall -Wextra -Werror>
+        -Wall -Wextra>
       $<$<CXX_COMPILER_ID:MSVC>:/W0 /D_WIN32_WINNT=0x0A00 /EHsc>
     )
 


### PR DESCRIPTION
Using `-Werror` as a default build option makes it nearly impossible to compile the Triton client with other (more modern) toolchains and/or different 3rd party library versions.

Closes #902.