### PR TITLE
fix: Modernize tritonclient wheel metadata and emit Metadata-Version 2.4

### DIFF
--- a/src/python/library/setup.py
+++ b/src/python/library/setup.py
@@ -43,7 +43,13 @@ if "VERSION" not in os.environ:
 VERSION = os.environ["VERSION"]
 
 try:
-    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+    # setuptools >= 70.1 ships an integrated bdist_wheel. Prefer it over the
+    # standalone 'wheel' package, which is deprecated and caps the generated
+    # wheel metadata at Metadata-Version 2.1.
+    try:
+        from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+    except ImportError:
+        from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
     class bdist_wheel(_bdist_wheel):
         def finalize_options(self):

--- a/src/python/library/setup.py
+++ b/src/python/library/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -92,8 +92,12 @@ setup(
     """for package details.\n\nThe [client examples](https://github.com/triton-inference-server/client/tree/main/src/python/examples) demonstrate how to use the """
     """package to issue request to [triton inference server](https://github.com/triton-inference-server/server).""",
     long_description_content_type="text/markdown",
-    license="BSD",
-    url="https://developer.nvidia.com/nvidia-triton-inference-server",
+    license="BSD-3-Clause",
+    project_urls={
+        "Homepage": "https://developer.nvidia.com/nvidia-triton-inference-server",
+        "Source": "https://github.com/triton-inference-server/client",
+        "Bug Tracker": "https://github.com/triton-inference-server/server/issues",
+    },
     keywords=[
         "grpc",
         "http",
@@ -115,15 +119,15 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development :: Libraries",
         "Topic :: Utilities",
-        "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Environment :: Console",
         "Natural Language :: English",
         "Operating System :: OS Independent",
     ],
+    python_requires=">=3.12",
     install_requires=install_requires,
     extras_require=extras_require,
     packages=find_packages(),


### PR DESCRIPTION
## Summary

Modernizes the `tritonclient` wheel metadata and fixes the reason the modern
fields never actually reached the built wheel.

### 1. Emit `Metadata-Version: 2.4` (the actual bug)

`setup.py` imported `bdist_wheel` from the standalone `wheel` package:

```python
from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
```

That command is deprecated and caps generated wheel metadata at
`Metadata-Version: 2.1`, so newer core-metadata fields were silently dropped
from the built wheel regardless of the installed setuptools version. The build
log has been warning about this:

> `FutureWarning: The 'wheel' package is no longer the canonical location of the
> 'bdist_wheel' command, and will be removed in a future release. Please update
> to setuptools v70.1 or later which contains an integrated version of this command.`

Now prefers setuptools' integrated `bdist_wheel` (setuptools >= 70.1), falling
back to the `wheel` package for older setuptools.

### 2. Core-metadata modernization

Aligned `setup.py` with the [Core Metadata specification](https://packaging.python.org/en/latest/specifications/core-metadata/):

- Python version classifiers `3.6`/`3.7`/`3.8` → `3.12`/`3.13`/`3.14`, and added
  `python_requires=">=3.12"`.
- `license="BSD"` → SPDX expression `"BSD-3-Clause"` (verified against
  `LICENSE.txt`, which is 3-clause).
- Dropped the deprecated `License ::` classifier — deprecated as of Metadata 2.4
  in favor of the license expression.
- Replaced the deprecated `url=` (`Home-page`) with `project_urls`
  (`Homepage`, `Source`, `Bug Tracker`).

## Test plan

Verified inside the `26.08-py3-sdk` container (setuptools 84.0.0), rebuilding the
wheel with this `setup.py`:

| `bdist_wheel` source | `Metadata-Version` |
|---|---|
| `wheel.bdist_wheel` (before) | 2.1 |
| `setuptools.command.bdist_wheel` (after) | **2.4** |

Resulting wheel `METADATA`:

```
Metadata-Version: 2.4
Name: tritonclient
License: BSD-3-Clause
Project-URL: Homepage, https://developer.nvidia.com/nvidia-triton-inference-server
Project-URL: Source, https://github.com/triton-inference-server/client
Project-URL: Bug Tracker, https://github.com/triton-inference-server/server/issues
Classifier: Programming Language :: Python :: 3.12
Classifier: Programming Language :: Python :: 3.13
Classifier: Programming Language :: Python :: 3.14
Requires-Python: >=3.12
```

No packaging behavior change beyond the metadata:

- Wheel filename unchanged: `tritonclient-<ver>-py3-none-any.whl`
- `root_is_pure=False` still honored — `.data/purelib/` layout preserved
- `--plat-name` handling unchanged (nothing in the build passes it; it already
  resolved to `any`)
- `pre-commit run --files src/python/library/setup.py` — all hooks pass

## Notes

Full PEP 639 `License-Expression` metadata requires a `pyproject.toml`
`[project]` table; this package still builds via `setup.py`, so the legacy
`license=` keyword continues to emit the classic `License:` field with the SPDX
string as its value. Migrating to `pyproject.toml` is out of scope here.
